### PR TITLE
RAD-172 Clean radiology_report db

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
@@ -37,7 +37,6 @@ public class RadiologyReport extends BaseOpenmrsData {
 	}
 	
 	public RadiologyReport(RadiologyOrder radiologyOrder) {
-		super.setDateCreated(new Date());
 		this.radiologyOrder = radiologyOrder;
 		this.reportStatus = RadiologyReportStatus.CLAIMED;
 	}

--- a/api/src/main/resources/RadiologyReport.hbm.xml
+++ b/api/src/main/resources/RadiologyReport.hbm.xml
@@ -5,24 +5,25 @@
 <hibernate-mapping package="org.openmrs.module.radiology">
 	<class name="org.openmrs.module.radiology.report.RadiologyReport"
 		table="radiology_report" lazy="false">
-		<id name="radiologyReportId" column="radiology_report_id">
+		<id name="radiologyReportId" column="report_id">
 			<generator class="native">
 				<param name="sequence">radiology_report_id_seq</param>
 			</generator>
 		</id>
 		<many-to-one name="radiologyOrder" column="order_id"
 			unique="true" not-null="true" />
-		<property name="reportStatus" column="report_status">
+		<property name="reportStatus" column="report_status"
+			not-null="true">
 			<type name="org.openmrs.util.HibernateEnumType">
 				<param name="enumClassName">org.openmrs.module.radiology.report.RadiologyReportStatus</param>
 				<param name="useNamed">true</param>
 			</type>
 		</property>
-		<many-to-one name="principalResultsInterpreter" column="principalResultsInterpreter_id" unique="false"
-			not-null="false" />
+		<many-to-one name="principalResultsInterpreter" column="principal_results_interpreter"
+			unique="false" not-null="false" />
 		<property name="reportDate" column="report_date" />
 		<property name="reportBody" column="report_body" not-null="false" />
-		<many-to-one name="creator" column="creator" unique="false" not-null="false"/>
-		<property name="dateCreated" column="creationDate"/>
+		<many-to-one name="creator" unique="false" not-null="true" />
+		<property name="dateCreated" column="date_created" not-null="true" />
 	</class>
 </hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -5,7 +5,7 @@
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
-	<!-- See http://www.liquibase.org/manual/home#available_database_refactorings
+	<!-- See http://www.liquibase.org/manual/home#available_database_refactorings 
 		for a list of supported elements and attributes -->
 
 	<changeSet id="radiology-1" author="cortex">
@@ -231,27 +231,34 @@
 		</sql>
 		<comment>radiology_report</comment>
 		<createTable tableName="radiology_report">
-			<column name="radiology_report_id" type="int" autoIncrement="true">
+			<column name="report_id" type="int" autoIncrement="true">
 				<constraints primaryKey="true" nullable="false" />
 			</column>
-			<column name="order_id" type="int" />
-			<column name="report_status" type="varchar(25)" />
-			<column name="principalResultsInterpreter_id" type="int" />
+			<column name="order_id" type="int">
+				<constraints nullable="false" />
+			</column>
+			<column name="report_status" type="varchar(12)">
+				<constraints nullable="false" />
+			</column>
+			<column name="principal_results_interpreter" type="int" />
 			<column name="report_date" type="date" />
 			<column name="report_body" type="longtext" />
-			<column name="creator" type="int">
-				<constraints unique="false"/>
+			<column name="creator" type="int" defaultValueNumeric="0">
+				<constraints nullable="false" />
 			</column>
-			<column name="creationDate" type="date"></column>
+			<column name="date_created" type="DATETIME">
+				<constraints nullable="false" />
+			</column>
 		</createTable>
 		<addForeignKeyConstraint constraintName="radiology_report_order_id_fk"
 			baseTableName="radiology_report" baseColumnNames="order_id"
 			referencedTableName="radiology_order" referencedColumnNames="order_id" />
-		<addForeignKeyConstraint constraintName="radiology_report_provider_id_fk"
-			baseTableName="radiology_report" baseColumnNames="principalResultsInterpreter_id"
+		<addForeignKeyConstraint
+			constraintName="radiology_report_principal_results_interpreter_fk"
+			baseTableName="radiology_report" baseColumnNames="principal_results_interpreter"
 			referencedTableName="provider" referencedColumnNames="provider_id" />
-		<addForeignKeyConstraint constraintName="radiology_report_creator_id_fk"
-			 baseTableName="radiology_report" baseColumnNames="creator"
-			 referencedTableName="users" referencedColumnNames="user_id"/>
+		<addForeignKeyConstraint constraintName="radiology_report_creator_fk"
+			baseTableName="radiology_report" baseColumnNames="creator"
+			referencedTableName="users" referencedColumnNames="user_id" />
 	</changeSet>
 </databaseChangeLog>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyServiceComponentTestDataset.xml
@@ -86,20 +86,20 @@
   <test_order order_id="2006" />
   <radiology_order order_id="2006" />
   <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="DEFAULT" />
-  <radiology_report radiology_report_id="1" order_id="2006" report_status="CLAIMED" principalResultsInterpreter_id="1" />
+  <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" />
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" />
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="DEFAULT" />
-  <radiology_report radiology_report_id="2" order_id="2007" report_status="COMPLETED" principalResultsInterpreter_id="1" />
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" />
 
   <!-- radiology order with associated study and with a discontinued report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" />
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="DEFAULT" />
-  <radiology_report radiology_report_id="3" order_id="2008" report_status="DISCONTINUED" principalResultsInterpreter_id="1" />
+  <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" />
 
 </dataset>


### PR DESCRIPTION
update the database radiology_report
* column radiology_report_id
** rename to report_id
* column order_id
** add not null constraint (a report must not exist without order)
* column report_status
** shrink size to max enum of RadiologyReportStatus which is DISCONTINUED -> 12
** add not null constraint
* column principalResultsInterpreter_id
** rename to principal_results_interpreter
* column creator
** add not null constraint, defauts to '0'
* column creationDate
** rename to date_created
** convert type to datetime
** add not null constraint
* rename foreign key constraints to "tablename_columname_fk"

* remove setting dateCreated in RadiologyReport constructor since its
done by AuditableInterceptor

see https://issues.openmrs.org/browse/RAD-172