### PR TITLE
RAD-175 Prevent report creation of incomplete order

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
@@ -16,7 +16,8 @@ import org.openmrs.Provider;
 import org.openmrs.module.radiology.RadiologyOrder;
 
 /**
- * RadiologyReport represents a radiology report for a RadiologyOrder
+ * RadiologyReport represents a radiology report written by a Provider for a RadiologyOrder once the
+ * order is completed
  */
 public class RadiologyReport extends BaseOpenmrsData {
 	
@@ -32,69 +33,161 @@ public class RadiologyReport extends BaseOpenmrsData {
 	
 	private String reportBody;
 	
-	protected RadiologyReport() {
-		
+	/**
+	 * Instantiate a RadiologyReport
+	 */
+	private RadiologyReport() {
+		// needed by hibernate to instantiate a bean
 	}
 	
+	/**
+	 * Instantiate a RadiologyReport for given RadiologyOrder
+	 * 
+	 * @param radiologyOrder RadiologyOrder which is being/was reported
+	 * @throws IllegalArgumentException if given radiology order is null
+	 * @throws IllegalArgumentException if given radiology order is not completed
+	 * @should set radiology order to given radiology order and report status to claimed
+	 * @should throw an illegal argument exception if given radiology order is null
+	 * @should throw an illegal argument exception if given radiology order is not completed
+	 */
 	public RadiologyReport(RadiologyOrder radiologyOrder) {
+		
+		if (radiologyOrder == null) {
+			throw new IllegalArgumentException("radiologyOrder cannot be null");
+		}
+		
+		if (radiologyOrder.isNotCompleted()) {
+			throw new IllegalArgumentException("radiologyOrder is not completed");
+		}
+		
 		this.radiologyOrder = radiologyOrder;
 		this.reportStatus = RadiologyReportStatus.CLAIMED;
 	}
 	
+	/**
+	 * Get RadiologyOrder which is being/was reported.
+	 * 
+	 * @return RadiologyOrder which is being/was reported
+	 */
 	public RadiologyOrder getRadiologyOrder() {
 		return radiologyOrder;
 	}
 	
+	/**
+	 * Set RadiologyOrder which is being/was reported.
+	 * 
+	 * @param radiologyOrder RadiologyOrder which is being/was reported
+	 */
 	public void setRadiologyOrder(RadiologyOrder radiologyOrder) {
 		this.radiologyOrder = radiologyOrder;
 	}
 	
+	/**
+	 * Get Provider which is the report author.
+	 * 
+	 * @return Provider which is the report author
+	 */
 	public Provider getPrincipalResultsInterpreter() {
 		return principalResultsInterpreter;
 	}
 	
+	/**
+	 * Set Provider which is the report author.
+	 * 
+	 * @param principalResultsInterpreter Provider which is the report author
+	 */
 	public void setPrincipalResultsInterpreter(Provider principalResultsInterpreter) {
 		this.principalResultsInterpreter = principalResultsInterpreter;
 	}
 	
+	/**
+	 * Get radiologyReportId of RadiologyReport.
+	 * 
+	 * @return radiologyReportId of RadiologyReport
+	 */
 	@Override
 	public Integer getId() {
 		return getRadiologyReportId();
 	}
 	
+	/**
+	 * Set radiologyReportId of RadiologyReport.
+	 * 
+	 * @param radiologyReportId Id of RadiologyReport
+	 */
 	@Override
 	public void setId(Integer radiologyReportId) {
 		setRadiologyReportId(radiologyReportId);
 	}
 	
+	/**
+	 * Get radiologyReportId of RadiologyReport.
+	 * 
+	 * @return radiologyReportId of RadiologyReport
+	 */
 	private Integer getRadiologyReportId() {
 		return this.radiologyReportId;
 	}
 	
+	/**
+	 * Set radiologyReportId of RadiologyReport.
+	 * 
+	 * @param radiologyReportId Id of RadiologyReport
+	 */
 	private void setRadiologyReportId(Integer radiologyReportId) {
 		this.radiologyReportId = radiologyReportId;
 	}
 	
+	/**
+	 * Get reportDate of RadiologyReport.
+	 * 
+	 * @return reportDate of RadiologyReport
+	 */
 	public Date getReportDate() {
 		return reportDate;
 	}
 	
+	/**
+	 * Set reportDate of RadiologyReport.
+	 * 
+	 * @param reportDate date of RadiologyReport
+	 */
 	public void setReportDate(Date reportDate) {
 		this.reportDate = reportDate;
 	}
 	
+	/**
+	 * Get reportStatus of RadiologyReport.
+	 * 
+	 * @return reportStatus of RadiologyReport
+	 */
 	public RadiologyReportStatus getReportStatus() {
 		return reportStatus;
 	}
 	
+	/**
+	 * Set reportStatus of RadiologyReport.
+	 * 
+	 * @param reportStatus status of RadiologyReport
+	 */
 	public void setReportStatus(RadiologyReportStatus reportStatus) {
 		this.reportStatus = reportStatus;
 	}
 	
+	/**
+	 * Get reportBody of RadiologyReport.
+	 * 
+	 * @return reportBody of RadiologyReport
+	 */
 	public String getReportBody() {
 		return reportBody;
 	}
 	
+	/**
+	 * Set reportBody of RadiologyReport.
+	 * 
+	 * @param reportBody body of RadiologyReport
+	 */
 	public void setReportBody(String reportBody) {
 		this.reportBody = reportBody;
 	}

--- a/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
@@ -34,6 +34,7 @@ import org.openmrs.Provider;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.module.radiology.Modality;
+import org.openmrs.module.radiology.PerformedProcedureStepStatus;
 import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.report.RadiologyReport;
@@ -177,7 +178,9 @@ public class RadiologyTestData {
 		mockRadiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
 		mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
 		mockRadiologyOrder.setVoided(false);
-		mockRadiologyOrder.setStudy(getMockStudy1PostSave());
+		Study study = getMockStudy1PostSave();
+		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		mockRadiologyOrder.setStudy(study);
 		
 		return mockRadiologyOrder;
 	}
@@ -197,6 +200,9 @@ public class RadiologyTestData {
 		mockRadiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
 		mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITHOUT IV CONTRAST");
 		mockRadiologyOrder.setVoided(false);
+		Study study = getMockStudy2PostSave();
+		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		mockRadiologyOrder.setStudy(study);
 		
 		return mockRadiologyOrder;
 	}
@@ -444,9 +450,9 @@ public class RadiologyTestData {
 	}
 	
 	public static RadiologyReport getMockRadiologyReport1() {
+		
 		RadiologyReport radiologyReport = new RadiologyReport(getMockRadiologyOrder1());
 		radiologyReport.setId(1);
-		radiologyReport.setRadiologyOrder(getMockRadiologyOrder1());
 		return radiologyReport;
 	}
 }


### PR DESCRIPTION
* reduce visibility of no arg constructor which is only used by hibernate
* ensure creation of RadiologyReport only with complete RadiologyOrder
* remove RadiologyReportTest's of logic that is not implemented in
RadiologyReport
* add javadocs and tests

see https://issues.openmrs.org/browse/RAD-175