### PR TITLE
RAD-178 Change reporting dependency to 0.9.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<dependency>
 			<groupId>org.openmrs.module</groupId>
 			<artifactId>reporting-api</artifactId>
-			<version>0.9.9-SNAPSHOT</version>
+			<version>0.9.9</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
* version 0.9.9 of reporting module was released, snapshot is no longer valid.
* fixes failed travis ci builds

see https://issues.openmrs.org/browse/RAD-178