### PR TITLE
RAD-144 RadiologyOrder can be discontinued if already performed

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyOrder.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyOrder.java
@@ -39,6 +39,36 @@ public class RadiologyOrder extends TestOrder {
 	}
 	
 	/**
+	 * Returns true if study is in progress and false otherwise.
+	 * 
+	 * @return true if study is in progress and false otherwise
+	 * @should return false if associated study is null
+	 * @should return false if associated study is not in progress
+	 * @should return true if associated study is in progress
+	 */
+	public boolean isInProgress() {
+		
+		if (this.study == null) {
+			return false;
+		} else {
+			return this.study.isInProgress();
+		}
+	}
+	
+	/**
+	 * Returns true if study is not in progress and false otherwise.
+	 * 
+	 * @return true if study is not in progress and false otherwise
+	 * @should return true if associated study is null
+	 * @should return true if associated study is not in progress
+	 * @should return false if associated study in progress
+	 */
+	public boolean isNotInProgress() {
+		
+		return !this.isInProgress();
+	}
+	
+	/**
 	 * Returns true when this RadiologyOrder has a completed Study and false otherwise.
 	 * 
 	 * @return true if order has completed study and false otherwise
@@ -66,5 +96,19 @@ public class RadiologyOrder extends TestOrder {
 	public boolean isNotCompleted() {
 		
 		return !this.isCompleted();
+	}
+	
+	/**
+	 * Returns true when this RadiologyOrder can be discontinued and false otherwise.
+	 * 
+	 * @return true if radiology order can be discontinued and false otherwise
+	 * @should return false if order is not active
+	 * @should return false if radiology order is in progress
+	 * @should return false if radiology order is completed
+	 * @should return true if radiology order is active not in progress and not completed
+	 */
+	public boolean isDiscontinuationAllowed() {
+		
+		return this.isActive() && this.isNotInProgress() && this.isNotCompleted();
 	}
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyService.java
@@ -67,10 +67,12 @@ public interface RadiologyService extends OpenmrsService {
 	 * @throws IllegalArgumentException if radiologyOrder orderId is null
 	 * @throws IllegalArgumentException if radiologyOrder is not active
 	 * @throws IllegalArgumentException if provider is null
-	 * @should create discontinuation order which discontinues given radiology order object
+	 * @should create discontinuation order which discontinues given radiology order that is not in progress or completed
 	 * @should throw illegal argument exception given empty radiology order
 	 * @should throw illegal argument exception given radiology order with orderId null
 	 * @should throw illegal argument exception if radiology order is not active
+	 * @should throw illegal argument exception if radiology order is in progress
+	 * @should throw illegal argument exception if radiology order is completed
 	 * @should throw illegal argument exception given empty provider
 	 */
 	public Order discontinueRadiologyOrder(RadiologyOrder radiologyOrder, Provider orderer, Date discontinueDate,

--- a/api/src/main/java/org/openmrs/module/radiology/Study.java
+++ b/api/src/main/java/org/openmrs/module/radiology/Study.java
@@ -60,6 +60,18 @@ public class Study {
 	}
 	
 	/**
+	 * Returns true when this Study's performedStatus is in progress and false otherwise.
+	 * 
+	 * @return true on performedStatus in progress and false otherwise
+	 * @should return false if performed status is null
+	 * @should return false if performed status is not in progress
+	 * @should return true if performed status is in progress
+	 */
+	public boolean isInProgress() {
+		return performedStatus == PerformedProcedureStepStatus.IN_PROGRESS;
+	}
+	
+	/**
 	 * Returns true when this Study's performedStatus is completed and false otherwise.
 	 * 
 	 * @return true on performedStatus completed and false otherwise

--- a/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
@@ -195,6 +195,14 @@ class RadiologyServiceImpl extends BaseOpenmrsService implements RadiologyServic
 			throw new IllegalArgumentException("order is not active");
 		}
 		
+		if (radiologyOrderToDiscontinue.isInProgress()) {
+			throw new IllegalArgumentException("radiologyOrder is in progress");
+		}
+		
+		if (radiologyOrderToDiscontinue.isCompleted()) {
+			throw new IllegalArgumentException("radiologyOrder is completed");
+		}
+		
 		if (orderer == null) {
 			throw new IllegalArgumentException("provider is required");
 		}

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyOrderTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyOrderTest.java
@@ -16,6 +16,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
+import org.openmrs.Order;
 
 /**
  * Tests {@link RadiologyOrder}
@@ -61,6 +62,92 @@ public class RadiologyOrderTest {
 		radiologyOrder.setStudy(null);
 		
 		assertNotNull(radiologyOrder);
+	}
+	
+	/**
+	 * @see RadiologyOrder#isInProgress()
+	 * @verifies return false if associated study is null
+	 */
+	@Test
+	public void isInProgress_shouldReturnFalseIfAssociatedStudyIsNull() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		radiologyOrder.setStudy(null);
+		
+		assertFalse(radiologyOrder.isInProgress());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isInProgress()
+	 * @verifies return false if associated study is not in progress
+	 */
+	@Test
+	public void isInProgress_shouldReturnFalseIfAssociatedStudyIsNotInProgress() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		radiologyOrder.setStudy(study);
+		
+		assertFalse(radiologyOrder.isInProgress());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isInProgress()
+	 * @verifies return true if associated study is in progress
+	 */
+	@Test
+	public void isInProgress_shouldReturnTrueIfAssociatedStudyIsInProgress() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+		radiologyOrder.setStudy(study);
+		
+		assertTrue(radiologyOrder.isInProgress());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isNotInProgress()
+	 * @verifies return true if associated study is null
+	 */
+	@Test
+	public void isNotInProgress_shouldReturnTrueIfAssociatedStudyIsNull() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		radiologyOrder.setStudy(null);
+		
+		assertTrue(radiologyOrder.isNotInProgress());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isNotInProgress()
+	 * @verifies return true if associated study is not in progress
+	 */
+	@Test
+	public void isNotInProgress_shouldReturnTrueIfAssociatedStudyIsNotInProgress() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		radiologyOrder.setStudy(study);
+		
+		assertTrue(radiologyOrder.isNotInProgress());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isNotInProgress()
+	 * @verifies return false if associated study in progress
+	 */
+	@Test
+	public void isNotInProgress_shouldReturnFalseIfAssociatedStudyInProgress() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+		radiologyOrder.setStudy(study);
+		
+		assertFalse(radiologyOrder.isNotInProgress());
 	}
 	
 	/**
@@ -143,5 +230,65 @@ public class RadiologyOrderTest {
 		radiologyOrder.setStudy(study);
 		
 		assertFalse(radiologyOrder.isNotCompleted());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isDiscontinuationAllowed()
+	 * @verifies return false if order is not active
+	 */
+	@Test
+	public void isDiscontinuationAllowed_shouldReturnFalseIfOrderIsNotActive() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+		radiologyOrder.setStudy(study);
+		radiologyOrder.setAction(Order.Action.DISCONTINUE);
+		
+		assertFalse(radiologyOrder.isDiscontinuationAllowed());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isDiscontinuationAllowed()
+	 * @verifies return false if radiology order is in progress
+	 */
+	@Test
+	public void isDiscontinuationAllowed_shouldReturnFalseIfRadiologyOrderIsInProgress() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+		radiologyOrder.setStudy(study);
+		
+		assertFalse(radiologyOrder.isDiscontinuationAllowed());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isDiscontinuationAllowed()
+	 * @verifies return false if radiology order is completed
+	 */
+	@Test
+	public void isDiscontinuationAllowed_shouldReturnFalseIfRadiologyOrderIsCompleted() throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		radiologyOrder.setStudy(study);
+		
+		assertFalse(radiologyOrder.isDiscontinuationAllowed());
+	}
+	
+	/**
+	 * @see RadiologyOrder#isDiscontinuationAllowed()
+	 * @verifies return true if radiology order is active not in progress and not completed
+	 */
+	@Test
+	public void isDiscontinuationAllowed_shouldReturnTrueIfRadiologyOrderIsActiveNotInProgressAndNotCompleted()
+	        throws Exception {
+		
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		radiologyOrder.setStudy(null);
+		
+		assertTrue(radiologyOrder.isDiscontinuationAllowed());
 	}
 }

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyServiceComponentTest.java
@@ -270,14 +270,16 @@ public class RadiologyServiceComponentTest extends BaseModuleContextSensitiveTes
 	}
 	
 	/**
-	 * @see RadiologyService#discontinueRadiologyOrder(RadiologyOrder, Provider, Date, String)
-	 * @verifies should create discontinuation order which discontinues given radiology order object
+	 * @see RadiologyService#discontinueRadiologyOrder(RadiologyOrder,Provider,Date,String)
+	 * @verifies create discontinuation order which discontinues given radiology order that is not
+	 *           in progress or completed
 	 */
 	@Test
-	public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWhichDiscontinuesGivenRadiologyOrderObject()
+	public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWhichDiscontinuesGivenRadiologyOrderThatIsNotInProgressOrCompleted()
 	        throws Exception {
 		
 		RadiologyOrder radiologyOrder = radiologyService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+		radiologyOrder.getStudy().setPerformedStatus(null);
 		String discontinueReason = "Wrong Procedure";
 		Date discontinueDate = new GregorianCalendar(2015, Calendar.JANUARY, 01).getTime();
 		
@@ -344,6 +346,42 @@ public class RadiologyServiceComponentTest extends BaseModuleContextSensitiveTes
 	}
 	
 	/**
+	 * @see RadiologyService#discontinueRadiologyOrder(RadiologyOrder,Provider,Date,String)
+	 * @verifies throw illegal argument exception if radiology order is completed
+	 */
+	@Test
+	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsCompleted() throws Exception {
+		
+		RadiologyOrder radiologyOrder = radiologyService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+		radiologyOrder.getStudy().setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+		String discontinueReason = "Wrong Procedure";
+		Date discontinueDate = new GregorianCalendar(2015, Calendar.JANUARY, 01).getTime();
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("radiologyOrder is in progress");
+		radiologyService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueDate,
+		    discontinueReason);
+	}
+	
+	/**
+	 * @see RadiologyService#discontinueRadiologyOrder(RadiologyOrder,Provider,Date,String)
+	 * @verifies throw illegal argument exception if radiology order is in progress
+	 */
+	@Test
+	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsInProgress() throws Exception {
+		
+		RadiologyOrder radiologyOrder = radiologyService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+		radiologyOrder.getStudy().setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		String discontinueReason = "Wrong Procedure";
+		Date discontinueDate = new GregorianCalendar(2015, Calendar.JANUARY, 01).getTime();
+		
+		expectedException.expect(IllegalArgumentException.class);
+		expectedException.expectMessage("radiologyOrder is completed");
+		radiologyService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueDate,
+		    discontinueReason);
+	}
+	
+	/**
 	 * @see RadiologyService#discontinueRadiologyOrder(RadiologyOrder, Provider, Date, String)
 	 * @verifies should throw illegal argument exception given empty provider
 	 */
@@ -351,6 +389,7 @@ public class RadiologyServiceComponentTest extends BaseModuleContextSensitiveTes
 	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenEmptyProvider() throws Exception {
 		
 		RadiologyOrder radiologyOrder = radiologyService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+		radiologyOrder.getStudy().setPerformedStatus(null);
 		String discontinueReason = "Wrong Procedure";
 		Date discontinueDate = new GregorianCalendar(2015, Calendar.JANUARY, 01).getTime();
 		

--- a/api/src/test/java/org/openmrs/module/radiology/StudyTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/StudyTest.java
@@ -8,6 +8,41 @@ import org.junit.Test;
 public class StudyTest {
 	
 	/**
+	 * @see Study#isInProgress()
+	 * @verifies return false if performed status is null
+	 */
+	@Test
+	public void isInProgress_shouldReturnFalseIfPerformedStatusIsNull() throws Exception {
+		
+		Study study = new Study();
+		assertFalse(study.isInProgress());
+	}
+	
+	/**
+	 * @see Study#isInProgress()
+	 * @verifies return false if performed status is not in progress
+	 */
+	@Test
+	public void isInProgress_shouldReturnFalseIfPerformedStatusIsNotInProgress() throws Exception {
+		
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		assertFalse(study.isInProgress());
+	}
+	
+	/**
+	 * @see Study#isInProgress()
+	 * @verifies return true if performed status is in progress
+	 */
+	@Test
+	public void isInProgress_shouldReturnTrueIfPerformedStatusIsInProgress() throws Exception {
+		
+		Study study = new Study();
+		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+		assertTrue(study.isInProgress());
+	}
+	
+	/**
 	 * @see Study#isCompleted()
 	 * @verifies return false if performedStatus is null
 	 */

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
@@ -80,11 +80,10 @@ public class RadiologyOrderFormController {
 		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
 		
 		if (Context.isAuthenticated()) {
+			modelAndView.addObject("order", new Order());
+			modelAndView.addObject("radiologyReport", null);
 			final RadiologyOrder radiologyOrder = new RadiologyOrder();
 			radiologyOrder.setStudy(new Study());
-			modelAndView.addObject("order", new Order());
-			modelAndView.addObject("isOrderActive", true);
-			modelAndView.addObject("radiologyReport", null);
 			modelAndView.addObject("radiologyOrder", radiologyOrder);
 		}
 		
@@ -135,7 +134,6 @@ public class RadiologyOrderFormController {
 		
 		if (Context.isAuthenticated()) {
 			modelAndView.addObject("order", order);
-			modelAndView.addObject("isOrderActive", order.isActive());
 			modelAndView.addObject("discontinuationOrder", new Order());
 			
 			if (order instanceof RadiologyOrder) {
@@ -185,7 +183,6 @@ public class RadiologyOrderFormController {
 		} else {
 			new RadiologyOrderValidator().validate(radiologyOrder, radiologyOrderErrors);
 			if (radiologyOrderErrors.hasErrors()) {
-				modelAndView.addObject("isOrderActive", radiologyOrder.isActive());
 				return modelAndView;
 			}
 			
@@ -239,7 +236,6 @@ public class RadiologyOrderFormController {
 			new RadiologyDiscontinuedOrderValidator().validate(discontinuationOrder, radiologyOrderErrors);
 			if (radiologyOrderErrors.hasErrors()) {
 				modelAndView.addObject("order", radiologyOrderToDiscontinue);
-				modelAndView.addObject("isOrderActive", radiologyOrderToDiscontinue.isActive());
 				log.error(radiologyService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
 				modelAndView.addObject("radiologyOrder", radiologyService
 				        .getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
@@ -264,7 +260,6 @@ public class RadiologyOrderFormController {
 		}
 		
 		modelAndView.addObject("order", radiologyOrderToDiscontinue);
-		modelAndView.addObject("isOrderActive", radiologyOrderToDiscontinue.isActive());
 		modelAndView.addObject("radiologyOrder", radiologyService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue
 		        .getOrderId()));
 		modelAndView.addObject("discontinuationOrder", discontinuationOrder);

--- a/omod/src/main/webapp/radiologyOrderForm.jsp
+++ b/omod/src/main/webapp/radiologyOrderForm.jsp
@@ -174,7 +174,7 @@
 
 	<c:otherwise>
 		<c:if test="${empty radiologyOrder}">
-			<!--  Show existing RadiologyOrder's and discontinuation Order's -->
+			<!--  Show discontinuation Order's -->
 			<form:form method="post" modelAttribute="order" cssClass="box">
 				<table>
 					<tr>
@@ -236,6 +236,7 @@
 			</form:form>
 		</c:if>
 		<c:if test="${not empty radiologyOrder}">
+			<!--  Show existing RadiologyOrder's -->
 			<%@ include file="portlets/radiologyOrderDetailsPortlet.jsp"%>
 			<c:if test="${radiologyOrder.completed}">
 				<h2>
@@ -275,7 +276,8 @@
 					</c:otherwise>
 				</c:choose>
 			</c:if>
-			<c:if test="${isOrderActive}">
+			<c:if test="${radiologyOrder.discontinuationAllowed}">
+				<!--  Show form to discontinue an active non in progress/completed RadiologyOrder -->
 				<br />
 				<form:form method="post" modelAttribute="discontinuationOrder"
 					cssClass="box">
@@ -319,7 +321,6 @@
 		</c:if>
 	</c:otherwise>
 </c:choose>
-
 
 <div id="moreInfoPopup"></div>
 <%@ include file="/WEB-INF/template/footer.jsp"%>


### PR DESCRIPTION
* add isInProgress to Study
* add isInProgress and isInNotProgress to RadiologyOrder
* prevent discontinuation of radorder in API and web UI if in progress or completed
* remove isOrderActive in mav
* add isDiscontinuationAllowed to RadiologyOrder and use it jsp

see https://issues.openmrs.org/browse/RAD-144