### PR TITLE
RAD-195 Move getCommonOrderPriorityFrom to HL7Utils

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/DicomUtils.java
+++ b/api/src/main/java/org/openmrs/module/radiology/DicomUtils.java
@@ -15,10 +15,8 @@ import org.dcm4che2.data.DicomElement;
 import org.dcm4che2.data.DicomObject;
 import org.dcm4che2.data.SpecificCharacterSet;
 import org.dcm4che2.data.Tag;
-import org.openmrs.Order;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.CommonOrderPriority;
 import org.openmrs.module.radiology.hl7.message.RadiologyORMO01;
 
 import ca.uhn.hl7v2.HL7Exception;
@@ -157,11 +155,8 @@ public class DicomUtils {
 				.getMwlStatus();
 		final CommonOrderOrderControl commonOrderOrderControl = getCommonOrderControlFrom(mwlstatus, orderRequest);
 		
-		final CommonOrderPriority orderPriority = getCommonOrderPriorityFrom(radiologyOrder.getUrgency());
-		
 		try {
-			final RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, commonOrderOrderControl,
-					orderPriority);
+			final RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, commonOrderOrderControl);
 			encodedHL7OrmMessage = radiologyOrderMessage.createEncodedRadiologyORMO01Message();
 			log.info("Created HL7 ORM^O01 message \n" + encodedHL7OrmMessage);
 		}
@@ -208,36 +203,6 @@ public class DicomUtils {
 				break;
 			default:
 				break;
-		}
-		return result;
-	}
-	
-	/**
-	 * Get the HL7 Priority component of Quantity/Timing (ORC-7) field included in an HL7 version
-	 * 2.3.1 Common Order segment given the Order Urgency.
-	 * 
-	 * @param urgency order urgency
-	 * @return string representation of hl7 common order priority mapping to order urgency
-	 * @should return hl7 common order priority given order urgency
-	 * @should return default hl7 common order priority given null
-	 */
-	public static CommonOrderPriority getCommonOrderPriorityFrom(Order.Urgency urgency) {
-		CommonOrderPriority result = null;
-		
-		if (urgency == null) {
-			result = CommonOrderPriority.ROUTINE;
-		} else {
-			switch (urgency) {
-				case STAT:
-					result = CommonOrderPriority.STAT;
-					break;
-				case ROUTINE:
-					result = CommonOrderPriority.ROUTINE;
-					break;
-				case ON_SCHEDULED_DATE:
-					result = CommonOrderPriority.TIMING_CRITICAL;
-					break;
-			}
 		}
 		return result;
 	}

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/HL7Utils.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/HL7Utils.java
@@ -9,14 +9,15 @@
  */
 package org.openmrs.module.radiology.hl7;
 
+import org.openmrs.Order;
 import org.openmrs.PersonName;
 
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.v231.datatype.XPN;
 
 /**
- * HL7Utils is a utility class transforming OpenMRS PersonName into an HL7 conform Extended Person
- * Name
+ * HL7Utils is a utility class containing methods for transforming OpenMRS PersonName into an HL7 conform Extended Person
+ * Name and mapping Order.Urgency to HL7 Priority codes.
  */
 public class HL7Utils {
 	
@@ -50,6 +51,41 @@ public class HL7Utils {
 					.setValue(personName.getGivenName());
 			result.getMiddleInitialOrName()
 					.setValue(personName.getMiddleName());
+		}
+		return result;
+	}
+	
+	/**
+	 * Get the HL7 Priority component of Quantity/Timing (ORC-7) field included in an HL7 version
+	 * 2.3.1 Common Order segment from given Order.Urgency.
+	 * 
+	 * @param orderUrgency Order.Urgency to be converted to CommonOrderPriority
+	 * @return CommonOrderPriority for given Order.Urgency
+	 * @should return routine given null
+	 * @should return stat given order urgency stat
+	 * @should return routine given order urgency routine
+	 * @should return timing critical given order urgency on scheduled date
+	 */
+	public static CommonOrderPriority convertOrderUrgencyToCommonOrderPriority(Order.Urgency orderUrgency) {
+		final CommonOrderPriority result;
+		
+		if (orderUrgency == null) {
+			result = CommonOrderPriority.ROUTINE;
+		} else {
+			switch (orderUrgency) {
+				case STAT:
+					result = CommonOrderPriority.STAT;
+					break;
+				case ROUTINE:
+					result = CommonOrderPriority.ROUTINE;
+					break;
+				case ON_SCHEDULED_DATE:
+					result = CommonOrderPriority.TIMING_CRITICAL;
+					break;
+				default:
+					result = CommonOrderPriority.ROUTINE;
+					break;
+			}
 		}
 		return result;
 	}

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/message/RadiologyORMO01.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/message/RadiologyORMO01.java
@@ -13,7 +13,6 @@ import java.util.Date;
 
 import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.CommonOrderPriority;
 import org.openmrs.module.radiology.hl7.custommodel.v231.message.ORM_O01;
 import org.openmrs.module.radiology.hl7.segment.RadiologyMSH;
 import org.openmrs.module.radiology.hl7.segment.RadiologyOBR;
@@ -44,23 +43,17 @@ public class RadiologyORMO01 {
 	
 	private final CommonOrderOrderControl commonOrderControl;
 	
-	private final CommonOrderPriority commonOrderPriority;
-	
 	/**
 	 * Constructor for <code>RadiologyORMO01</code>
 	 * 
 	 * @param radiologyOrder radiology order
 	 * @param commonOrderOrderControl Order Control Code of Common Order (ORC) segment
-	 * @param commonOrderPriority Priority component of Common Order (ORC) segment attribute
-	 *        Quantity/Timing
 	 * @should create new radiology ormo01 object given all params
 	 * @should throw illegal argument exception given null as radiologyOrder
 	 * @should throw illegal argument exception if given radiology orders study is null
 	 * @should throw illegal argument exception given null as orderControlCode
-	 * @should throw illegal argument exception given null as orderControlPriority
 	 */
-	public RadiologyORMO01(RadiologyOrder radiologyOrder, CommonOrderOrderControl commonOrderOrderControl,
-		CommonOrderPriority commonOrderPriority) {
+	public RadiologyORMO01(RadiologyOrder radiologyOrder, CommonOrderOrderControl commonOrderOrderControl) {
 		
 		if (radiologyOrder == null) {
 			throw new IllegalArgumentException("radiologyOrder cannot be null.");
@@ -72,13 +65,10 @@ public class RadiologyORMO01 {
 		
 		if (commonOrderOrderControl == null) {
 			throw new IllegalArgumentException("orderControlCode cannot be null.");
-		} else if (commonOrderPriority == null) {
-			throw new IllegalArgumentException("orderControlPriority cannot be null.");
 		}
 		
 		this.radiologyOrder = radiologyOrder;
 		this.commonOrderControl = commonOrderOrderControl;
-		this.commonOrderPriority = commonOrderPriority;
 	}
 	
 	/**
@@ -111,7 +101,7 @@ public class RadiologyORMO01 {
 				.getPID(), radiologyOrder.getPatient());
 		
 		RadiologyORC.populateCommonOrder(result.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
-				.getORC(), radiologyOrder, commonOrderControl, commonOrderPriority);
+				.getORC(), radiologyOrder, commonOrderControl);
 		
 		RadiologyOBR.populateObservationRequest(result.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
 				.getOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTE()

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/segment/RadiologyORC.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/segment/RadiologyORC.java
@@ -11,7 +11,7 @@ package org.openmrs.module.radiology.hl7.segment;
 
 import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.CommonOrderPriority;
+import org.openmrs.module.radiology.hl7.HL7Utils;
 import org.openmrs.module.radiology.utils.DateTimeUtils;
 
 import ca.uhn.hl7v2.model.DataTypeException;
@@ -34,8 +34,6 @@ public class RadiologyORC {
 	 * @param commonOrderSegment Common Order Segment to populate
 	 * @param radiologyOrder to map to commonOrderSegment segment
 	 * @param commonOrderOrderControl Order Control element of Common Order (ORC)
-	 * @param commonOrderPriority Priority component of Common Order (ORC) segment attribute
-	 *        Quantity/Timing
 	 * @return populated commonOrderSegment segment
 	 * @throws DataTypeException
 	 * @should return populated common order segment given all params
@@ -43,8 +41,7 @@ public class RadiologyORC {
 	 * @should throw illegal argument exception given null as radiology order
 	 */
 	public static ORC populateCommonOrder(ORC commonOrderSegment, RadiologyOrder radiologyOrder,
-			CommonOrderOrderControl commonOrderOrderControl, CommonOrderPriority commonOrderPriority)
-			throws DataTypeException {
+			CommonOrderOrderControl commonOrderOrderControl) throws DataTypeException {
 		
 		if (commonOrderSegment == null) {
 			throw new IllegalArgumentException("commonOrderSegment cannot be null.");
@@ -65,7 +62,8 @@ public class RadiologyORC {
 				.setValue(DateTimeUtils.getPlainDateTimeFrom(radiologyOrder.getEffectiveStartDate()));
 		commonOrderSegment.getQuantityTiming()
 				.getPriority()
-				.setValue(commonOrderPriority.getValue());
+				.setValue(HL7Utils.convertOrderUrgencyToCommonOrderPriority(radiologyOrder.getUrgency())
+						.getValue());
 		
 		return commonOrderSegment;
 	}

--- a/api/src/test/java/org/openmrs/module/radiology/DicomUtilsComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/DicomUtilsComponentTest.java
@@ -44,7 +44,6 @@ import org.openmrs.PersonName;
 import org.openmrs.api.AdministrationService;
 import org.openmrs.module.radiology.DicomUtils.OrderRequest;
 import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.CommonOrderPriority;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -834,29 +833,6 @@ public class DicomUtilsComponentTest extends BaseModuleContextSensitiveTest {
 		assertThat(terser.get("/.ZDS-1-2"), is(nullValue()));
 		assertThat(terser.get("/.ZDS-1-3"), is("Application"));
 		assertThat(terser.get("/.ZDS-1-4"), is("DICOM"));
-	}
-	
-	/**
-	 * @see {@link DicomUtils#getCommonOrderPriorityFrom(Order.Urgency)}
-	 * @verifies should return hl7 common order priority given order urgency
-	 */
-	@Test
-	public void getCommonOrderPriorityFrom_shouldReturnHL7CommonOrderPriorityGivenOrderUrgency() {
-		
-		assertThat(DicomUtils.getCommonOrderPriorityFrom(Order.Urgency.STAT), is(CommonOrderPriority.STAT));
-		assertThat(DicomUtils.getCommonOrderPriorityFrom(Order.Urgency.ROUTINE), is(CommonOrderPriority.ROUTINE));
-		assertThat(DicomUtils.getCommonOrderPriorityFrom(Order.Urgency.ON_SCHEDULED_DATE),
-			is(CommonOrderPriority.TIMING_CRITICAL));
-	}
-	
-	/**
-	 * @see {@link DicomUtils#getCommonOrderPriorityFrom(Order.Urgency)}
-	 * @verifies should return default hl7 common order priority given null
-	 */
-	@Test
-	public void getCommonOrderPriorityFrom_shouldReturnDefaultHL7CommonOrderPriorityGivenNull() {
-		
-		assertThat(DicomUtils.getCommonOrderPriorityFrom(null), is(CommonOrderPriority.ROUTINE));
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/HL7UtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/HL7UtilsTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
+import org.openmrs.Order;
 import org.openmrs.PersonName;
 import org.openmrs.test.Verifies;
 
@@ -163,5 +164,47 @@ public class HL7UtilsTest {
 		String extendedPersonName = PipeParser.encode(xpn, encodingCharacters);
 		
 		assertThat(extendedPersonName, is(""));
+	}
+	
+	/**
+	 * @see HL7Utils#convertOrderUrgencyToCommonOrderPriority(Order.Urgency)
+	 * @verifies return routine given null
+	 */
+	@Test
+	public void convertOrderUrgencyToCommonOrderPriority_shouldReturnRoutineGivenNull() throws Exception {
+		
+		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(null), is(CommonOrderPriority.ROUTINE));
+	}
+	
+	/**
+	 * @see HL7Utils#convertOrderUrgencyToCommonOrderPriority(Order.Urgency)
+	 * @verifies return stat given order urgency stat
+	 */
+	@Test
+	public void convertOrderUrgencyToCommonOrderPriority_shouldReturnStatGivenOrderUrgencyStat() throws Exception {
+		
+		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.STAT), is(CommonOrderPriority.STAT));
+	}
+	
+	/**
+	 * @see HL7Utils#convertOrderUrgencyToCommonOrderPriority(Order.Urgency)
+	 * @verifies return routine given order urgency routine
+	 */
+	@Test
+	public void convertOrderUrgencyToCommonOrderPriority_shouldReturnRoutineGivenOrderUrgencyRoutine() throws Exception {
+		
+		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.ROUTINE), is(CommonOrderPriority.ROUTINE));
+	}
+	
+	/**
+	 * @see HL7Utils#convertOrderUrgencyToCommonOrderPriority(Order.Urgency)
+	 * @verifies return timing critical given order urgency on scheduled date
+	 */
+	@Test
+	public void convertOrderUrgencyToCommonOrderPriority_shouldReturnTimingCriticalGivenOrderUrgencyOnScheduledDate()
+			throws Exception {
+		
+		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.ON_SCHEDULED_DATE),
+			is(CommonOrderPriority.TIMING_CRITICAL));
 	}
 }

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/message/RadiologyORMO01Test.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/message/RadiologyORMO01Test.java
@@ -116,8 +116,7 @@ public class RadiologyORMO01Test {
 	@Test
 	public void RadiologyORMO01_shouldCreateNewRadiologyOrmo01ObjectGivenAllParams() throws Exception {
 		
-		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER,
-				CommonOrderPriority.STAT);
+		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
 		assertNotNull(radiologyOrderMessage);
 	}
 	
@@ -130,7 +129,7 @@ public class RadiologyORMO01Test {
 		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("radiologyOrder cannot be null."));
-		new RadiologyORMO01(null, CommonOrderOrderControl.NEW_ORDER, CommonOrderPriority.STAT);
+		new RadiologyORMO01(null, CommonOrderOrderControl.NEW_ORDER);
 	}
 	
 	/**
@@ -143,7 +142,7 @@ public class RadiologyORMO01Test {
 		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("radiologyOrder.study cannot be null."));
-		new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER, CommonOrderPriority.STAT);
+		new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
 	}
 	
 	/**
@@ -155,19 +154,7 @@ public class RadiologyORMO01Test {
 		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("orderControlCode cannot be null."));
-		new RadiologyORMO01(radiologyOrder, null, CommonOrderPriority.STAT);
-	}
-	
-	/**
-	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,CommonOrderOrderControl,CommonOrderPriority)
-	 * @verifies throw illegal argument exception given null as orderControlPriority
-	 */
-	@Test
-	public void RadiologyORMO01_shouldThrowIllegalArgumentExceptionGivenNullAsOrderControlPriority() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage(is("orderControlPriority cannot be null."));
-		new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER, null);
+		new RadiologyORMO01(radiologyOrder, null);
 	}
 	
 	/**
@@ -177,8 +164,7 @@ public class RadiologyORMO01Test {
 	@Test
 	public void createEncodedRadiologyORMO01Message_shouldCreateEncodedHl7Ormo01Message() throws Exception {
 		
-		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER,
-				CommonOrderPriority.STAT);
+		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
 		String encodedOrmMessage = radiologyOrderMessage.createEncodedRadiologyORMO01Message();
 		
 		assertThat(encodedOrmMessage, startsWith("MSH|^~\\&|OpenMRSRadiologyModule|OpenMRS|||"));
@@ -186,7 +172,7 @@ public class RadiologyORMO01Test {
 			encodedOrmMessage,
 			endsWith("||ORM^O01||P|2.3.1\r"
 					+ "PID|||100||Doe^John^Francis||19500401000000|M\r"
-					+ "ORC|NW|ORD-20|||||^^^20150204143500^^S\r"
+					+ "ORC|NW|ORD-20|||||^^^20150204143500^^T\r"
 					+ "OBR||||^^^^CT ABDOMEN PANCREAS WITH IV CONTRAST|||||||||||||||ORD-20|1||||CT||||||||||||||||||||^CT ABDOMEN PANCREAS WITH IV CONTRAST\r"
 					+ "ZDS|1.2.826.0.1.3680043.8.2186.1.1^^Application^DICOM\r"));
 	}
@@ -198,8 +184,7 @@ public class RadiologyORMO01Test {
 	@Test
 	public void createRadiologyORMO01Message_shouldCreateOrmo01Message() throws Exception {
 		
-		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER,
-				CommonOrderPriority.STAT);
+		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
 		
 		Method createRadiologyORMO01Message = ReflectionUtils.findMethod(RadiologyORMO01.class,
 			"createRadiologyORMO01Message");
@@ -212,7 +197,7 @@ public class RadiologyORMO01Test {
 			encodedOrmMessage,
 			endsWith("||ORM^O01||P|2.3.1\r"
 					+ "PID|||100||Doe^John^Francis||19500401000000|M\r"
-					+ "ORC|NW|ORD-20|||||^^^20150204143500^^S\r"
+					+ "ORC|NW|ORD-20|||||^^^20150204143500^^T\r"
 					+ "OBR||||^^^^CT ABDOMEN PANCREAS WITH IV CONTRAST|||||||||||||||ORD-20|1||||CT||||||||||||||||||||^CT ABDOMEN PANCREAS WITH IV CONTRAST\r"
 					+ "ZDS|1.2.826.0.1.3680043.8.2186.1.1^^Application^DICOM\r"));
 	}

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/segment/RadiologyORCTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/segment/RadiologyORCTest.java
@@ -64,7 +64,7 @@ public class RadiologyORCTest {
 		
 		ORM_O01 message = new ORM_O01();
 		RadiologyORC.populateCommonOrder(message.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
-				.getORC(), radiologyOrder, CommonOrderOrderControl.NEW_ORDER, CommonOrderPriority.STAT);
+				.getORC(), radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
 		
 		ORC commonOrderSegment = message.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
 				.getORC();
@@ -79,9 +79,9 @@ public class RadiologyORCTest {
 				.getValue(), is("20150204143500"));
 		assertThat(commonOrderSegment.getQuantityTiming()
 				.getPriority()
-				.getValue(), is("S"));
+				.getValue(), is(CommonOrderPriority.TIMING_CRITICAL.getValue()));
 		
-		assertThat(PipeParser.encode(commonOrderSegment, encodingCharacters), is("ORC|NW|ORD-1|||||^^^20150204143500^^S"));
+		assertThat(PipeParser.encode(commonOrderSegment, encodingCharacters), is("ORC|NW|ORD-1|||||^^^20150204143500^^T"));
 	}
 	
 	/**
@@ -95,7 +95,7 @@ public class RadiologyORCTest {
 		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("commonOrderSegment cannot be null."));
-		RadiologyORC.populateCommonOrder(null, radiologyOrder, CommonOrderOrderControl.NEW_ORDER, CommonOrderPriority.STAT);
+		RadiologyORC.populateCommonOrder(null, radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
 	}
 	
 	/**
@@ -110,6 +110,6 @@ public class RadiologyORCTest {
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("radiologyOrder cannot be null."));
 		RadiologyORC.populateCommonOrder(message.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
-				.getORC(), null, CommonOrderOrderControl.NEW_ORDER, CommonOrderPriority.STAT);
+				.getORC(), null, CommonOrderOrderControl.NEW_ORDER);
 	}
 }


### PR DESCRIPTION
* remove getCommonOrderPriorityFrom() in DicomUtils
* create method convertOrderUrgencyToCommonOrderPriority() in HL7Utils
* use new method in RadiologyORC segment directly, thus remove
parameter from RadiologyORMO01 constructor

see https://issues.openmrs.org/browse/RAD-195