### PR TITLE
RAD-198 Reduce OrderRequest and MwlStatus

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/DicomUtils.java
+++ b/api/src/main/java/org/openmrs/module/radiology/DicomUtils.java
@@ -133,7 +133,7 @@ public class DicomUtils {
 	}
 	
 	public enum OrderRequest {
-		Save_Order, Void_Order, Discontinue_Order, Undiscontinue_Order, Unvoid_Order;
+		Save_Order, Discontinue_Order;
 	}
 	
 	/**
@@ -143,19 +143,13 @@ public class DicomUtils {
 	 * @param radiologyOrder radiology order for which the order message is created
 	 * @param orderRequest OrderRequest specifying the action of the order message
 	 * @return encoded HL7 ORM^O01 message
-	 * @should return encoded HL7 ORMO01 message string with new order control given study with
-	 *         mwlstatus default and save order request
-	 * @should return encoded HL7 ORMO01 message string with cancel order control given study with
-	 *         mwlstatus default and void order request
-	 * @should return encoded HL7 ORMO01 message string with change order control given study with
-	 *         mwlstatus save ok and save order request
+	 * @should return encoded HL7 ORMO01 message string given radiology order and save order request
+	 * @should return encoded HL7 ORMO01 message string given radiology order and discontinue order request
 	 */
 	public static String createHL7Message(RadiologyOrder radiologyOrder, OrderRequest orderRequest) {
 		String encodedHL7OrmMessage = null;
 		
-		final MwlStatus mwlstatus = radiologyOrder.getStudy()
-				.getMwlStatus();
-		final CommonOrderOrderControl commonOrderOrderControl = getCommonOrderControlFrom(mwlstatus, orderRequest);
+		final CommonOrderOrderControl commonOrderOrderControl = getCommonOrderControlFrom(orderRequest);
 		
 		try {
 			final RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, commonOrderOrderControl);
@@ -176,32 +170,24 @@ public class DicomUtils {
 	 * Get the HL7 Order Control Code component used in an HL7 common order segment (ORC-1 field)
 	 * given the mwlstatus and orderRequest.
 	 * 
-	 * @param mwlstatus mwlstatus of a study
-	 * @param orderRequest
-	 * @should return hl7 order control given mwlstatus and orderrequest
+	 * @param orderRequest OrderRequest to be translated into hl7 order control code
+	 * @should return new order given order request save order
+	 * @should return cancel order given order request discontinue order
+	 * @should return null given null
 	 */
-	public static CommonOrderOrderControl getCommonOrderControlFrom(MwlStatus mwlstatus, OrderRequest orderRequest) {
+	public static CommonOrderOrderControl getCommonOrderControlFrom(OrderRequest orderRequest) {
 		CommonOrderOrderControl result = null;
+		
+		if (orderRequest == null) {
+			return null;
+		}
 		
 		switch (orderRequest) {
 			case Save_Order:
-				if (mwlstatus == MwlStatus.DEFAULT || mwlstatus == MwlStatus.SAVE_ERR) {
-					result = CommonOrderOrderControl.NEW_ORDER;
-				} else {
-					result = CommonOrderOrderControl.CHANGE_ORDER;
-				}
-				break;
-			case Void_Order:
-				result = CommonOrderOrderControl.CANCEL_ORDER;
-				break;
-			case Unvoid_Order:
 				result = CommonOrderOrderControl.NEW_ORDER;
 				break;
 			case Discontinue_Order:
 				result = CommonOrderOrderControl.CANCEL_ORDER;
-				break;
-			case Undiscontinue_Order:
-				result = CommonOrderOrderControl.NEW_ORDER;
 				break;
 			default:
 				break;

--- a/api/src/main/java/org/openmrs/module/radiology/MwlStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/MwlStatus.java
@@ -11,22 +11,11 @@ package org.openmrs.module.radiology;
 
 /**
  * <p>
- * Represents custom MWL Status Codes, which help determine what sync status of the order is in.
+ * Represents custom Modality Worklist (MWL) Status Codes, which tell if the radiology orders placed/discontinued in the
+ * radiology module are in sync with the DICOM MWL worklist entry of the same order in the PACS.
  * </p>
  */
 public enum MwlStatus {
 	
-	DEFAULT,
-	SAVE_OK,
-	SAVE_ERR,
-	UPDATE_OK,
-	UPDATE_ERR,
-	VOID_OK,
-	VOID_ERR,
-	DISCONTINUE_OK,
-	DISCONTINUE_ERR,
-	UNDISCONTINUE_OK,
-	UNDISCONTINUE_ERR,
-	UNVOID_OK,
-	UNVOID_ERR;
+	IN_SYNC, OUT_OF_SYNC;
 }

--- a/api/src/main/java/org/openmrs/module/radiology/Study.java
+++ b/api/src/main/java/org/openmrs/module/radiology/Study.java
@@ -29,7 +29,7 @@ public class Study {
 	
 	private Modality modality;
 	
-	private MwlStatus mwlStatus = MwlStatus.DEFAULT;
+	private MwlStatus mwlStatus = MwlStatus.OUT_OF_SYNC;
 	
 	public Integer getStudyId() {
 		return studyId;

--- a/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
@@ -276,59 +276,15 @@ class RadiologyServiceImpl extends BaseOpenmrsService implements RadiologyServic
 	
 	@Override
 	public boolean sendModalityWorklist(RadiologyOrder radiologyOrder, OrderRequest orderRequest) {
-		MwlStatus mwlStatus = radiologyOrder.getStudy()
-				.getMwlStatus();
+		
 		final String hl7message = DicomUtils.createHL7Message(radiologyOrder, orderRequest);
 		final boolean result = DicomUtils.sendHL7Message(hl7message);
 		
+		final MwlStatus mwlStatus;
 		if (result) {
-			switch (orderRequest) {
-				case Save_Order:
-					if (mwlStatus == MwlStatus.DEFAULT || mwlStatus == MwlStatus.SAVE_ERR) {
-						mwlStatus = MwlStatus.SAVE_OK;
-					} else {
-						mwlStatus = MwlStatus.UPDATE_OK;
-					}
-					break;
-				case Void_Order:
-					mwlStatus = MwlStatus.VOID_OK;
-					break;
-				case Unvoid_Order:
-					mwlStatus = MwlStatus.UNVOID_OK;
-					break;
-				case Discontinue_Order:
-					mwlStatus = MwlStatus.DISCONTINUE_OK;
-					break;
-				case Undiscontinue_Order:
-					mwlStatus = MwlStatus.UNDISCONTINUE_OK;
-					break;
-				default:
-					break;
-			}
+			mwlStatus = MwlStatus.IN_SYNC;
 		} else {
-			switch (orderRequest) {
-				case Save_Order:
-					if (mwlStatus == MwlStatus.DEFAULT || mwlStatus == MwlStatus.SAVE_ERR) {
-						mwlStatus = MwlStatus.SAVE_ERR;
-					} else {
-						mwlStatus = MwlStatus.UPDATE_ERR;
-					}
-					break;
-				case Void_Order:
-					mwlStatus = MwlStatus.VOID_ERR;
-					break;
-				case Unvoid_Order:
-					mwlStatus = MwlStatus.UNVOID_ERR;
-					break;
-				case Discontinue_Order:
-					mwlStatus = MwlStatus.DISCONTINUE_ERR;
-					break;
-				case Undiscontinue_Order:
-					mwlStatus = MwlStatus.UNDISCONTINUE_ERR;
-					break;
-				default:
-					break;
-			}
+			mwlStatus = MwlStatus.OUT_OF_SYNC;
 		}
 		
 		radiologyOrder.getStudy()

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyServiceComponentTest.java
@@ -200,7 +200,6 @@ public class RadiologyServiceComponentTest extends BaseModuleContextSensitiveTes
 		
 		Study study = new Study();
 		study.setModality(Modality.CT);
-		study.setMwlStatus(MwlStatus.DEFAULT);
 		study.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
 		radiologyOrder.setStudy(study);
 		

--- a/api/src/test/java/org/openmrs/module/radiology/impl/RadiologyServiceImplComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/impl/RadiologyServiceImplComponentTest.java
@@ -34,7 +34,6 @@ import org.openmrs.api.PatientService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.radiology.Modality;
-import org.openmrs.module.radiology.MwlStatus;
 import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.RadiologyService;
@@ -204,7 +203,6 @@ public class RadiologyServiceImplComponentTest extends BaseModuleContextSensitiv
 		
 		Study study = new Study();
 		study.setModality(Modality.CT);
-		study.setMwlStatus(MwlStatus.DEFAULT);
 		study.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
 		return study;
 	}

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyServiceComponentTestDataset.xml
@@ -54,12 +54,12 @@
   <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" />
   <test_order order_id="2001"/>
   <radiology_order order_id="2001" />
-  <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="CT" mwl_status="DEFAULT"/>
+  <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="CT" mwl_status="IN_SYNC"/>
 
   <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" />
   <test_order order_id="2002"/>
   <radiology_order order_id="2002" />
-  <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" mwl_status="DEFAULT"/>
+  <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" mwl_status="IN_SYNC"/>
 
   <obs obs_id="20021" person_id="70021" order_id="2002" concept_id="178" obs_datetime="2015-02-06 17:14:00.0" location_id="1" creator="1" date_created="2015-02-06 17:14:35.0" voided="false" uuid="be3a4d7a-f9ab-47bb-aaad-bc0b452fcda4" accession_number="RAD2002"/>
 
@@ -79,27 +79,27 @@
   <orders order_id="2005" order_number="2005" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" />
   <test_order order_id="2005" />
   <radiology_order order_id="2005" />
-  <radiology_study study_id="3" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.3" order_id="2005" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="DEFAULT" />
+  <radiology_study study_id="3" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.3" order_id="2005" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="IN_SYNC" />
 
   <!-- radiology order with associated study and with a claimed report -->
   <orders order_id="2006" order_number="2006" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" />
   <test_order order_id="2006" />
   <radiology_order order_id="2006" />
-  <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="DEFAULT" />
+  <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="IN_SYNC" />
   <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" uuid="e699d90d-e230-4762-8747-d2d0059394b0" />
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" />
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
-  <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="DEFAULT" />
+  <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="IN_SYNC" />
   <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810"/>
 
   <!-- radiology order with associated study and with a discontinued report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" />
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
-  <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="DEFAULT" />
+  <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" mwl_status="IN_SYNC" />
   <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59"/>
 
 </dataset>

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -41,7 +41,7 @@
 @MODULE_ID@.status=Status
 @MODULE_ID@.crossDate=Start date is more recent than end date!
 @MODULE_ID@.privilegesRequired=Privileges required: {0}
-@MODULE_ID@.mwlStatus=DCM4CHEE Modality Worklist Sync Status
+@MODULE_ID@.mwlStatus=PACS Modality Worklist Sync Status
 
 @MODULE_ID@.createOrder=Create Order
 @MODULE_ID@.patient=Patient
@@ -76,8 +76,8 @@
 @MODULE_ID@.createSCP=Create SCP
 @MODULE_ID@.scheduled=Scheduled
 @MODULE_ID@.performed=Performed
-@MODULE_ID@.failWorklist= Failed sending request to dcm4chee. Check if dcm4chee server is online or check if the correct ip address for dcm4chee has been set.
-@MODULE_ID@.savedFailWorklist= Order Saved in OpenMRS but failed sending request to dcm4chee. Check if dcm4chee server is online or check if the correct ip address for dcm4chee has been set.
+@MODULE_ID@.failWorklist= Failed sending order request to the PACS. Check if the PACS is online or if IP address, HL7 port have been set correctly.
+@MODULE_ID@.savedFailWorklist= Order Saved in OpenMRS but failed sending order request to the PACS. Check if the PACS is online or if IP address, HL7 port have been set correctly.
 
 # Urgency
 @MODULE_ID@.ROUTINE=Routine
@@ -97,19 +97,8 @@
 @MODULE_ID@.COMPLETED=COMPLETED
 
 # Mwl Sync Status
-@MODULE_ID@.DEFAULT=Default
-@MODULE_ID@.SAVE_OK=In Sync : Save order successful.
-@MODULE_ID@.SAVE_ERR=Out of Sync : Save order failed. Try Again!
-@MODULE_ID@.UPDATE_OK=In Sync : Update order successful.
-@MODULE_ID@.UPDATE_ERR=Out of Sync : Update order failed. Try again!
-@MODULE_ID@.VOID_OK=In Sync : Void order successful.
-@MODULE_ID@.VOID_ERR=Out of Sync : Void order failed. Try again!
-@MODULE_ID@.DISCONTINUE_OK=In Sync : Discontinue order successful.
-@MODULE_ID@.DISCONTINUE_ERR=Out of Sync : Discontinue order failed. Try again!
-@MODULE_ID@.UNDISCONTINUE_OK=In Sync : Undiscontinue order successful.
-@MODULE_ID@.UNDISCONTINUE_ERR=Out of Sync : Undiscontinue order failed. Try again!
-@MODULE_ID@.UNVOID_OK=In Sync :  Unvoid order successfull
-@MODULE_ID@.UNVOID_ERR=Out of Sync :  Unvoid order failed. Try again!
+@MODULE_ID@.IN_SYNC=In Sync
+@MODULE_ID@.OUT_OF_SYNC=Out of Sync
 
 @MODULE_ID@.radiologyReportTitle=Report
 @MODULE_ID@.radiologyReportId=Id

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
@@ -257,7 +257,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		// given
 		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrderToDiscontinue.getStudy()
-				.setMwlStatus(MwlStatus.DISCONTINUE_OK);
+				.setMwlStatus(MwlStatus.IN_SYNC);
 		String discontinueReason = "Wrong Procedure";
 		Date discontinueDate = new GregorianCalendar(2015, Calendar.JANUARY, 01).getTime();
 		
@@ -295,7 +295,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		// given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrder.getStudy()
-				.setMwlStatus(MwlStatus.SAVE_OK);
+				.setMwlStatus(MwlStatus.IN_SYNC);
 		
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.sendModalityWorklist(mockRadiologyOrder, OrderRequest.Save_Order)).thenReturn(true);
@@ -328,7 +328,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		// given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrder.getStudy()
-				.setMwlStatus(MwlStatus.SAVE_OK);
+				.setMwlStatus(MwlStatus.IN_SYNC);
 		
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.sendModalityWorklist(mockRadiologyOrder, OrderRequest.Save_Order)).thenReturn(true);
@@ -362,7 +362,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		// given
 		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrder.getStudy()
-				.setMwlStatus(MwlStatus.SAVE_ERR);
+				.setMwlStatus(MwlStatus.OUT_OF_SYNC);
 		
 		when(radiologyService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
 		when(radiologyService.sendModalityWorklist(mockRadiologyOrder, OrderRequest.Save_Order)).thenReturn(false);
@@ -461,7 +461,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		// given
 		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrderToDiscontinue.getStudy()
-				.setMwlStatus(MwlStatus.DISCONTINUE_OK);
+				.setMwlStatus(MwlStatus.IN_SYNC);
 		String discontinueReason = "Wrong Procedure";
 		Date discontinueDate = new GregorianCalendar(2015, Calendar.JANUARY, 01).getTime();
 		
@@ -509,7 +509,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		// given
 		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrderToDiscontinue.getStudy()
-				.setMwlStatus(MwlStatus.DISCONTINUE_OK);
+				.setMwlStatus(MwlStatus.IN_SYNC);
 		String discontinueReason = "Wrong Procedure";
 		Date discontinueDate = new Date();
 		APIException apiException = new APIException("Discontinue date cannot be in the future");
@@ -567,7 +567,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		// given
 		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrderToDiscontinue.getStudy()
-				.setMwlStatus(MwlStatus.DISCONTINUE_ERR);
+				.setMwlStatus(MwlStatus.OUT_OF_SYNC);
 		String discontinueReason = "Wrong Procedure";
 		
 		Order mockDiscontinuationOrder = new Order();
@@ -624,7 +624,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 		
 		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
 		mockRadiologyOrderToDiscontinue.getStudy()
-				.setMwlStatus(MwlStatus.DISCONTINUE_ERR);
+				.setMwlStatus(MwlStatus.OUT_OF_SYNC);
 		String discontinueReason = "Wrong Procedure";
 		
 		Order mockDiscontinuationOrder = new Order();


### PR DESCRIPTION
* remove non supported OrderRequest, keep only supported Save/Discontinue_Order
* change MwlStatus to only IN_SYNC and OUT_OF_SYNC

since all other MwlStatus do not give us additional information and just clutter
the code. by default a study is OUT_OF_SYNC since it is created in the
radiology module but not yet in the PACS DICOM MWL. once the hl7 order message
has been sent and the sending was successful we set the status to IN_SYNC.

see https://issues.openmrs.org/browse/RAD-198