### PR TITLE
RAD-205 Rearrange packages for hl7

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/DicomUtils.java
+++ b/api/src/main/java/org/openmrs/module/radiology/DicomUtils.java
@@ -16,8 +16,8 @@ import org.dcm4che2.data.DicomObject;
 import org.dcm4che2.data.SpecificCharacterSet;
 import org.dcm4che2.data.Tag;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.message.RadiologyORMO01;
+import org.openmrs.module.radiology.hl7.v231.code.OrderControlElement;
+import org.openmrs.module.radiology.hl7.v231.message.RadiologyORMO01;
 
 import ca.uhn.hl7v2.HL7Exception;
 
@@ -137,16 +137,16 @@ public class DicomUtils {
 	 * Framework Volume 2.
 	 * 
 	 * @param radiologyOrder radiology order for which the order message is created
-	 * @param commonOrderControl common order control of the hl7 order message
+	 * @param orderControlElement common order control of the hl7 order message
 	 * @return encoded HL7 ORM^O01 message
 	 * @should return encoded HL7 ORMO01 message string given radiology order and common order control new order
 	 * @should return encoded HL7 ORMO01 message string given radiology order and common order control cancel order
 	 */
-	public static String createHL7Message(RadiologyOrder radiologyOrder, CommonOrderOrderControl commonOrderControl) {
+	public static String createHL7Message(RadiologyOrder radiologyOrder, OrderControlElement orderControlElement) {
 		String encodedHL7OrmMessage = null;
 		
 		try {
-			final RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, commonOrderControl);
+			final RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, orderControlElement);
 			encodedHL7OrmMessage = radiologyOrderMessage.createEncodedRadiologyORMO01Message();
 			log.info("Created HL7 ORM^O01 message \n" + encodedHL7OrmMessage);
 		}

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/util/DateTimeUtils.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/util/DateTimeUtils.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.utils;
+package org.openmrs.module.radiology.hl7.util;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/code/OrderControlElement.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/code/OrderControlElement.java
@@ -7,16 +7,16 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7;
+package org.openmrs.module.radiology.hl7.v231.code;
 
 /**
  * <p>
- * Represents the Order Control element of HL7 Common Order (ORC) defined in HL7 version 2.3.1
+ * Represents the Order Control (ID) element code used in the HL7 Common Order (ORC) Segment defined in HL7 version 2.3.1
  * </p>
  * Note: This enum does not include every control code defined by the HL7 standard. Only the codes
  * used so far by the radiology module have been implemented here.
  */
-public enum CommonOrderOrderControl {
+public enum OrderControlElement {
 	NEW_ORDER("NW", "New order"),
 	CANCEL_ORDER("CA", "Cancel order request"),
 	CHANGE_ORDER("XO", "Change order request");
@@ -25,7 +25,7 @@ public enum CommonOrderOrderControl {
 	
 	private String description;
 	
-	private CommonOrderOrderControl(String value, String description) {
+	private OrderControlElement(String value, String description) {
 		this.value = value;
 		this.description = description;
 	}

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/code/PriorityComponent.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/code/PriorityComponent.java
@@ -7,17 +7,17 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7;
+package org.openmrs.module.radiology.hl7.v231.code;
 
 /**
  * <p>
- * Represents the Priority component (ST) of HL7 Common Order (ORC) Segment's attribute QUANTITY/TIMING (TQ) defined in HL7
- * version 2.3.1
+ * Represents the Priority (ST) component code used for example in the HL7 Common Order (ORC) Segment's attribute
+ * QUANTITY/TIMING (TQ) defined in HL7 version 2.3.1
  * </p>
  * Note: This enum does not include every priority defined by the HL7 standard. Only the priorities
  * used so far by the radiology module have been implemented here.
  */
-public enum CommonOrderPriority {
+public enum PriorityComponent {
 	STAT(0, "S", "With highest priority"),
 	ASAP(1, "A", "Fill after Stat orders"),
 	ROUTINE(2, "R", "Default"),
@@ -29,7 +29,7 @@ public enum CommonOrderPriority {
 	
 	private final String description;
 	
-	private CommonOrderPriority(int priority, String value, String description) {
+	private PriorityComponent(int priority, String value, String description) {
 		this.priority = priority;
 		this.value = value;
 		this.description = description;

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/message/RadiologyORMO01.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/message/RadiologyORMO01.java
@@ -7,18 +7,18 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.message;
+package org.openmrs.module.radiology.hl7.v231.message;
 
 import java.util.Date;
 
 import org.openmrs.module.radiology.RadiologyOrder;
-import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
 import org.openmrs.module.radiology.hl7.custommodel.v231.message.ORM_O01;
-import org.openmrs.module.radiology.hl7.segment.RadiologyMSH;
-import org.openmrs.module.radiology.hl7.segment.RadiologyOBR;
-import org.openmrs.module.radiology.hl7.segment.RadiologyORC;
-import org.openmrs.module.radiology.hl7.segment.RadiologyPID;
-import org.openmrs.module.radiology.hl7.segment.RadiologyZDS;
+import org.openmrs.module.radiology.hl7.v231.code.OrderControlElement;
+import org.openmrs.module.radiology.hl7.v231.segment.RadiologyMSH;
+import org.openmrs.module.radiology.hl7.v231.segment.RadiologyOBR;
+import org.openmrs.module.radiology.hl7.v231.segment.RadiologyORC;
+import org.openmrs.module.radiology.hl7.v231.segment.RadiologyPID;
+import org.openmrs.module.radiology.hl7.v231.segment.RadiologyZDS;
 
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.parser.EncodingCharacters;
@@ -41,19 +41,19 @@ public class RadiologyORMO01 {
 	
 	private final RadiologyOrder radiologyOrder;
 	
-	private final CommonOrderOrderControl commonOrderControl;
+	private final OrderControlElement commonOrderControl;
 	
 	/**
 	 * Constructor for <code>RadiologyORMO01</code>
 	 * 
 	 * @param radiologyOrder radiology order
-	 * @param commonOrderOrderControl Order Control Code of Common Order (ORC) segment
+	 * @param orderControlElement Order Control Code of Common Order (ORC) segment
 	 * @should create new radiology ormo01 object given all params
 	 * @should throw illegal argument exception given null as radiologyOrder
 	 * @should throw illegal argument exception if given radiology orders study is null
-	 * @should throw illegal argument exception given null as orderControlCode
+	 * @should throw illegal argument exception given null as orderControlElement
 	 */
-	public RadiologyORMO01(RadiologyOrder radiologyOrder, CommonOrderOrderControl commonOrderOrderControl) {
+	public RadiologyORMO01(RadiologyOrder radiologyOrder, OrderControlElement orderControlElement) {
 		
 		if (radiologyOrder == null) {
 			throw new IllegalArgumentException("radiologyOrder cannot be null.");
@@ -63,12 +63,12 @@ public class RadiologyORMO01 {
 			}
 		}
 		
-		if (commonOrderOrderControl == null) {
+		if (orderControlElement == null) {
 			throw new IllegalArgumentException("orderControlCode cannot be null.");
 		}
 		
 		this.radiologyOrder = radiologyOrder;
-		this.commonOrderControl = commonOrderOrderControl;
+		this.commonOrderControl = orderControlElement;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyMSH.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyMSH.java
@@ -7,11 +7,11 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import java.util.Date;
 
-import org.openmrs.module.radiology.utils.DateTimeUtils;
+import org.openmrs.module.radiology.hl7.util.DateTimeUtils;
 
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.v231.segment.MSH;

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyOBR.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyOBR.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import org.openmrs.module.radiology.RadiologyOrder;
 

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyORC.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyORC.java
@@ -7,12 +7,12 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import org.openmrs.module.radiology.RadiologyOrder;
-import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.HL7Utils;
-import org.openmrs.module.radiology.utils.DateTimeUtils;
+import org.openmrs.module.radiology.hl7.util.DateTimeUtils;
+import org.openmrs.module.radiology.hl7.v231.code.OrderControlElement;
+import org.openmrs.module.radiology.hl7.v231.util.HL7Utils;
 
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.v231.segment.ORC;
@@ -33,7 +33,7 @@ public class RadiologyORC {
 	 * 
 	 * @param commonOrderSegment Common Order Segment to populate
 	 * @param radiologyOrder to map to commonOrderSegment segment
-	 * @param commonOrderOrderControl Order Control element of Common Order (ORC)
+	 * @param orderControlElement Order Control element of Common Order (ORC)
 	 * @return populated commonOrderSegment segment
 	 * @throws DataTypeException
 	 * @should return populated common order segment given all params
@@ -41,7 +41,7 @@ public class RadiologyORC {
 	 * @should throw illegal argument exception given null as radiology order
 	 */
 	public static ORC populateCommonOrder(ORC commonOrderSegment, RadiologyOrder radiologyOrder,
-			CommonOrderOrderControl commonOrderOrderControl) throws DataTypeException {
+			OrderControlElement orderControlElement) throws DataTypeException {
 		
 		if (commonOrderSegment == null) {
 			throw new IllegalArgumentException("commonOrderSegment cannot be null.");
@@ -52,7 +52,7 @@ public class RadiologyORC {
 		}
 		
 		commonOrderSegment.getOrderControl()
-				.setValue(commonOrderOrderControl.getValue());
+				.setValue(orderControlElement.getValue());
 		commonOrderSegment.getPlacerOrderNumber()
 				.getEntityIdentifier()
 				.setValue(radiologyOrder.getOrderNumber() == null ? "" : String.valueOf(radiologyOrder.getOrderNumber()));

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyPID.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyPID.java
@@ -7,12 +7,12 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import org.openmrs.Patient;
 import org.openmrs.PersonName;
-import org.openmrs.module.radiology.hl7.HL7Utils;
-import org.openmrs.module.radiology.utils.DateTimeUtils;
+import org.openmrs.module.radiology.hl7.util.DateTimeUtils;
+import org.openmrs.module.radiology.hl7.v231.util.HL7Utils;
 
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.DataTypeException;

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyZDS.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyZDS.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.hl7.custommodel.v231.segment.ZDS;

--- a/api/src/main/java/org/openmrs/module/radiology/hl7/v231/util/HL7Utils.java
+++ b/api/src/main/java/org/openmrs/module/radiology/hl7/v231/util/HL7Utils.java
@@ -7,10 +7,11 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7;
+package org.openmrs.module.radiology.hl7.v231.util;
 
 import org.openmrs.Order;
 import org.openmrs.PersonName;
+import org.openmrs.module.radiology.hl7.v231.code.PriorityComponent;
 
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.v231.datatype.XPN;
@@ -59,31 +60,31 @@ public class HL7Utils {
 	 * Get the HL7 Priority component of Quantity/Timing (ORC-7) field included in an HL7 version
 	 * 2.3.1 Common Order segment from given Order.Urgency.
 	 * 
-	 * @param orderUrgency Order.Urgency to be converted to CommonOrderPriority
-	 * @return CommonOrderPriority for given Order.Urgency
+	 * @param orderUrgency Order.Urgency to be converted to PriorityComponent
+	 * @return PriorityComponent for given Order.Urgency
 	 * @should return routine given null
 	 * @should return stat given order urgency stat
 	 * @should return routine given order urgency routine
 	 * @should return timing critical given order urgency on scheduled date
 	 */
-	public static CommonOrderPriority convertOrderUrgencyToCommonOrderPriority(Order.Urgency orderUrgency) {
-		final CommonOrderPriority result;
+	public static PriorityComponent convertOrderUrgencyToCommonOrderPriority(Order.Urgency orderUrgency) {
+		final PriorityComponent result;
 		
 		if (orderUrgency == null) {
-			result = CommonOrderPriority.ROUTINE;
+			result = PriorityComponent.ROUTINE;
 		} else {
 			switch (orderUrgency) {
 				case STAT:
-					result = CommonOrderPriority.STAT;
+					result = PriorityComponent.STAT;
 					break;
 				case ROUTINE:
-					result = CommonOrderPriority.ROUTINE;
+					result = PriorityComponent.ROUTINE;
 					break;
 				case ON_SCHEDULED_DATE:
-					result = CommonOrderPriority.TIMING_CRITICAL;
+					result = PriorityComponent.TIMING_CRITICAL;
 					break;
 				default:
-					result = CommonOrderPriority.ROUTINE;
+					result = PriorityComponent.ROUTINE;
 					break;
 			}
 		}

--- a/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/impl/RadiologyServiceImpl.java
@@ -38,7 +38,7 @@ import org.openmrs.module.radiology.Study;
 import org.openmrs.module.radiology.db.RadiologyOrderDAO;
 import org.openmrs.module.radiology.db.RadiologyReportDAO;
 import org.openmrs.module.radiology.db.StudyDAO;
-import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
+import org.openmrs.module.radiology.hl7.v231.code.OrderControlElement;
 import org.openmrs.module.radiology.report.RadiologyReport;
 import org.openmrs.module.radiology.report.RadiologyReportStatus;
 import org.springframework.transaction.annotation.Transactional;
@@ -316,7 +316,7 @@ class RadiologyServiceImpl extends BaseOpenmrsService implements RadiologyServic
 			throw new IllegalArgumentException("radiologyOrder.study is required");
 		}
 		
-		final String hl7message = DicomUtils.createHL7Message(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+		final String hl7message = DicomUtils.createHL7Message(radiologyOrder, OrderControlElement.NEW_ORDER);
 		final boolean result = DicomUtils.sendHL7Message(hl7message);
 		
 		updateStudyMwlStatus(radiologyOrder, result);
@@ -338,7 +338,7 @@ class RadiologyServiceImpl extends BaseOpenmrsService implements RadiologyServic
 			throw new IllegalArgumentException("radiologyOrder is not persisted");
 		}
 		
-		final String hl7message = DicomUtils.createHL7Message(radiologyOrder, CommonOrderOrderControl.CANCEL_ORDER);
+		final String hl7message = DicomUtils.createHL7Message(radiologyOrder, OrderControlElement.CANCEL_ORDER);
 		final boolean result = DicomUtils.sendHL7Message(hl7message);
 		
 		updateStudyMwlStatus(radiologyOrder, result);

--- a/api/src/test/java/org/openmrs/module/radiology/DicomUtilsComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/DicomUtilsComponentTest.java
@@ -42,7 +42,7 @@ import org.openmrs.PatientIdentifier;
 import org.openmrs.PatientIdentifierType;
 import org.openmrs.PersonName;
 import org.openmrs.api.AdministrationService;
-import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
+import org.openmrs.module.radiology.hl7.v231.code.OrderControlElement;
 import org.openmrs.test.BaseContextSensitiveTest;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -472,7 +472,7 @@ public class DicomUtilsComponentTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see DicomUtils#createHL7Message(RadiologyOrder,CommonOrderOrderControl)
+	 * @see DicomUtils#createHL7Message(RadiologyOrder,OrderControlElement)
 	 * @verifies return encoded HL7 ORMO01 message string given radiology order and common order control new order
 	 */
 	@Test
@@ -483,7 +483,7 @@ public class DicomUtilsComponentTest extends BaseModuleContextSensitiveTest {
 		Study study = getMockStudy();
 		radiologyOrder.setStudy(study);
 		
-		String saveOrderHL7String = DicomUtils.createHL7Message(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+		String saveOrderHL7String = DicomUtils.createHL7Message(radiologyOrder, OrderControlElement.NEW_ORDER);
 		
 		assertThat(saveOrderHL7String, startsWith("MSH|^~\\&|OpenMRSRadiologyModule|OpenMRS|||"));
 		assertThat(
@@ -591,7 +591,7 @@ public class DicomUtilsComponentTest extends BaseModuleContextSensitiveTest {
 	}
 	
 	/**
-	 * @see DicomUtils#createHL7Message(RadiologyOrder,CommonOrderOrderControl)
+	 * @see DicomUtils#createHL7Message(RadiologyOrder,OrderControlElement)
 	 * @verifies return encoded HL7 ORMO01 message string given radiology order and common order control cancel order
 	 */
 	@Test
@@ -602,7 +602,7 @@ public class DicomUtilsComponentTest extends BaseModuleContextSensitiveTest {
 		Study study = getMockStudy();
 		radiologyOrder.setStudy(study);
 		
-		String saveOrderHL7String = DicomUtils.createHL7Message(radiologyOrder, CommonOrderOrderControl.CANCEL_ORDER);
+		String saveOrderHL7String = DicomUtils.createHL7Message(radiologyOrder, OrderControlElement.CANCEL_ORDER);
 		
 		assertThat(saveOrderHL7String, startsWith("MSH|^~\\&|OpenMRSRadiologyModule|OpenMRS|||"));
 		assertThat(

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/util/DateTimeUtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/util/DateTimeUtilsTest.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.utils;
+package org.openmrs.module.radiology.hl7.util;
 
 import static org.junit.Assert.assertEquals;
 

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/v231/message/RadiologyORMO01Test.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/v231/message/RadiologyORMO01Test.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.message;
+package org.openmrs.module.radiology.hl7.v231.message;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringEndsWith.endsWith;
@@ -33,9 +33,8 @@ import org.openmrs.PersonName;
 import org.openmrs.module.radiology.Modality;
 import org.openmrs.module.radiology.RadiologyOrder;
 import org.openmrs.module.radiology.Study;
-import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.CommonOrderPriority;
 import org.openmrs.module.radiology.hl7.custommodel.v231.message.ORM_O01;
+import org.openmrs.module.radiology.hl7.v231.code.OrderControlElement;
 import org.springframework.util.ReflectionUtils;
 
 import ca.uhn.hl7v2.parser.EncodingCharacters;
@@ -110,18 +109,18 @@ public class RadiologyORMO01Test {
 	}
 	
 	/**
-	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,CommonOrderOrderControl,CommonOrderPriority)
+	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,OrderControlElement)
 	 * @verifies create new radiology ormo01 object given all params
 	 */
 	@Test
 	public void RadiologyORMO01_shouldCreateNewRadiologyOrmo01ObjectGivenAllParams() throws Exception {
 		
-		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, OrderControlElement.NEW_ORDER);
 		assertNotNull(radiologyOrderMessage);
 	}
 	
 	/**
-	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,CommonOrderOrderControl,CommonOrderPriority)
+	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,OrderControlElement)
 	 * @verifies throw illegal argument exception given null as radiologyOrder
 	 */
 	@Test
@@ -129,11 +128,11 @@ public class RadiologyORMO01Test {
 		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("radiologyOrder cannot be null."));
-		new RadiologyORMO01(null, CommonOrderOrderControl.NEW_ORDER);
+		new RadiologyORMO01(null, OrderControlElement.NEW_ORDER);
 	}
 	
 	/**
-	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,CommonOrderOrderControl,CommonOrderPriority)
+	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,OrderControlElement)
 	 * @verifies throw illegal argument exception if given radiology orders study is null
 	 */
 	@Test
@@ -142,12 +141,12 @@ public class RadiologyORMO01Test {
 		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("radiologyOrder.study cannot be null."));
-		new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+		new RadiologyORMO01(radiologyOrder, OrderControlElement.NEW_ORDER);
 	}
 	
 	/**
-	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,CommonOrderOrderControl,CommonOrderPriority)
-	 * @verifies throw illegal argument exception given null as orderControlCode
+	 * @see RadiologyORMO01#RadiologyORMO01(RadiologyOrder,OrderControlElement)
+	 * @verifies throw illegal argument exception given null as orderControlElement
 	 */
 	@Test
 	public void RadiologyORMO01_shouldThrowIllegalArgumentExceptionGivenNullAsOrderControlCode() throws Exception {
@@ -164,7 +163,7 @@ public class RadiologyORMO01Test {
 	@Test
 	public void createEncodedRadiologyORMO01Message_shouldCreateEncodedHl7Ormo01Message() throws Exception {
 		
-		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, OrderControlElement.NEW_ORDER);
 		String encodedOrmMessage = radiologyOrderMessage.createEncodedRadiologyORMO01Message();
 		
 		assertThat(encodedOrmMessage, startsWith("MSH|^~\\&|OpenMRSRadiologyModule|OpenMRS|||"));
@@ -184,7 +183,7 @@ public class RadiologyORMO01Test {
 	@Test
 	public void createRadiologyORMO01Message_shouldCreateOrmo01Message() throws Exception {
 		
-		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+		RadiologyORMO01 radiologyOrderMessage = new RadiologyORMO01(radiologyOrder, OrderControlElement.NEW_ORDER);
 		
 		Method createRadiologyORMO01Message = ReflectionUtils.findMethod(RadiologyORMO01.class,
 			"createRadiologyORMO01Message");

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyMSHTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyMSHTest.java
@@ -7,12 +7,14 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.Calendar;
+import java.util.Date;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -20,6 +22,7 @@ import org.openmrs.test.Verifies;
 
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.v231.message.ORM_O01;
+import ca.uhn.hl7v2.model.v231.segment.MSH;
 import ca.uhn.hl7v2.parser.EncodingCharacters;
 import ca.uhn.hl7v2.parser.PipeParser;
 

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyOBRTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyOBRTest.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyORCTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyORCTest.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -20,8 +20,8 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.openmrs.Order;
 import org.openmrs.module.radiology.RadiologyOrder;
-import org.openmrs.module.radiology.hl7.CommonOrderOrderControl;
-import org.openmrs.module.radiology.hl7.CommonOrderPriority;
+import org.openmrs.module.radiology.hl7.v231.code.OrderControlElement;
+import org.openmrs.module.radiology.hl7.v231.code.PriorityComponent;
 import org.openmrs.test.Verifies;
 
 import ca.uhn.hl7v2.HL7Exception;
@@ -41,10 +41,10 @@ public class RadiologyORCTest {
 	private static final EncodingCharacters encodingCharacters = new EncodingCharacters('|', '^', '~', '\\', '&');
 	
 	/**
-	 * @see {@link RadiologyORC#populateCommonOrder(ORC, RadiologyOrder, CommonOrderOrderControl, CommonOrderPriority)}
+	 * @see {@link RadiologyORC#populateCommonOrder(ORC, RadiologyOrder, OrderControlElement)}
 	 */
 	@Test
-	@Verifies(value = "should return populated common order segment given all params", method = "populateCommonOrder(ORC, RadiologyOrder, CommonOrderOrderControl, CommonOrderPriority)")
+	@Verifies(value = "should return populated common order segment given all params", method = "populateCommonOrder(ORC, RadiologyOrder, OrderControlElement)")
 	public void populateCommonOrder_shouldReturnPopulatedCommonOrderSegmentGivenAllParams() throws Exception {
 		
 		RadiologyOrder radiologyOrder = new RadiologyOrder();
@@ -64,7 +64,7 @@ public class RadiologyORCTest {
 		
 		ORM_O01 message = new ORM_O01();
 		RadiologyORC.populateCommonOrder(message.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
-				.getORC(), radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+				.getORC(), radiologyOrder, OrderControlElement.NEW_ORDER);
 		
 		ORC commonOrderSegment = message.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
 				.getORC();
@@ -79,30 +79,30 @@ public class RadiologyORCTest {
 				.getValue(), is("20150204143500"));
 		assertThat(commonOrderSegment.getQuantityTiming()
 				.getPriority()
-				.getValue(), is(CommonOrderPriority.TIMING_CRITICAL.getValue()));
+				.getValue(), is(PriorityComponent.TIMING_CRITICAL.getValue()));
 		
 		assertThat(PipeParser.encode(commonOrderSegment, encodingCharacters), is("ORC|NW|ORD-1|||||^^^20150204143500^^T"));
 	}
 	
 	/**
-	 * @see {@link RadiologyORC#populateCommonOrder(ORC, RadiologyOrder, CommonOrderOrderControl, CommonOrderPriority)}
+	 * @see {@link RadiologyORC#populateCommonOrder(ORC, RadiologyOrder, OrderControlElement)}
 	 */
 	@Test
-	@Verifies(value = "should throw illegal argument exception given null as common order segment", method = "populateCommonOrder(ORC, RadiologyOrder, CommonOrderOrderControl, CommonOrderPriority)")
+	@Verifies(value = "should throw illegal argument exception given null as common order segment", method = "populateCommonOrder(ORC, RadiologyOrder, OrderControlElement)")
 	public void populateCommonOrder_shouldThrowIllegalArgumentExceptionGivenNullAsCommonOrderSegment() throws HL7Exception {
 		
 		RadiologyOrder radiologyOrder = new RadiologyOrder();
 		
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("commonOrderSegment cannot be null."));
-		RadiologyORC.populateCommonOrder(null, radiologyOrder, CommonOrderOrderControl.NEW_ORDER);
+		RadiologyORC.populateCommonOrder(null, radiologyOrder, OrderControlElement.NEW_ORDER);
 	}
 	
 	/**
-	 * @see {@link RadiologyORC#populateCommonOrder(ORC, RadiologyOrder, CommonOrderOrderControl, CommonOrderPriority)}
+	 * @see {@link RadiologyORC#populateCommonOrder(ORC, RadiologyOrder, OrderControlElement)}
 	 */
 	@Test
-	@Verifies(value = "should throw illegal argument exception given null as radiology order", method = "populateCommonOrder(ORC, RadiologyOrder, CommonOrderOrderControl, CommonOrderPriority)")
+	@Verifies(value = "should throw illegal argument exception given null as radiology order", method = "populateCommonOrder(ORC, RadiologyOrder, OrderControlElement)")
 	public void populateCommonOrder_shouldThrowIllegalArgumentExceptionGivenNullAsRadiologyOrder() throws HL7Exception {
 		
 		ORM_O01 message = new ORM_O01();
@@ -110,6 +110,6 @@ public class RadiologyORCTest {
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage(is("radiologyOrder cannot be null."));
 		RadiologyORC.populateCommonOrder(message.getORCOBRRQDRQ1ODSODTRXONTEDG1RXRRXCNTEOBXNTECTIBLG()
-				.getORC(), null, CommonOrderOrderControl.NEW_ORDER);
+				.getORC(), null, OrderControlElement.NEW_ORDER);
 	}
 }

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyPIDTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyPIDTest.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -27,6 +27,7 @@ import org.openmrs.test.Verifies;
 
 import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.v231.message.ORM_O01;
+import ca.uhn.hl7v2.model.v231.segment.PID;
 import ca.uhn.hl7v2.parser.EncodingCharacters;
 import ca.uhn.hl7v2.parser.PipeParser;
 

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyZDSTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/v231/segment/RadiologyZDSTest.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7.segment;
+package org.openmrs.module.radiology.hl7.v231.segment;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertNull;

--- a/api/src/test/java/org/openmrs/module/radiology/hl7/v231/util/HL7UtilsTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/hl7/v231/util/HL7UtilsTest.java
@@ -7,7 +7,7 @@
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
  * graphic logo is a trademark of OpenMRS Inc.
  */
-package org.openmrs.module.radiology.hl7;
+package org.openmrs.module.radiology.hl7.v231.util;
 
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
@@ -15,6 +15,8 @@ import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.openmrs.Order;
 import org.openmrs.PersonName;
+import org.openmrs.module.radiology.hl7.v231.code.PriorityComponent;
+import org.openmrs.module.radiology.hl7.v231.util.HL7Utils;
 import org.openmrs.test.Verifies;
 
 import ca.uhn.hl7v2.model.DataTypeException;
@@ -173,7 +175,7 @@ public class HL7UtilsTest {
 	@Test
 	public void convertOrderUrgencyToCommonOrderPriority_shouldReturnRoutineGivenNull() throws Exception {
 		
-		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(null), is(CommonOrderPriority.ROUTINE));
+		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(null), is(PriorityComponent.ROUTINE));
 	}
 	
 	/**
@@ -183,7 +185,7 @@ public class HL7UtilsTest {
 	@Test
 	public void convertOrderUrgencyToCommonOrderPriority_shouldReturnStatGivenOrderUrgencyStat() throws Exception {
 		
-		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.STAT), is(CommonOrderPriority.STAT));
+		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.STAT), is(PriorityComponent.STAT));
 	}
 	
 	/**
@@ -193,7 +195,7 @@ public class HL7UtilsTest {
 	@Test
 	public void convertOrderUrgencyToCommonOrderPriority_shouldReturnRoutineGivenOrderUrgencyRoutine() throws Exception {
 		
-		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.ROUTINE), is(CommonOrderPriority.ROUTINE));
+		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.ROUTINE), is(PriorityComponent.ROUTINE));
 	}
 	
 	/**
@@ -205,6 +207,6 @@ public class HL7UtilsTest {
 			throws Exception {
 		
 		assertThat(HL7Utils.convertOrderUrgencyToCommonOrderPriority(Order.Urgency.ON_SCHEDULED_DATE),
-			is(CommonOrderPriority.TIMING_CRITICAL));
+			is(PriorityComponent.TIMING_CRITICAL));
 	}
 }


### PR DESCRIPTION
* create subpackage hl7.v231 and move all version
specific classes beneath
* create subpackage hl7.v231.code and put
OrderControlElement and PriorityComponent in it.
* renamed above enums to stick to hl7 nomenclature
* create hl7.v231.util package and move HL7Utils in it
* move DateTimeUtils into hl7.util

see https://issues.openmrs.org/browse/RAD-205