### PR TITLE
Added test for RAD-164 Report completion date shows datetime

### DIFF
--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
@@ -13,6 +13,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 import java.util.Calendar;
+import java.util.Date;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -103,5 +104,18 @@ public class RadiologyReportTest {
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage("radiologyOrder cannot be null");
 		radiologyReport = new RadiologyReport(null);
+	}
+
+	/**
+	 * @see RadiologyReport#RadiologyReport(RadiologyOrder)
+	 * @verifies completion date is a date and not datetime
+	 */
+	@Test
+	public void RadiologyReport_shouldHaveCompletionDateasADate() {
+
+		radiologyReport = new RadiologyReport(radiologyOrder);
+		Date date = new Date(1793425);
+		radiologyReport.setReportDate(date);
+		assertThat(radiologyReport.getReportDate().toString().contains(":"), is(false));
 	}
 }


### PR DESCRIPTION
*To be clear, this test currently fails since the bug still exists* This test fails the bug mentioned in RAD-164. The bug points out that the date is in datetime format, not date format. The test works by calling getReportDate, converting it to a string, and checking to make sure it doesn't contain the ':' character, which is only found in times, not dates. 