### PR TITLE
RAD-217 Add tests for RadiologyDiscontinuedOrderValidator

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/validator/RadiologyDiscontinuedOrderValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/validator/RadiologyDiscontinuedOrderValidator.java
@@ -23,12 +23,29 @@ import org.springframework.validation.Validator;
 @Component
 public class RadiologyDiscontinuedOrderValidator implements Validator {
 	
+	/** Log for this class and subclasses */
 	protected final Log log = LogFactory.getLog(getClass());
 	
+	/**
+	 * Determines if the command object being submitted is a valid type
+	 *
+	 * @see org.springframework.validation.Validator#supports(java.lang.Class)
+	 * @should return true for Order objects and subclasses
+	 * @should return false for other object types
+	 */
 	public boolean supports(Class c) {
 		return Order.class.isAssignableFrom(c);
 	}
 	
+	/**
+	 * Checks the form object for any inconsistencies/errors
+	 *
+	 * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
+	 * @should fail validation if order is null
+	 * @should fail validation if orderer is null
+	 * @should fail validation if orderReasonNonCoded is null
+	 * @should pass validation if all fields are correct
+	 */
 	public void validate(Object obj, Errors errors) {
 		final Order order = (Order) obj;
 		if (order == null) {

--- a/api/src/test/java/org/openmrs/module/radiology/validator/RadiologyDiscontinuedOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/validator/RadiologyDiscontinuedOrderValidatorTest.java
@@ -1,0 +1,122 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.radiology.validator;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+import org.openmrs.Provider;
+import org.openmrs.module.radiology.RadiologyOrder;
+import org.openmrs.Order;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+
+/**
+ * Tests {@link RadiologyDiscontinuedOrderValidator}.
+ */
+public class RadiologyDiscontinuedOrderValidatorTest {
+	
+	/**
+	 * @verifies return false for other object types
+	 * @see RadiologyDiscontinuedOrderValidator#supports(Class)
+	 */
+	@Test
+	public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
+		
+		RadiologyDiscontinuedOrderValidator radiologyDiscontinuedOrderValidator = new RadiologyDiscontinuedOrderValidator();
+		assertFalse(radiologyDiscontinuedOrderValidator.supports(Object.class));
+	}
+	
+	/**
+	 * @verifies return true for Order objects and subclasses
+	 * @see RadiologyDiscontinuedOrderValidator#supports(Class)
+	 */
+	@Test
+	public void supports_shouldReturnTrueForOrderObjectsAndSubclasses() throws Exception {
+		
+		RadiologyDiscontinuedOrderValidator radiologyDiscontinuedOrderValidator = new RadiologyDiscontinuedOrderValidator();
+		// true for Orders
+		assertTrue(radiologyDiscontinuedOrderValidator.supports(Order.class));
+		// true for Subclass
+		assertTrue(radiologyDiscontinuedOrderValidator.supports(RadiologyOrder.class));
+	}
+	
+	/**
+	 * @verifies fail validation if order is null
+	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldFailValidationIfOrderIsNull() throws Exception {
+		
+		Errors errors = new BindException(new Order(), "order");
+		new RadiologyDiscontinuedOrderValidator().validate(null, errors);
+		
+		assertTrue(errors.hasErrors());
+		assertThat((errors.getAllErrors()).get(0)
+				.getCode(), is("error.general"));
+	}
+	
+	/**
+	 * @verifies fail validation if orderer is null
+	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldFailValidationIfOrdererIsNull() throws Exception {
+		
+		Order order = new Order();
+		order.setOrderer(null);
+		order.setOrderReasonNonCoded("Wrong Procedure");
+		
+		Errors errors = new BindException(order, "order");
+		new RadiologyDiscontinuedOrderValidator().validate(order, errors);
+		
+		assertTrue(errors.hasFieldErrors("orderer"));
+		assertFalse(errors.hasFieldErrors("orderReasonNonCoded"));
+	}
+	
+	/**
+	 * @verifies fail validation if orderReasonNonCoded is null
+	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldFailValidationIfOrderReasonNonCodedIsNull() throws Exception {
+		
+		Order order = new Order();
+		
+		order.setOrderer(new Provider());
+		order.setOrderReasonNonCoded(null);
+		
+		Errors errors = new BindException(order, "order");
+		new RadiologyDiscontinuedOrderValidator().validate(order, errors);
+		
+		assertFalse(errors.hasFieldErrors("orderer"));
+		assertTrue(errors.hasFieldErrors("orderReasonNonCoded"));
+	}
+	
+	/**
+	 * @verifies pass validation if all fields are correct
+	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+	 */
+	@Test
+	public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
+		
+		Order order = new Order();
+		order.setOrderer(new Provider());
+		order.setOrderReasonNonCoded("Wrong Procedure");
+		
+		Errors errors = new BindException(order, "order");
+		new RadiologyDiscontinuedOrderValidator().validate(order, errors);
+		
+		assertFalse(errors.hasErrors());
+	}
+}


### PR DESCRIPTION
Corrected issue with fork and made the desired changes. 

Make sure the supports(Class c) returns

true for objects assignable from the Order class
false for other types
Make sure the validate(Object obj, Errors errors)

fails when ** radiology order is null ** orderer is null ** orderReasonNonCoded is null
passes when ** all fields are correct
See https://issues.openmrs.org/browse/RAD-217