### PR TITLE
RAD-219 Add tests for Study.java

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudy.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudy.java
@@ -88,6 +88,13 @@ public class RadiologyStudy {
 		return performedStatus == PerformedProcedureStepStatus.COMPLETED;
 	}
 	
+	/**
+	 * Returns true when this Study's performedStatus is null and false otherwise.
+	 *
+	 * @return true on performedStatus null and false otherwise
+	 * @should return true if performedStatus is null
+	 * @should return false if performedStatus is not null
+	 */
 	public boolean isScheduleable() {
 		return performedStatus == null;
 	}
@@ -120,6 +127,12 @@ public class RadiologyStudy {
 		this.studyInstanceUid = studyInstanceUid;
 	}
 	
+	/**
+	 * @see Object#toString()
+	 * @return String of Study
+	 * @should return string of study with null for members that are null
+	 * @should return string of study
+	 */
 	@Override
 	public String toString() {
 		final StringBuilder buff = new StringBuilder();

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyTest.java
@@ -2,9 +2,20 @@ package org.openmrs.module.radiology.study;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.startsWith;
 
 import org.junit.Test;
+import org.openmrs.Concept;
+import org.openmrs.Patient;
+import org.openmrs.PersonName;
+import org.openmrs.module.radiology.order.RadiologyOrder;
 import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
+import org.openmrs.module.radiology.dicom.code.ScheduledProcedureStepStatus;
+import org.openmrs.module.radiology.Modality;
+
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Tests {@link RadiologyStudy}.
@@ -28,7 +39,6 @@ public class RadiologyStudyTest {
 	 */
 	@Test
 	public void isInProgress_shouldReturnFalseIfPerformedStatusIsNotInProgress() throws Exception {
-		
 		RadiologyStudy radiologyStudy = new RadiologyStudy();
 		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
 		assertFalse(radiologyStudy.isInProgress());
@@ -79,5 +89,89 @@ public class RadiologyStudyTest {
 		RadiologyStudy radiologyStudy = new RadiologyStudy();
 		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
 		assertTrue(radiologyStudy.isCompleted());
+	}
+	
+	/**
+	 * @see RadiologyStudy#isScheduleable()
+	 * @verifies return true if performedStatus is null
+	 */
+	@Test
+	public void isScheduleable_shouldReturnTrueIfPerformedStatusIsNull() throws Exception {
+		
+		RadiologyStudy radiologyStudy = new RadiologyStudy();
+		radiologyStudy.setPerformedStatus(null);
+		assertTrue(radiologyStudy.isScheduleable());
+	}
+	
+	/**
+	 * @see RadiologyStudy#isScheduleable()
+	 * @verifies return false if performedStatus is not null
+	 */
+	@Test
+	public void isScheduleable_shouldReturnFalseIfPerformedStatusIsNotNull() throws Exception {
+		
+		RadiologyStudy radiologyStudy = new RadiologyStudy();
+		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		
+		assertFalse(radiologyStudy.isScheduleable());
+	}
+	
+	/**
+	 * @see RadiologyStudy#toString()
+	 * @verifies return string of study
+	 */
+	@Test
+	public void toString_shouldReturnStringOfStudy() throws Exception {
+		
+		RadiologyStudy radiologyStudy = new RadiologyStudy();
+		radiologyStudy.setStudyId(2);
+		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		radiologyStudy.setStudyInstanceUid("Complete");
+		radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
+		radiologyStudy.setModality(Modality.CR);
+		radiologyStudy.setMwlStatus(MwlStatus.IN_SYNC);
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		radiologyOrder.setOrderId(2);
+		
+		Patient mockPatient = new Patient();
+		mockPatient.setPatientId(1);
+		Set<PersonName> personNames = new HashSet<PersonName>();
+		PersonName personName = new PersonName();
+		personName.setFamilyName("Doe");
+		personName.setGivenName("John");
+		personName.setMiddleName("Francis");
+		personNames.add(personName);
+		mockPatient.setNames(personNames);
+		radiologyOrder.setPatient(mockPatient);
+		
+		Concept concept = new Concept();
+		concept.setConceptId(2);
+		radiologyOrder.setConcept(concept);
+		
+		radiologyStudy.setRadiologyOrder(radiologyOrder);
+		
+		assertThat(
+			radiologyStudy.toString(),
+			startsWith("studyId: 2 studyInstanceUid: Complete radiologyOrder: Order. orderId: 2 patient: Patient#1 concept: 2 care setting: null scheduledStatus: SCHEDULED performedStatus: COMPLETED modality: CR mwlStatus: IN_SYNC "));
+	}
+	
+	/**
+	 * @see RadiologyStudy#toString()
+	 * @verifies return string of study with null for members that are null
+	 */
+	@Test
+	public void toString_shouldReturnStringOfStudyWithNullForMembersThatAreNull() throws Exception {
+		
+		RadiologyStudy radiologyStudy = new RadiologyStudy();
+		radiologyStudy.setStudyId(2);
+		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+		radiologyStudy.setStudyInstanceUid("Complete");
+		radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
+		radiologyStudy.setModality(Modality.CR);
+		radiologyStudy.setMwlStatus(MwlStatus.IN_SYNC);
+		
+		assertThat(
+			radiologyStudy.toString(),
+			startsWith("studyId: 2 studyInstanceUid: Complete radiologyOrder: null scheduledStatus: SCHEDULED performedStatus: COMPLETED modality: CR mwlStatus: IN_SYNC "));
 	}
 }


### PR DESCRIPTION
Updated with changes and corrected fork.

Make sure the isScheduleable() returns

    true for Study objects that their performedStatus is null
    false for Study objects that their performedStatus is not null

Make sure the toString() returns

    A string of a Study's components
        "null" when a component of a study is not initialized
        String of component otherwise
See https://issues.openmrs.org/browse/RAD-219