### PR TITLE
RAD-226 Travis CI fails due to memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,9 @@ after_success:
   - mvn jacoco:report coveralls:report
 notifications:
   email: false
-sudo: false
+sudo: true
+before_install:
+  - cat /etc/hosts # optionally check the content *before*
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts # optionally check the content *after*


### PR DESCRIPTION
Running travis CI in containerized environment is limited by 3GB RAM.
Somehow we now hit this limit on our component tests.
Trying out the non-containerized environment to see if thats really the issue

see https://issues.openmrs.org/browse/RAD-226