### PR TITLE
RAD-236 discontinueRadiologyOrderInPacs does not cancel order

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
@@ -247,7 +247,8 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
 			throw new IllegalArgumentException("radiologyOrder is not persisted");
 		}
 		
-		final String hl7message = new RadiologyORMO01().createEncodedMessage(radiologyOrder, OrderControlElement.NEW_ORDER);
+		final String hl7message = new RadiologyORMO01().createEncodedMessage(radiologyOrder,
+			OrderControlElement.CANCEL_ORDER);
 		log.info("Created HL7 ORM^O01 message \n" + hl7message);
 		final boolean result = HL7Sender.sendHL7Message(hl7message);
 		


### PR DESCRIPTION
* fix OrderControl in RadiologyOrderServiceImpl's
discontinueRadiologyOrderInPacs which was NEW_ORDER instead
of CANCEL_ORDER

see https://issues.openmrs.org/browse/RAD-236