### PR TITLE
RAD-138 Simplify radiologyOrder URIs for UI

### DIFF
--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormController.java
@@ -51,7 +51,7 @@ import org.springframework.web.servlet.ModelAndView;
 @RequestMapping(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING)
 public class RadiologyOrderFormController {
 	
-	protected static final String RADIOLOGY_ORDER_FORM_REQUEST_MAPPING = "/module/radiology/radiologyOrder.form";
+	protected static final String RADIOLOGY_ORDER_FORM_REQUEST_MAPPING = "/module/radiology/radiologyOrders";
 	
 	static final String RADIOLOGY_ORDER_FORM_VIEW = "/module/radiology/radiologyOrderForm";
 	
@@ -126,9 +126,8 @@ public class RadiologyOrderFormController {
 	 * @should populate model and view with existing order if given order id only matches an order
 	 *         and not a radiology order
 	 */
-	@RequestMapping(method = RequestMethod.GET, params = "orderId")
-	protected ModelAndView getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(
-			@RequestParam(value = "orderId", required = true) Order order) {
+	@RequestMapping(method = RequestMethod.GET, value = "/{orderId}")
+	protected ModelAndView getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(Order order) {
 		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
 		
 		if (Context.isAuthenticated()) {
@@ -198,7 +197,7 @@ public class RadiologyOrderFormController {
 							.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "radiology.savedFailWorklist");
 				}
 				
-				modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "?orderId="
+				modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "/"
 						+ radiologyOrder.getOrderId());
 			}
 			catch (Exception ex) {
@@ -222,11 +221,10 @@ public class RadiologyOrderFormController {
 	 * @should discontinue non discontinued order and redirect to discontinuation order
 	 * @should not redirect if discontinuation failed in pacs
 	 */
-	@RequestMapping(method = RequestMethod.POST, params = "discontinueOrder")
+	@RequestMapping(method = RequestMethod.POST, params = "discontinueOrder", value = "/{orderId}")
 	protected ModelAndView postDiscontinueRadiologyOrder(HttpServletRequest request, HttpServletResponse response,
-			@RequestParam("orderId") RadiologyOrder radiologyOrderToDiscontinue,
-			@ModelAttribute("discontinuationOrder") Order discontinuationOrder, BindingResult radiologyOrderErrors)
-			throws Exception {
+			RadiologyOrder radiologyOrderToDiscontinue, @ModelAttribute("discontinuationOrder") Order discontinuationOrder,
+			BindingResult radiologyOrderErrors) throws Exception {
 		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
 		
 		try {
@@ -244,7 +242,7 @@ public class RadiologyOrderFormController {
 			if (radiologyOrderService.discontinueRadiologyOrderInPacs(radiologyOrderToDiscontinue)) {
 				request.getSession()
 						.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "Order.discontinuedSuccessfully");
-				modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "?orderId="
+				modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "/"
 						+ discontinuationOrder.getOrderId());
 			} else {
 				request.getSession()

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderListController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyOrderListController.java
@@ -18,7 +18,7 @@ import org.springframework.web.servlet.ModelAndView;
 @RequestMapping(RadiologyOrderListController.RADIOLOGY_ORDER_LIST_REQUEST_MAPPING)
 public class RadiologyOrderListController {
 	
-	protected static final String RADIOLOGY_ORDER_LIST_REQUEST_MAPPING = "/module/radiology/radiologyOrder.list";
+	protected static final String RADIOLOGY_ORDER_LIST_REQUEST_MAPPING = "/module/radiology/radiologyOrders/search";
 	
 	private static final String RADIOLOGY_ORDER_LIST_VIEW = "/module/radiology/radiologyOrderList";
 	

--- a/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyReportFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/controller/RadiologyReportFormController.java
@@ -47,9 +47,8 @@ public class RadiologyReportFormController {
 	 * @return model and view containing new radiology report for given radiology order
 	 * @should populate model and view with new radiology report for given radiology order
 	 */
-	@RequestMapping(method = RequestMethod.GET, params = "orderId")
-	protected ModelAndView getRadiologyReportFormWithNewRadiologyReport(
-			@RequestParam(value = "orderId", required = true) RadiologyOrder radiologyOrder) {
+	@RequestMapping(method = RequestMethod.GET, value = "/{orderId}")
+	protected ModelAndView getRadiologyReportFormWithNewRadiologyReport(RadiologyOrder radiologyOrder) {
 		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
 		
 		if (Context.isAuthenticated()) {
@@ -122,8 +121,8 @@ public class RadiologyReportFormController {
 		
 		if (Context.isAuthenticated()) {
 			radiologyReportService.unclaimRadiologyReport(radiologyReport);
-			return new ModelAndView("redirect:" + RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING
-					+ "?orderId=" + radiologyReport.getRadiologyOrder()
+			return new ModelAndView("redirect:" + RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "/"
+					+ radiologyReport.getRadiologyOrder()
 							.getOrderId());
 		}
 		return modelAndView;

--- a/omod/src/main/webapp/localHeader.jsp
+++ b/omod/src/main/webapp/localHeader.jsp
@@ -18,13 +18,13 @@
 		<c:if
 			test='<%=request.getRequestURI().contains("radiologyOrderForm")%>'>
 			<li class="active"><a
-				href="${pageContext.request.contextPath}/module/radiology/radiologyOrder.form?orderId=${radiologyOrder.orderId}">
+				href="${pageContext.request.contextPath}/module/radiology/radiologyOrders/${radiologyOrder.orderId}">
 					Radiology Order </a></li>
 		</c:if>
 		<c:if
 			test='<%=request.getRequestURI().contains("radiology/radiologyReport")%>'>
 			<li><a
-				href="${pageContext.request.contextPath}/module/radiology/radiologyOrder.form?orderId=${radiologyOrder.orderId}">
+				href="${pageContext.request.contextPath}/module/radiology/radiologyOrders/${radiologyOrder.orderId}">
 					Radiology Order </a></li>
 			<li class="active"><a
 				href="${pageContext.request.contextPath}/module/radiology/radiologyReport

--- a/omod/src/main/webapp/portlets/orderSearch.jsp
+++ b/omod/src/main/webapp/portlets/orderSearch.jsp
@@ -34,7 +34,7 @@
 						data-child-mwl="<spring:message code="radiology.${radiologyOrder.study.mwlStatus}"/>">
 						<td class="details-control"></td>
 						<td><a
-							href="radiologyOrder.form?orderId=${radiologyOrder.orderId}">${radiologyOrder.orderId}</a></td>
+							href="radiologyOrders/${radiologyOrder.orderId}">${radiologyOrder.orderId}</a></td>
 						<td style="text-align: center"><a
 							href="/openmrs/patientDashboard.form?patientId=${radiologyOrder.patient.patientId}">${radiologyOrder.patient.patientIdentifier}</a></td>
 						<td><a

--- a/omod/src/main/webapp/portlets/radiologyDashboardTab.jsp
+++ b/omod/src/main/webapp/portlets/radiologyDashboardTab.jsp
@@ -45,7 +45,7 @@
 					<c:forEach items="${radiologyOrders}" var="radiologyOrder">
 						<tr>
 							<td style="text-align: center"><a
-								href="module/radiology/radiologyOrder.form?orderId=${radiologyOrder.orderId}">${radiologyOrder.orderId}
+								href="module/radiology/radiologyOrders/${radiologyOrder.orderId}">${radiologyOrder.orderId}
 							</a></td>
 							<td><spring:message
 									code="radiology.${radiologyOrder.urgency}"

--- a/omod/src/main/webapp/radiologyOrderForm.jsp
+++ b/omod/src/main/webapp/radiologyOrderForm.jsp
@@ -2,7 +2,7 @@
 <%@ include file="/WEB-INF/template/include.jsp"%>
 
 <openmrs:require privilege="Edit Orders" otherwise="/login.htm"
-	redirect="/module/radiology/radiologyOrder.form" />
+	redirect="/module/radiology/radiologyOrders" />
 
 <%@ include file="/WEB-INF/template/header.jsp"%>
 <%@ include file="localHeader.jsp"%>
@@ -236,7 +236,7 @@
 						<tr>
 							<td><spring:message code="radiology.discontinuedOrder" /></td>
 							<td><spring:bind path="previousOrder">
-									<a href="radiologyOrder.form?orderId=${status.value}">${status.value}</a>
+									<a href="radiologyOrders/${status.value}">${status.value}</a>
 								</spring:bind></td>
 						</tr>
 						<tr>

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyOrderFormControllerTest.java
@@ -310,8 +310,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 			mockRadiologyOrder, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockRadiologyOrder.getOrderId()));
+		assertThat(modelAndView.getViewName(),
+			is("redirect:/module/radiology/radiologyOrders/" + mockRadiologyOrder.getOrderId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
 	}
 	
@@ -344,8 +344,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 					.getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockRadiologyOrder.getOrderId()));
+		assertThat(modelAndView.getViewName(),
+			is("redirect:/module/radiology/radiologyOrders/" + mockRadiologyOrder.getOrderId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
 	}
 	
@@ -378,8 +378,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 					.getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockRadiologyOrder.getOrderId()));
+		assertThat(modelAndView.getViewName(),
+			is("redirect:/module/radiology/radiologyOrders/" + mockRadiologyOrder.getOrderId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR), is("radiology.savedFailWorklist"));
 	}
 	
@@ -488,8 +488,8 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
 			mockRadiologyOrderToDiscontinue, mockDiscontinuationOrder, orderErrors);
 		
 		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockDiscontinuationOrder.getOrderId()));
+		assertThat(modelAndView.getViewName(),
+			is("redirect:/module/radiology/radiologyOrders/" + mockDiscontinuationOrder.getOrderId()));
 		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.discontinuedSuccessfully"));
 	}
 	

--- a/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyReportFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/web/controller/RadiologyReportFormControllerTest.java
@@ -166,7 +166,7 @@ public class RadiologyReportFormControllerTest extends BaseContextMockTest {
 		ModelAndView modelAndView = radiologyReportFormController.unclaimRadiologyReport(mockRadiologyReport);
 		
 		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
+		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrders/"
 				+ mockRadiologyReport.getRadiologyOrder()
 						.getOrderId()));
 	}


### PR DESCRIPTION
## Description
Simplified the Radioloy Order URIs and updated the associated tests
## Related Issue
RAD-138 Simplify radiologyOrder URIs for UI
see https://issues.openmrs.org/browse/RAD-138

## Checklist:
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I modified existing tests to reflect the new URIs. Following the code style, I kept the tests close to what they were, but was wondering if we should instead use:
`RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING`

in place of 
`"/module/radiology/radiologyOrders/"`

in the tests? 

For example:

```
assertThat(modelAndView.getViewName(),
			is("redirect:/module/radiology/radiologyOrders/" + mockRadiologyOrder.getOrderId()));

```
becomes

```
assertThat(modelAndView.getViewName(),
			is("redirect:" + RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING 
+ mockRadiologyOrder.getOrderId()));

```
so the tests don't need to be modified if the URI scheme changes again.
