### PR TITLE
Add test for getActiveRadiologyReportByRadiologyOrder

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -169,7 +169,7 @@ public interface RadiologyReportService extends OpenmrsService {
 	 * @throws IllegalArgumentException if radiologyOrder is null
 	 * @should return a RadiologyReport if the reportStatus is completed
 	 * @should return a RadiologyReport if the reportStatus is claimed
-	 * @should return null if
+	 * @should return null if the reportStatus is not null, completed, or claimed
 	 * @should throw an IllegalArgumentException if radiologyOrder is null
 	 */
 	@Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import java.util.List;
 import java.util.Properties;
@@ -665,5 +666,15 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage("radiologyOrder cannot be null");
 		radiologyReportService.getActiveRadiologyReportByRadiologyOrder(null);
+	}
+	
+	/**
+	 * @verifies return null if the reportStatus is not null, completed, or claimed
+	 * @see RadiologyOrderService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
+	 */
+	@Test
+	public void getActiveRadiologyReportByRadiologyOrder_shouldReturnNullIfTheReportStatusIsNotNullCompletedOrClaimed() {
+		RadiologyReport activeReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
+		assertNull(activeReport);
 	}
 }

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
@@ -104,4 +104,15 @@ public class RadiologyReportTest {
 		expectedException.expectMessage("radiologyOrder cannot be null");
 		radiologyReport = new RadiologyReport(null);
 	}
+	
+	/**
+	 * @see RadiologyReport#setId(Integer)
+	 * @verifies ID of RadiologyReport is correctly set
+	 */
+	@Test
+	public void setID_IDOfRadiologyReportIsCorrectlySet() {
+		RadiologyOrder radiologyOrder = new RadiologyOrder();
+		radiologyOrder.setId(123);
+		assertThat(radiologyOrder.getId(), is(123));
+	}
 }


### PR DESCRIPTION
* added test for getActiveRadiologyReportByRadiologyOrder when given a RadiologyOrder with only a discontinued RadiologyReport

see https://issues.openmrs.org/browse/RAD-242
