### PR TITLE
RAD-243 Avoid NPEs in Hibernate DAOs

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
@@ -56,13 +56,12 @@ class HibernateRadiologyOrderDAO implements RadiologyOrderDAO {
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
-		List<RadiologyOrder> result = new ArrayList<RadiologyOrder>();
 		
 		Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
 		addRestrictionOnPatient(radiologyOrderCriteria, patient);
 		
-		result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
-		return result;
+		final List<RadiologyOrder> result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
+		return result == null ? new ArrayList<RadiologyOrder>() : result;
 	}
 	
 	/**
@@ -94,13 +93,12 @@ class HibernateRadiologyOrderDAO implements RadiologyOrderDAO {
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
-		List<RadiologyOrder> result = new ArrayList<RadiologyOrder>();
 		
 		final Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
 		addRestrictionOnPatients(radiologyOrderCriteria, patients);
 		
-		result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
-		return result;
+		final List<RadiologyOrder> result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
+		return result == null ? new ArrayList<RadiologyOrder>() : result;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -102,6 +102,7 @@ public interface RadiologyOrderService extends OpenmrsService {
 	 * @throws IllegalArgumentException if patients is null
 	 * @should return all radiology orders associated with given patients
 	 * @should return all radiology orders given empty patient list
+	 * @should return empty list given patient list without associated radiology orders
 	 * @should throw illegal argument exception given null
 	 */
 	@Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })

--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.radiology.report;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.hibernate.SessionFactory;
@@ -94,11 +95,13 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
 	@Override
 	public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(RadiologyOrder radiologyOrder,
 			RadiologyReportStatus radiologyReportStatus) {
-		return sessionFactory.getCurrentSession()
+		
+		final List<RadiologyReport> result = sessionFactory.getCurrentSession()
 				.createCriteria(RadiologyReport.class)
 				.add(Restrictions.eq("radiologyOrder", radiologyOrder))
 				.add(Restrictions.eq("reportStatus", radiologyReportStatus))
 				.list();
+		return result == null ? new ArrayList<RadiologyReport>() : result;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
@@ -90,15 +90,13 @@ class HibernateRadiologyStudyDAO implements RadiologyStudyDAO {
 	@Override
 	public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
 		List<RadiologyStudy> result = new ArrayList<RadiologyStudy>();
-		
 		if (!radiologyOrders.isEmpty()) {
 			Criteria studyCriteria = sessionFactory.getCurrentSession()
 					.createCriteria(RadiologyStudy.class);
 			addRestrictionOnRadiologyOrders(studyCriteria, radiologyOrders);
 			result = (List<RadiologyStudy>) studyCriteria.list();
 		}
-		
-		return result;
+		return result == null ? new ArrayList<RadiologyStudy>() : result;
 	}
 	
 	/**

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
@@ -641,6 +642,21 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
 		expectedException.expect(IllegalArgumentException.class);
 		expectedException.expectMessage("patients is required");
 		radiologyOrderService.getRadiologyOrdersByPatients(null);
+	}
+	
+	/**
+	 * @see RadiologyOrderService#getRadiologyOrdersByPatients(List)
+	 * @verifies return empty list given patient list without associated radiology orders
+	 */
+	@Test
+	public void getRadiologyOrdersByPatients_shouldReturnEmptyListGivenPatientListWithoutAssociatedRadiologyOrders()
+			throws Exception {
+		
+		Patient patientWithoutRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER);
+		
+		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(patientWithoutRadiologyOrders));
+		
+		assertThat(radiologyOrders.size(), is(0));
 	}
 	
 	/**


### PR DESCRIPTION
## Description
* Change HibernateDAOs to return empty lists instead of null

## Related Issue
see https://issues.openmrs.org/browse/RAD-243

