### PR TITLE
RAD-246 Remove spring:hasBindErrors from radiologyOrderDisplayPortlet…

### DIFF
--- a/omod/src/main/webapp/portlets/radiologyOrderDisplayPortlet.jsp
+++ b/omod/src/main/webapp/portlets/radiologyOrderDisplayPortlet.jsp
@@ -8,14 +8,6 @@
 		</div>
 	</div>
 </c:if>
-<spring:hasBindErrors name="radiologyOrder">
-	<spring:message code="fix.error" />
-	<br />
-</spring:hasBindErrors>
-<spring:hasBindErrors name="study">
-	<spring:message code="fix.error" />
-	<br />
-</spring:hasBindErrors>
 
 <div>
 	<span class="boxHeader"> <b><spring:message


### PR DESCRIPTION
## Description
* Remove spring:hasBindErrors from radiologyOrderDisplayPortlet.jsp

## Related Issue
see https://issues.openmrs.org/browse/RAD-246