### PR TITLE
RAD-247: Create radiology menu entry

### DIFF
--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
@@ -1,0 +1,32 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.web.extension.html;
+
+import org.openmrs.module.radiology.RadiologyPrivileges;
+import org.openmrs.module.radiology.order.web.RadiologyOrderListController;
+import org.openmrs.module.web.extension.LinkExt;
+
+public class GutterListExt extends LinkExt {
+	
+	@Override
+	public String getLabel() {
+		return "radiology.home.title";
+	}
+	
+	@Override
+	public String getRequiredPrivilege() {
+		return RadiologyPrivileges.VIEW_RADIOLOGY_SECTION;
+	}
+	
+	@Override
+	public String getUrl() {
+		return RadiologyOrderListController.RADIOLOGY_ORDER_LIST_REQUEST_MAPPING;
+	}
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -37,6 +37,10 @@
 		<class>@MODULE_PACKAGE@.web.extension.html.RadiologyDashboardExt
 		</class>
 	</extension>
+	<extension>
+		<point>org.openmrs.gutter.tools</point>
+		<class>@MODULE_PACKAGE@.web.extension.html.GutterListExt</class>
+	</extension>
 
 	<!-- /Extensions -->
 

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -1,4 +1,5 @@
 @MODULE_ID@.title=Radiology Module
+@MODULE_ID@.home.title=Radiology
 @MODULE_ID@.manageOrders=Manage Radiology Orders
 @MODULE_ID@.radiologyOrder=Radiology Order
 @MODULE_ID@.radiologyOrders=Radiology Orders


### PR DESCRIPTION
[RAD-247: Create radiology menu](https://issues.openmrs.org/browse/RAD-248)

## Description
Added a gutter extension for radiology on the openmrs home page. It leads the manage radiology orders and needs a privilege of View Radiology Section

## Related Issue
[RAD-248 Add orders tab](https://issues.openmrs.org/browse/RAD-248)

<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-247
