### PR TITLE
RAD-248 minor cleanup

### DIFF
--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletController.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
+
 /**
  * This Source Code Form is subject to the terms of the Mozilla Public License,
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
@@ -40,16 +41,18 @@ public class PatientDashboardRadiologyTabPortletController extends PortletContro
 	private RadiologyOrderService radiologyOrderService;
 	
 	/**
-	 * Convenient method to customize the model that is returned to the view
+	 * Add radiologyOrders to the <code>model</code> for patient contained in the <code>model</code>.
 	 * 
 	 * @param request HttpServletRequest that holds all information about this request
 	 * @param model holds variables that will be used in the jsp view
+	 * @should model is populated with all radiology orders for given patient
+	 * @should model is populated with an empty list of radiology orders if given patient is unknown
 	 */
 	@Override
 	protected void populateModel(HttpServletRequest request, Map<String, Object> model) {
+		
 		Patient patient = (Patient) model.get("patient");
 		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patient);
-		
 		model.put("radiologyOrders", radiologyOrders);
 	}
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
@@ -11,7 +11,6 @@ package org.openmrs.module.radiology.web.extension.html;
 
 import org.openmrs.module.radiology.RadiologyPrivileges;
 import org.openmrs.module.radiology.order.web.RadiologyDashboardFormController;
-import org.openmrs.module.radiology.order.web.RadiologyOrderListController;
 import org.openmrs.module.web.extension.LinkExt;
 
 public class GutterListExt extends LinkExt {

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
@@ -23,7 +23,7 @@ public class PatientDashboardRadiologyTabExt extends PatientDashboardTabExt {
 	
 	@Override
 	public String getTabId() {
-		return "patientDashboardRadiology";
+		return "patientDashboardRadiologyTab";
 	}
 	
 	@Override

--- a/omod/src/main/webapp/portlets/radiologyOrdersTab.jsp
+++ b/omod/src/main/webapp/portlets/radiologyOrdersTab.jsp
@@ -14,12 +14,11 @@
 <openmrs:htmlInclude
 	file="/moduleResources/radiology/css/details-control.dataTables.css" />
 
-<div id="calendar"></div>
-
 <div id="openmrs_msg" name="loading">
 	<spring:message code="general.loading" />
 </div>
 <openmrs:hasPrivilege privilege="Add Radiology Orders">
+<br>
 	<a href="radiologyOrder.form"><spring:message
 			code="radiology.addOrder" /></a>
 	<br>

--- a/omod/src/main/webapp/resources/radiology.css
+++ b/omod/src/main/webapp/resources/radiology.css
@@ -50,7 +50,7 @@ margin:0 1px 0 0;
 #radiologyTabs ul, #radiologyTabs li {
 	display: inline;
 	list-style-type: none;
-	padding: 0px 0px 0px 0px;
+	padding: 0 0 0 0;
 }
 
 #radiologyTabs a:link, #radiologyTabs a:visited {

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletControllerTest.java
@@ -9,12 +9,12 @@
  */
 package org.openmrs.module.radiology.order.web;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.verify;
-import static org.hamcrest.core.Is.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -68,16 +68,15 @@ public class PatientDashboardRadiologyTabPortletControllerTest extends BaseConte
 		invalidPatient = new Patient();
 		ArrayList<RadiologyOrder> emptyOrdersList = new ArrayList<RadiologyOrder>();
 		when((radiologyOrderService.getRadiologyOrdersByPatient(invalidPatient))).thenReturn(emptyOrdersList);
-		
 	}
 	
 	/**
 	 * @see PatientDashboardRadiologyTabPortletController#populateModel(HttpServletRequest, Map)
 	 * @verifies model is populated with all radiology orders for given patient
 	 */
-	@SuppressWarnings("unchecked")
 	@Test
 	public void populateModel_shouldPopulateModelWithAllRadiologyOrdersForGivenPatient() {
+		
 		model.put("patient", mockPatient1);
 		patientDashboardRadiologyTabPortletController.populateModel(request, model);
 		
@@ -89,12 +88,11 @@ public class PatientDashboardRadiologyTabPortletControllerTest extends BaseConte
 	
 	/**
 	 * @see PatientDashboardRadiologyTabPortletController#populateModel(HttpServletRequest, Map)
-	 * @verifies model is populated with an empty list of radiology orders if given
-	 *           patient is unknown
+	 * @verifies model is populated with an empty list of radiology orders if given patient is unknown
 	 */
-	@SuppressWarnings("unchecked")
 	@Test
 	public void populateModel_shouldPopulateModelWithEmptyRadiologyOrderListWhenInvalidPatientIsGiven() {
+		
 		model.put("patient", invalidPatient);
 		patientDashboardRadiologyTabPortletController.populateModel(request, model);
 		


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description

* fix javadoc summary PatientDashboardRadiologyTabPortletController.get()
* add missing @should to PatientDashboardRadiologyTabPortletController.get()
* remove @SuppressWarning from PatientDashboardRadiologyTabPortletControllerTest
* fix css lint 'Prohibit zero units'
* clean GutterListExt imports
* rename TabId to 'patientDashboardRadiologyTab'
* added linebreak in Orders tab between "Add Radiology Order" and top

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-248

