### PR TITLE
RAD-263 Do not use tabs

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/Modality.java
+++ b/api/src/main/java/org/openmrs/module/radiology/Modality.java
@@ -17,21 +17,21 @@ package org.openmrs.module.radiology;
  * </p>
  */
 public enum Modality {
-	
-	CR("Computed Radiography"),
-	MR("Magnetic Resonance"),
-	CT("Computed Tomography"),
-	NM("Nuclear Medicine"),
-	US("Ultrasound"),
-	XA("X-Ray Angiography");
-	
-	final private String fullName;
-	
-	Modality(String fullname) {
-		this.fullName = fullname;
-	}
-	
-	public String getFullName() {
-		return this.fullName;
-	}
+    
+    CR("Computed Radiography"),
+    MR("Magnetic Resonance"),
+    CT("Computed Tomography"),
+    NM("Nuclear Medicine"),
+    US("Ultrasound"),
+    XA("X-Ray Angiography");
+    
+    final private String fullName;
+    
+    Modality(String fullname) {
+        this.fullName = fullname;
+    }
+    
+    public String getFullName() {
+        return this.fullName;
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyActivator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyActivator.java
@@ -18,26 +18,26 @@ import org.openmrs.module.BaseModuleActivator;
  */
 
 public class RadiologyActivator extends BaseModuleActivator {
-	
-	private static final Log log = LogFactory.getLog(RadiologyActivator.class);
-	
-	@Override
-	public void willStart() {
-		log.info("Trying to start up Radiology Module");
-	}
-	
-	@Override
-	public void started() {
-		log.info("Radiology Module successfully started");
-	}
-	
-	@Override
-	public void willStop() {
-		log.info("Trying to shut down Radiology Module");
-	}
-	
-	@Override
-	public void stopped() {
-		log.info("Radiology Module successfully stopped");
-	}
+    
+    private static final Log log = LogFactory.getLog(RadiologyActivator.class);
+    
+    @Override
+    public void willStart() {
+        log.info("Trying to start up Radiology Module");
+    }
+    
+    @Override
+    public void started() {
+        log.info("Radiology Module successfully started");
+    }
+    
+    @Override
+    public void willStop() {
+        log.info("Trying to shut down Radiology Module");
+    }
+    
+    @Override
+    public void stopped() {
+        log.info("Radiology Module successfully stopped");
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
@@ -13,34 +13,34 @@ package org.openmrs.module.radiology;
  * A class that contains constants which are used within this module.
  */
 public class RadiologyConstants {
-	
-	public static final String GP_DICOM_UID_ORG_ROOT = "radiology.dicomUIDOrgRoot";
-	
-	public static final String GP_DICOM_UID_APPLICATION = "radiology.dicomUIDApplication";
-	
-	public static final String GP_DICOM_UID_TYPE_STUDY = "radiology.dicomUIDTypeStudy";
-	
-	public static final String GP_DICOM_WEB_VIEWER_ADDRESS = "radiology.dicomWebViewerAddress";
-	
-	public static final String GP_DICOM_WEB_VIEWER_PORT = "radiology.dicomWebViewerPort";
-	
-	public static final String GP_DICOM_WEB_VIEWER_BASE_URL = "radiology.dicomWebViewerBaseUrl";
-	
-	public static final String GP_DICOM_WEB_VIEWER_LOCAL_SERVER_NAME = "radiology.dicomWebViewerLocalServerName";
-	
-	public static final String GP_RADIOLOGY_CARE_SETTING = "radiology.radiologyCareSetting";
-	
-	public static final String GP_RADIOLOGY_CONCEPT_CLASSES = "radiology.radiologyConceptClasses";
-	
-	public static final String GP_RADIOLOGY_TEST_ORDER_TYPE = "radiology.radiologyTestOrderType";
-	
-	public static final String GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE = "radiology.radiologyOrderEncounterType";
-	
-	public static final String GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE = "radiology.radiologyOrderingProviderEncounterRole";
-	
-	public static final String GP_RADIOLOGY_VISIT_TYPE = "radiology.radiologyVisitType";
-	
-	private RadiologyConstants() {
-		// Utility class not meant to be instantiated.
-	}
+    
+    public static final String GP_DICOM_UID_ORG_ROOT = "radiology.dicomUIDOrgRoot";
+    
+    public static final String GP_DICOM_UID_APPLICATION = "radiology.dicomUIDApplication";
+    
+    public static final String GP_DICOM_UID_TYPE_STUDY = "radiology.dicomUIDTypeStudy";
+    
+    public static final String GP_DICOM_WEB_VIEWER_ADDRESS = "radiology.dicomWebViewerAddress";
+    
+    public static final String GP_DICOM_WEB_VIEWER_PORT = "radiology.dicomWebViewerPort";
+    
+    public static final String GP_DICOM_WEB_VIEWER_BASE_URL = "radiology.dicomWebViewerBaseUrl";
+    
+    public static final String GP_DICOM_WEB_VIEWER_LOCAL_SERVER_NAME = "radiology.dicomWebViewerLocalServerName";
+    
+    public static final String GP_RADIOLOGY_CARE_SETTING = "radiology.radiologyCareSetting";
+    
+    public static final String GP_RADIOLOGY_CONCEPT_CLASSES = "radiology.radiologyConceptClasses";
+    
+    public static final String GP_RADIOLOGY_TEST_ORDER_TYPE = "radiology.radiologyTestOrderType";
+    
+    public static final String GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE = "radiology.radiologyOrderEncounterType";
+    
+    public static final String GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE = "radiology.radiologyOrderingProviderEncounterRole";
+    
+    public static final String GP_RADIOLOGY_VISIT_TYPE = "radiology.radiologyVisitType";
+    
+    private RadiologyConstants() {
+        // Utility class not meant to be instantiated.
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyEncounterMatcher.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyEncounterMatcher.java
@@ -20,37 +20,37 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class RadiologyEncounterMatcher implements BaseEncounterMatcher {
-	
-	/**
-	 * Returns existing encounter according to visit and encounter parameters
-	 * 
-	 * @param visit containing encounters to me matched
-	 * @param encounterParameters encounter parameters of the encounter to be matched
-	 * @return existing encounter according to visit and encounter parameters
-	 * @throws IllegalArgumentException if visit is null
-	 * @throws IllegalArgumentException if encounterParameters are null
-	 * @should return encounter if encounter uuid given by encounter parameters is attached to given visit and is not voided
-	 * @should return null given visit without non voided encounters
-	 * @should return null if encounter uuid given by encounter parameters is voided
-	 * @should throw illegal argument exception if given visit is null
-	 * @should throw illegal argument exception if given encounterParameters are null
-	 */
-	@Override
-	public Encounter findEncounter(Visit visit, EncounterParameters encounterParameters) {
-		if (visit == null) {
-			throw new IllegalArgumentException("visit is required");
-		}
-		
-		if (encounterParameters == null) {
-			throw new IllegalArgumentException("encounterParameters are required");
-		}
-		
-		for (final Encounter encounter : visit.getNonVoidedEncounters()) {
-			if (encounter.getUuid()
-					.equals(encounterParameters.getEncounterUuid())) {
-				return encounter;
-			}
-		}
-		return null;
-	}
+    
+    /**
+     * Returns existing encounter according to visit and encounter parameters
+     * 
+     * @param visit containing encounters to me matched
+     * @param encounterParameters encounter parameters of the encounter to be matched
+     * @return existing encounter according to visit and encounter parameters
+     * @throws IllegalArgumentException if visit is null
+     * @throws IllegalArgumentException if encounterParameters are null
+     * @should return encounter if encounter uuid given by encounter parameters is attached to given visit and is not voided
+     * @should return null given visit without non voided encounters
+     * @should return null if encounter uuid given by encounter parameters is voided
+     * @should throw illegal argument exception if given visit is null
+     * @should throw illegal argument exception if given encounterParameters are null
+     */
+    @Override
+    public Encounter findEncounter(Visit visit, EncounterParameters encounterParameters) {
+        if (visit == null) {
+            throw new IllegalArgumentException("visit is required");
+        }
+        
+        if (encounterParameters == null) {
+            throw new IllegalArgumentException("encounterParameters are required");
+        }
+        
+        for (final Encounter encounter : visit.getNonVoidedEncounters()) {
+            if (encounter.getUuid()
+                    .equals(encounterParameters.getEncounterUuid())) {
+                return encounter;
+            }
+        }
+        return null;
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyPrivileges.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyPrivileges.java
@@ -17,24 +17,24 @@ package org.openmrs.module.radiology;
  * </p>
  */
 public class RadiologyPrivileges {
-	
-	public static final String ADD_RADIOLOGY_ORDERS = "Add Radiology Orders";
-	
-	public static final String ADD_RADIOLOGY_REPORTS = "Add Radiology Reports";
-	
-	public static final String DELETE_RADIOLOGY_ORDERS = "Delete Radiology Orders";
-	
-	public static final String DELETE_RADIOLOGY_REPORTS = "Delete Radiology Reports";
-	
-	public static final String EDIT_RADIOLOGY_REPORTS = "Edit Radiology Reports";
-	
-	public static final String GET_RADIOLOGY_ORDERS = "Get Radiology Orders";
-	
-	public static final String GET_RADIOLOGY_REPORTS = "Get Radiology Reports";
-	
-	public static final String VIEW_RADIOLOGY_SECTION = "Patient Dashboard - View Radiology Section";
-	
-	private RadiologyPrivileges() {
-		// Utility class not meant to be instantiated.
-	}
+    
+    public static final String ADD_RADIOLOGY_ORDERS = "Add Radiology Orders";
+    
+    public static final String ADD_RADIOLOGY_REPORTS = "Add Radiology Reports";
+    
+    public static final String DELETE_RADIOLOGY_ORDERS = "Delete Radiology Orders";
+    
+    public static final String DELETE_RADIOLOGY_REPORTS = "Delete Radiology Reports";
+    
+    public static final String EDIT_RADIOLOGY_REPORTS = "Edit Radiology Reports";
+    
+    public static final String GET_RADIOLOGY_ORDERS = "Get Radiology Orders";
+    
+    public static final String GET_RADIOLOGY_REPORTS = "Get Radiology Reports";
+    
+    public static final String VIEW_RADIOLOGY_SECTION = "Patient Dashboard - View Radiology Section";
+    
+    private RadiologyPrivileges() {
+        // Utility class not meant to be instantiated.
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
@@ -23,201 +23,201 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class RadiologyProperties extends ModuleProperties {
-	
-	/**
-	 * Return DICOM UID component used to identify the org root.
-	 * 
-	 * @return dicom uid org root
-	 * @throws IllegalStateException if global property for dicom uid org root cannot be found
-	 * @should return dicom uid org root
-	 * @should throw illegal state exception if global property for dicom uid org root cannot be found
-	 */
-	public String getDicomUIDOrgRoot() {
-		return getGlobalProperty(RadiologyConstants.GP_DICOM_UID_ORG_ROOT, true);
-	}
-	
-	/**
-	 * Return DICOM UID component used to identify this application.
-	 * 
-	 * @return dicom uid application
-	 * @throws IllegalStateException if global property for dicom uid application cannot be found
-	 * @should return dicom uid application
-	 * @should throw illegal state exception if global property for dicom uid application cannot be found
-	 */
-	public String getDicomUIDApplication() {
-		return getGlobalProperty(RadiologyConstants.GP_DICOM_UID_APPLICATION, true);
-	}
-	
-	/**
-	 * Return DICOM UID component used to identify the UID Type Study.
-	 * 
-	 * @return dicom uid type study
-	 * @throws IllegalStateException if global property for dicom uid type study cannot be found
-	 * @should return dicom uid type study
-	 * @should throw illegal state exception if global property for dicom uid type study cannot be found
-	 */
-	public String getDicomUIDTypeStudy() {
-		return getGlobalProperty(RadiologyConstants.GP_DICOM_UID_TYPE_STUDY, true);
-	}
-	
-	/**
-	 * Return study prefix Example: 1.2.826.0.1.3680043.8.2186.1. (With last dot)
-	 * 
-	 * @return study prefix
-	 * @should return study prefix consisting of org root and application uid and study uid slug
-	 */
-	public String getStudyPrefix() {
-		return this.getDicomUIDOrgRoot() + "." + this.getDicomUIDApplication() + "." + this.getDicomUIDTypeStudy() + ".";
-	}
-	
-	/**
-	 * Return DICOM web viewer address.
-	 * 
-	 * @return DICOM web viewer address
-	 * @throws IllegalStateException if global property for dicom web viewer address cannot be found
-	 * @should return dicom web viewer address
-	 * @should throw illegal state exception if global property for dicom web viewer address cannot
-	 *         be found
-	 */
-	public String getDicomWebViewerAddress() {
-		return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_ADDRESS, true);
-	}
-	
-	/**
-	 * Return DICOM web viewer port.
-	 * 
-	 * @return DICOM web viewer port
-	 * @throws IllegalStateException if global property for dicom web viewer port cannot be found
-	 * @should return dicom web viewer port
-	 * @should throw illegal state exception if global property for dicom web viewer port cannot be
-	 *         found
-	 */
-	public String getDicomWebViewerPort() {
-		return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_PORT, true);
-	}
-	
-	/**
-	 * Return DICOM web viewer base url.
-	 * 
-	 * @return DICOM web viewer base url
-	 * @throws IllegalStateException if global property for dicom web viewer base url cannot be
-	 *         found
-	 * @should return dicom web viewer base url
-	 * @should throw illegal state exception if global property for dicom web viewer base url cannot
-	 *         be found
-	 */
-	public String getDicomWebViewerBaseUrl() {
-		return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_BASE_URL, true);
-	}
-	
-	/**
-	 * Return DICOM web viewer local server name.
-	 * 
-	 * @return DICOM web viewer local server name
-	 * @should return dicom web viewer local server name
-	 */
-	public String getDicomWebViewerLocalServerName() {
-		return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_LOCAL_SERVER_NAME, false);
-	}
-	
-	/**
-	 * Get CareSetting for RadiologyOrder's
-	 * 
-	 * @return CareSetting for radiology orders
-	 * @should return radiology care setting
-	 * @should throw illegal state exception if global property for radiology care setting cannot be
-	 *         found
-	 * @should throw illegal state exception if radiology care setting cannot be found
-	 */
-	public CareSetting getRadiologyCareSetting() {
-		final String radiologyCareSettingUuid = getGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CARE_SETTING, true);
-		final CareSetting result = orderService.getCareSettingByUuid(radiologyCareSettingUuid);
-		if (result == null) {
-			throw new IllegalStateException("No existing care setting for uuid: "
-					+ RadiologyConstants.GP_RADIOLOGY_CARE_SETTING);
-		}
-		return result;
-	}
-	
-	/**
-	 * Test order type for radiology order
-	 * 
-	 * @return test order type for radiology order
-	 * @should return order type for radiology test orders
-	 * @should throw illegal state exception for non existing radiology test order type
-	 */
-	public OrderType getRadiologyTestOrderType() {
-		return getOrderTypeByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_TEST_ORDER_TYPE);
-	}
-	
-	/**
-	 * Get EncounterType for RadiologyOrder's
-	 * 
-	 * @return EncounterType for radiology orders
-	 * @should return encounter type for radiology orders
-	 * @should throw illegal state exception for non existing radiology encounter type
-	 */
-	public EncounterType getRadiologyOrderEncounterType() {
-		return getEncounterTypeByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE);
-	}
-	
-	/**
-	 * Get EncounterRole for the ordering provider
-	 * 
-	 * @return EncounterRole for ordering provider
-	 * @should return encounter role for ordering provider
-	 * @should throw illegal state exception for non existing ordering provider encounter role
-	 */
-	public EncounterRole getRadiologyOrderingProviderEncounterRole() {
-		return getEncounterRoleByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE);
-	}
-	
-	/**
-	 * Get VisitType for RadiologyOrder's
-	 * 
-	 * @return visitType for radiology orders
-	 * @should return visit type for radiology orders
-	 * @should throw illegal state exception for non existing radiology visit type
-	 */
-	public VisitType getRadiologyVisitType() {
-		return getVisitTypeByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_VISIT_TYPE);
-	}
-	
-	/**
-	 * Gets the Name of the ConceptClass for the UUID from the config
-	 *
-	 * @return a String that contains the Names of the ConceptClasses seperated by a comma
-	 * @should throw illegal state exception if global property radiologyConceptClasses is null
-	 * @should throw illegal state exception if global property radiologyConceptClasses is an empty
-	 *         string
-	 * @should throw illegal state exception if global property radiologyConceptClasses is badly
-	 *         formatted
-	 * @should throw illegal state exception if global property radiologyConceptClasses contains a
-	 *         UUID not found among ConceptClasses
-	 * @should returns comma separated list of ConceptClass names configured via ConceptClass UUIDs
-	 *         in global property radiologyConceptClasses
-	 */
-	public String getRadiologyConceptClassNames() {
-		
-		String radiologyConceptClassUuidSetting = getGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES, true);
-		radiologyConceptClassUuidSetting = radiologyConceptClassUuidSetting.replace(" ", "");
-		if (!radiologyConceptClassUuidSetting.matches("^[0-9a-fA-f,-]+$")) {
-			throw new IllegalStateException(
-					"Property radiology.radiologyConcepts needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
-		}
-		
-		final String[] radiologyConceptClassUuids = radiologyConceptClassUuidSetting.split(",");
-		
-		String result = "";
-		for (final String radiologyConceptClassUuid : radiologyConceptClassUuids) {
-			final ConceptClass fetchedConceptClass = conceptService.getConceptClassByUuid(radiologyConceptClassUuid);
-			if (fetchedConceptClass == null) {
-				throw new IllegalStateException("Property radiology.radiologyConceptClasses contains UUID "
-						+ radiologyConceptClassUuid + " which cannot be found as ConceptClass in the database.");
-			}
-			result = result + fetchedConceptClass.getName() + ",";
-		}
-		result = result.substring(0, result.length() - 1);
-		return result;
-	}
+    
+    /**
+     * Return DICOM UID component used to identify the org root.
+     * 
+     * @return dicom uid org root
+     * @throws IllegalStateException if global property for dicom uid org root cannot be found
+     * @should return dicom uid org root
+     * @should throw illegal state exception if global property for dicom uid org root cannot be found
+     */
+    public String getDicomUIDOrgRoot() {
+        return getGlobalProperty(RadiologyConstants.GP_DICOM_UID_ORG_ROOT, true);
+    }
+    
+    /**
+     * Return DICOM UID component used to identify this application.
+     * 
+     * @return dicom uid application
+     * @throws IllegalStateException if global property for dicom uid application cannot be found
+     * @should return dicom uid application
+     * @should throw illegal state exception if global property for dicom uid application cannot be found
+     */
+    public String getDicomUIDApplication() {
+        return getGlobalProperty(RadiologyConstants.GP_DICOM_UID_APPLICATION, true);
+    }
+    
+    /**
+     * Return DICOM UID component used to identify the UID Type Study.
+     * 
+     * @return dicom uid type study
+     * @throws IllegalStateException if global property for dicom uid type study cannot be found
+     * @should return dicom uid type study
+     * @should throw illegal state exception if global property for dicom uid type study cannot be found
+     */
+    public String getDicomUIDTypeStudy() {
+        return getGlobalProperty(RadiologyConstants.GP_DICOM_UID_TYPE_STUDY, true);
+    }
+    
+    /**
+     * Return study prefix Example: 1.2.826.0.1.3680043.8.2186.1. (With last dot)
+     * 
+     * @return study prefix
+     * @should return study prefix consisting of org root and application uid and study uid slug
+     */
+    public String getStudyPrefix() {
+        return this.getDicomUIDOrgRoot() + "." + this.getDicomUIDApplication() + "." + this.getDicomUIDTypeStudy() + ".";
+    }
+    
+    /**
+     * Return DICOM web viewer address.
+     * 
+     * @return DICOM web viewer address
+     * @throws IllegalStateException if global property for dicom web viewer address cannot be found
+     * @should return dicom web viewer address
+     * @should throw illegal state exception if global property for dicom web viewer address cannot
+     *         be found
+     */
+    public String getDicomWebViewerAddress() {
+        return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_ADDRESS, true);
+    }
+    
+    /**
+     * Return DICOM web viewer port.
+     * 
+     * @return DICOM web viewer port
+     * @throws IllegalStateException if global property for dicom web viewer port cannot be found
+     * @should return dicom web viewer port
+     * @should throw illegal state exception if global property for dicom web viewer port cannot be
+     *         found
+     */
+    public String getDicomWebViewerPort() {
+        return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_PORT, true);
+    }
+    
+    /**
+     * Return DICOM web viewer base url.
+     * 
+     * @return DICOM web viewer base url
+     * @throws IllegalStateException if global property for dicom web viewer base url cannot be
+     *         found
+     * @should return dicom web viewer base url
+     * @should throw illegal state exception if global property for dicom web viewer base url cannot
+     *         be found
+     */
+    public String getDicomWebViewerBaseUrl() {
+        return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_BASE_URL, true);
+    }
+    
+    /**
+     * Return DICOM web viewer local server name.
+     * 
+     * @return DICOM web viewer local server name
+     * @should return dicom web viewer local server name
+     */
+    public String getDicomWebViewerLocalServerName() {
+        return getGlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_LOCAL_SERVER_NAME, false);
+    }
+    
+    /**
+     * Get CareSetting for RadiologyOrder's
+     * 
+     * @return CareSetting for radiology orders
+     * @should return radiology care setting
+     * @should throw illegal state exception if global property for radiology care setting cannot be
+     *         found
+     * @should throw illegal state exception if radiology care setting cannot be found
+     */
+    public CareSetting getRadiologyCareSetting() {
+        final String radiologyCareSettingUuid = getGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CARE_SETTING, true);
+        final CareSetting result = orderService.getCareSettingByUuid(radiologyCareSettingUuid);
+        if (result == null) {
+            throw new IllegalStateException("No existing care setting for uuid: "
+                    + RadiologyConstants.GP_RADIOLOGY_CARE_SETTING);
+        }
+        return result;
+    }
+    
+    /**
+     * Test order type for radiology order
+     * 
+     * @return test order type for radiology order
+     * @should return order type for radiology test orders
+     * @should throw illegal state exception for non existing radiology test order type
+     */
+    public OrderType getRadiologyTestOrderType() {
+        return getOrderTypeByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_TEST_ORDER_TYPE);
+    }
+    
+    /**
+     * Get EncounterType for RadiologyOrder's
+     * 
+     * @return EncounterType for radiology orders
+     * @should return encounter type for radiology orders
+     * @should throw illegal state exception for non existing radiology encounter type
+     */
+    public EncounterType getRadiologyOrderEncounterType() {
+        return getEncounterTypeByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE);
+    }
+    
+    /**
+     * Get EncounterRole for the ordering provider
+     * 
+     * @return EncounterRole for ordering provider
+     * @should return encounter role for ordering provider
+     * @should throw illegal state exception for non existing ordering provider encounter role
+     */
+    public EncounterRole getRadiologyOrderingProviderEncounterRole() {
+        return getEncounterRoleByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE);
+    }
+    
+    /**
+     * Get VisitType for RadiologyOrder's
+     * 
+     * @return visitType for radiology orders
+     * @should return visit type for radiology orders
+     * @should throw illegal state exception for non existing radiology visit type
+     */
+    public VisitType getRadiologyVisitType() {
+        return getVisitTypeByGlobalProperty(RadiologyConstants.GP_RADIOLOGY_VISIT_TYPE);
+    }
+    
+    /**
+     * Gets the Name of the ConceptClass for the UUID from the config
+     *
+     * @return a String that contains the Names of the ConceptClasses seperated by a comma
+     * @should throw illegal state exception if global property radiologyConceptClasses is null
+     * @should throw illegal state exception if global property radiologyConceptClasses is an empty
+     *         string
+     * @should throw illegal state exception if global property radiologyConceptClasses is badly
+     *         formatted
+     * @should throw illegal state exception if global property radiologyConceptClasses contains a
+     *         UUID not found among ConceptClasses
+     * @should returns comma separated list of ConceptClass names configured via ConceptClass UUIDs
+     *         in global property radiologyConceptClasses
+     */
+    public String getRadiologyConceptClassNames() {
+        
+        String radiologyConceptClassUuidSetting = getGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES, true);
+        radiologyConceptClassUuidSetting = radiologyConceptClassUuidSetting.replace(" ", "");
+        if (!radiologyConceptClassUuidSetting.matches("^[0-9a-fA-f,-]+$")) {
+            throw new IllegalStateException(
+                    "Property radiology.radiologyConcepts needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
+        }
+        
+        final String[] radiologyConceptClassUuids = radiologyConceptClassUuidSetting.split(",");
+        
+        String result = "";
+        for (final String radiologyConceptClassUuid : radiologyConceptClassUuids) {
+            final ConceptClass fetchedConceptClass = conceptService.getConceptClassByUuid(radiologyConceptClassUuid);
+            if (fetchedConceptClass == null) {
+                throw new IllegalStateException("Property radiology.radiologyConceptClasses contains UUID "
+                        + radiologyConceptClassUuid + " which cannot be found as ConceptClass in the database.");
+            }
+            result = result + fetchedConceptClass.getName() + ",";
+        }
+        result = result.substring(0, result.length() - 1);
+        return result;
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyRoles.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyRoles.java
@@ -15,16 +15,16 @@ package org.openmrs.module.radiology;
  * </p>
  */
 public class RadiologyRoles {
-	
-	public static final String SCHEDULER = "Radiology: Scheduler";
-	
-	public static final String PERFORMING_PHYSICIAN = "Radiology: Performing physician";
-	
-	public static final String READING_PHYSICIAN = "Radiology: Reading physician";
-	
-	public static final String REFERRING_PHYSICIAN = "Radiology: Referring physician";
-	
-	private RadiologyRoles() {
-		// Utility class not meant to be instantiated.
-	}
+    
+    public static final String SCHEDULER = "Radiology: Scheduler";
+    
+    public static final String PERFORMING_PHYSICIAN = "Radiology: Performing physician";
+    
+    public static final String READING_PHYSICIAN = "Radiology: Reading physician";
+    
+    public static final String REFERRING_PHYSICIAN = "Radiology: Referring physician";
+    
+    private RadiologyRoles() {
+        // Utility class not meant to be instantiated.
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/DicomWebViewer.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/DicomWebViewer.java
@@ -22,42 +22,42 @@ import org.springframework.web.util.UriComponentsBuilder;
  */
 @Component
 public class DicomWebViewer {
-	
-	@Autowired
-	private RadiologyProperties radiologyProperties;
-	
-	/**
-	 * Return URL to open DICOM web viewer for given RadiologyStudy.
-	 * 
-	 * @param radiologyStudy RadiologyStudy for which DICOM web viewer URL should be created
-	 * @throws IllegalArgumentException given null
-	 * @throws IllegalArgumentException given a study with studyInstanceUid null
-	 * @should return a url to open dicom images of the given study in the configured dicom viewer
-	 * @should add query param server name to url if local server name is not blank
-	 * @should throw an illegal argument exception given null
-	 * @should throw an illegal argument exception given study with studyInstanceUid null
-	 */
-	public String getDicomViewerUrl(RadiologyStudy radiologyStudy) {
-		if (radiologyStudy == null) {
-			throw new IllegalArgumentException("study cannot be null");
-		} else if (radiologyStudy.getStudyInstanceUid() == null) {
-			throw new IllegalArgumentException("studyInstanceUid cannot be null");
-		}
-		
-		final UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance()
-				.scheme("http")
-				.host(radiologyProperties.getDicomWebViewerAddress())
-				.port(Integer.valueOf(radiologyProperties.getDicomWebViewerPort()))
-				.path(radiologyProperties.getDicomWebViewerBaseUrl())
-				.queryParam("studyUID", radiologyStudy.getStudyInstanceUid());
-		
-		final String serverName = radiologyProperties.getDicomWebViewerLocalServerName();
-		if (StringUtils.isNotBlank(serverName)) {
-			uriComponentsBuilder.queryParam("serverName", serverName);
-		}
-		
-		return uriComponentsBuilder.buildAndExpand()
-				.encode()
-				.toString();
-	}
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    /**
+     * Return URL to open DICOM web viewer for given RadiologyStudy.
+     * 
+     * @param radiologyStudy RadiologyStudy for which DICOM web viewer URL should be created
+     * @throws IllegalArgumentException given null
+     * @throws IllegalArgumentException given a study with studyInstanceUid null
+     * @should return a url to open dicom images of the given study in the configured dicom viewer
+     * @should add query param server name to url if local server name is not blank
+     * @should throw an illegal argument exception given null
+     * @should throw an illegal argument exception given study with studyInstanceUid null
+     */
+    public String getDicomViewerUrl(RadiologyStudy radiologyStudy) {
+        if (radiologyStudy == null) {
+            throw new IllegalArgumentException("study cannot be null");
+        } else if (radiologyStudy.getStudyInstanceUid() == null) {
+            throw new IllegalArgumentException("studyInstanceUid cannot be null");
+        }
+        
+        final UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.newInstance()
+                .scheme("http")
+                .host(radiologyProperties.getDicomWebViewerAddress())
+                .port(Integer.valueOf(radiologyProperties.getDicomWebViewerPort()))
+                .path(radiologyProperties.getDicomWebViewerBaseUrl())
+                .queryParam("studyUID", radiologyStudy.getStudyInstanceUid());
+        
+        final String serverName = radiologyProperties.getDicomWebViewerLocalServerName();
+        if (StringUtils.isNotBlank(serverName)) {
+            uriComponentsBuilder.queryParam("serverName", serverName);
+        }
+        
+        return uriComponentsBuilder.buildAndExpand()
+                .encode()
+                .toString();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatus.java
@@ -16,47 +16,47 @@ package org.openmrs.module.radiology.dicom.code;
  * </p>
  */
 public enum PerformedProcedureStepStatus {
-	
-	IN_PROGRESS,
-	DISCONTINUED,
-	COMPLETED;
-	
-	/**
-	 * Get name or UNKNOWN for given Performed Procedure Step Status
-	 * 
-	 * @param performedProcedureStepStatus PerformedProcedureStepStatus for which the name is
-	 *        returned
-	 * @return name of given PerformedProcedureStepStatus
-	 * @should return name given performed procedure step status
-	 * @should return unknown given null
-	 */
-	public static String getNameOrUnknown(PerformedProcedureStepStatus performedProcedureStepStatus) {
-		return (performedProcedureStepStatus == null) ? "UNKNOWN" : performedProcedureStepStatus.name();
-	}
-	
-	/**
-	 * Get Performed Procedure Step Status for given displayName
-	 * 
-	 * @param displayName name defined by DICOM standard for which the PerformedProcedureStepStatus is returned
-	 * @return PerformedProcedureStepStatus PerformedProcedureStepStatus matching given displayName
-	 * @throws IllegalArgumentException
-	 * @should return performed procedure step status given display name
-	 * @should return null given undefined display name
-	 * @should throw IllegalArgumentException given null
-	 */
-	public static PerformedProcedureStepStatus getMatchForDisplayName(String displayName) throws IllegalArgumentException {
-		if (displayName == null) {
-			throw new IllegalArgumentException("displayName is required");
-		}
-		
-		if (displayName.equalsIgnoreCase("in progress")) {
-			return IN_PROGRESS;
-		} else if (displayName.equalsIgnoreCase("discontinued")) {
-			return DISCONTINUED;
-		} else if (displayName.equalsIgnoreCase("completed")) {
-			return COMPLETED;
-		} else {
-			return null;
-		}
-	}
+    
+    IN_PROGRESS,
+    DISCONTINUED,
+    COMPLETED;
+    
+    /**
+     * Get name or UNKNOWN for given Performed Procedure Step Status
+     * 
+     * @param performedProcedureStepStatus PerformedProcedureStepStatus for which the name is
+     *        returned
+     * @return name of given PerformedProcedureStepStatus
+     * @should return name given performed procedure step status
+     * @should return unknown given null
+     */
+    public static String getNameOrUnknown(PerformedProcedureStepStatus performedProcedureStepStatus) {
+        return (performedProcedureStepStatus == null) ? "UNKNOWN" : performedProcedureStepStatus.name();
+    }
+    
+    /**
+     * Get Performed Procedure Step Status for given displayName
+     * 
+     * @param displayName name defined by DICOM standard for which the PerformedProcedureStepStatus is returned
+     * @return PerformedProcedureStepStatus PerformedProcedureStepStatus matching given displayName
+     * @throws IllegalArgumentException
+     * @should return performed procedure step status given display name
+     * @should return null given undefined display name
+     * @should throw IllegalArgumentException given null
+     */
+    public static PerformedProcedureStepStatus getMatchForDisplayName(String displayName) throws IllegalArgumentException {
+        if (displayName == null) {
+            throw new IllegalArgumentException("displayName is required");
+        }
+        
+        if (displayName.equalsIgnoreCase("in progress")) {
+            return IN_PROGRESS;
+        } else if (displayName.equalsIgnoreCase("discontinued")) {
+            return DISCONTINUED;
+        } else if (displayName.equalsIgnoreCase("completed")) {
+            return COMPLETED;
+        } else {
+            return null;
+        }
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatus.java
@@ -16,23 +16,23 @@ package org.openmrs.module.radiology.dicom.code;
  * </p>
  */
 public enum ScheduledProcedureStepStatus {
-	
-	SCHEDULED,
-	ARRIVED,
-	READY,
-	STARTED,
-	DEPARTED;
-	
-	/**
-	 * Get name or UNKNOWN for given Scheduled Procedure Step Status
-	 * 
-	 * @param scheduledProcedureStepStatus ScheduledProcedureStepStatus for which the
-	 *        name is returned
-	 * @return name of given ScheduledProcedureStepStatus
-	 * @should return name given scheduled procedure step status
-	 * @should return unknown given null
-	 */
-	public static String getNameOrUnknown(ScheduledProcedureStepStatus scheduledProcedureStepStatus) {
-		return (scheduledProcedureStepStatus == null) ? "UNKNOWN" : scheduledProcedureStepStatus.name();
-	}
+    
+    SCHEDULED,
+    ARRIVED,
+    READY,
+    STARTED,
+    DEPARTED;
+    
+    /**
+     * Get name or UNKNOWN for given Scheduled Procedure Step Status
+     * 
+     * @param scheduledProcedureStepStatus ScheduledProcedureStepStatus for which the
+     *        name is returned
+     * @return name of given ScheduledProcedureStepStatus
+     * @should return name given scheduled procedure step status
+     * @should return unknown given null
+     */
+    public static String getNameOrUnknown(ScheduledProcedureStepStatus scheduledProcedureStepStatus) {
+        return (scheduledProcedureStepStatus == null) ? "UNKNOWN" : scheduledProcedureStepStatus.name();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
@@ -28,88 +28,88 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 class HibernateRadiologyOrderDAO implements RadiologyOrderDAO {
-	
-	@Autowired
-	private SessionFactory sessionFactory;
-	
-	/**
-	 * Set session factory that allows us to connect to the database that Hibernate knows about.
-	 *
-	 * @param sessionFactory
-	 */
-	public void setSessionFactory(SessionFactory sessionFactory) {
-		this.sessionFactory = sessionFactory;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
-	 */
-	@Override
-	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
-		return (RadiologyOrder) sessionFactory.getCurrentSession()
-				.get(RadiologyOrder.class, orderId);
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
-		
-		final Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
-		addRestrictionOnPatient(radiologyOrderCriteria, patient);
-		
-		final List<RadiologyOrder> result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
-		return result == null ? new ArrayList<RadiologyOrder>() : result;
-	}
-	
-	/**
-	 * A utility method creating a criteria for RadiologyOrder
-	 *
-	 * @return criteria for RadiologyOrder
-	 */
-	private Criteria createRadiologyOrderCriteria() {
-		return sessionFactory.getCurrentSession()
-				.createCriteria(RadiologyOrder.class);
-	}
-	
-	/**
-	 * Adds an equality restriction for given patient on given criteria if patient is not null
-	 *
-	 * @param criteria criteria on which equality restriction is set if patient is not null
-	 * @param patient patient for which equality restriction will be set
-	 */
-	private void addRestrictionOnPatient(Criteria criteria, Patient patient) {
-		if (patient != null) {
-			criteria.add(Restrictions.eq("patient", patient));
-		}
-	}
-	
-	/**
-	 * @see
-	 *      org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
-		
-		final Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
-		addRestrictionOnPatients(radiologyOrderCriteria, patients);
-		
-		final List<RadiologyOrder> result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
-		return result == null ? new ArrayList<RadiologyOrder>() : result;
-	}
-	
-	/**
-	 * Adds an in restriction for given patients on given criteria if patients is not empty
-	 *
-	 * @param criteria criteria on which in restriction is set if patients is not empty
-	 * @param patients patient list for which in restriction will be set
-	 */
-	private void addRestrictionOnPatients(Criteria criteria, List<Patient> patients) {
-		if (!patients.isEmpty()) {
-			criteria.add(Restrictions.in("patient", patients));
-		}
-	}
+    
+    @Autowired
+    private SessionFactory sessionFactory;
+    
+    /**
+     * Set session factory that allows us to connect to the database that Hibernate knows about.
+     *
+     * @param sessionFactory
+     */
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     */
+    @Override
+    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
+        return (RadiologyOrder) sessionFactory.getCurrentSession()
+                .get(RadiologyOrder.class, orderId);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
+        
+        final Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
+        addRestrictionOnPatient(radiologyOrderCriteria, patient);
+        
+        final List<RadiologyOrder> result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
+        return result == null ? new ArrayList<RadiologyOrder>() : result;
+    }
+    
+    /**
+     * A utility method creating a criteria for RadiologyOrder
+     *
+     * @return criteria for RadiologyOrder
+     */
+    private Criteria createRadiologyOrderCriteria() {
+        return sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyOrder.class);
+    }
+    
+    /**
+     * Adds an equality restriction for given patient on given criteria if patient is not null
+     *
+     * @param criteria criteria on which equality restriction is set if patient is not null
+     * @param patient patient for which equality restriction will be set
+     */
+    private void addRestrictionOnPatient(Criteria criteria, Patient patient) {
+        if (patient != null) {
+            criteria.add(Restrictions.eq("patient", patient));
+        }
+    }
+    
+    /**
+     * @see
+     *      org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
+        
+        final Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
+        addRestrictionOnPatients(radiologyOrderCriteria, patients);
+        
+        final List<RadiologyOrder> result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
+        return result == null ? new ArrayList<RadiologyOrder>() : result;
+    }
+    
+    /**
+     * Adds an in restriction for given patients on given criteria if patients is not empty
+     *
+     * @param criteria criteria on which in restriction is set if patients is not empty
+     * @param patients patient list for which in restriction will be set
+     */
+    private void addRestrictionOnPatients(Criteria criteria, List<Patient> patients) {
+        if (!patients.isEmpty()) {
+            criteria.add(Restrictions.in("patient", patients));
+        }
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyDiscontinuedOrderValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyDiscontinuedOrderValidator.java
@@ -22,37 +22,37 @@ import org.springframework.validation.Validator;
  */
 @Component
 public class RadiologyDiscontinuedOrderValidator implements Validator {
-	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
-	
-	/**
-	 * Determines if the command object being submitted is a valid type
-	 *
-	 * @see org.springframework.validation.Validator#supports(java.lang.Class)
-	 * @should return true for Order objects and subclasses
-	 * @should return false for other object types
-	 */
-	public boolean supports(Class clazz) {
-		return Order.class.isAssignableFrom(clazz);
-	}
-	
-	/**
-	 * Checks the form object for any inconsistencies/errors
-	 *
-	 * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
-	 * @should fail validation if order is null
-	 * @should fail validation if orderer is null
-	 * @should fail validation if orderReasonNonCoded is null
-	 * @should pass validation if all fields are correct
-	 */
-	public void validate(Object obj, Errors errors) {
-		final Order order = (Order) obj;
-		if (order == null) {
-			errors.reject("error.general");
-		} else {
-			ValidationUtils.rejectIfEmpty(errors, "orderer", "error.null");
-			ValidationUtils.rejectIfEmpty(errors, "orderReasonNonCoded", "error.null");
-		}
-	}
+    
+    /** Log for this class and subclasses */
+    protected final Log log = LogFactory.getLog(getClass());
+    
+    /**
+     * Determines if the command object being submitted is a valid type
+     *
+     * @see org.springframework.validation.Validator#supports(java.lang.Class)
+     * @should return true for Order objects and subclasses
+     * @should return false for other object types
+     */
+    public boolean supports(Class clazz) {
+        return Order.class.isAssignableFrom(clazz);
+    }
+    
+    /**
+     * Checks the form object for any inconsistencies/errors
+     *
+     * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
+     * @should fail validation if order is null
+     * @should fail validation if orderer is null
+     * @should fail validation if orderReasonNonCoded is null
+     * @should pass validation if all fields are correct
+     */
+    public void validate(Object obj, Errors errors) {
+        final Order order = (Order) obj;
+        if (order == null) {
+            errors.reject("error.general");
+        } else {
+            ValidationUtils.rejectIfEmpty(errors, "orderer", "error.null");
+            ValidationUtils.rejectIfEmpty(errors, "orderReasonNonCoded", "error.null");
+        }
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrder.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrder.java
@@ -16,100 +16,100 @@ import org.openmrs.module.radiology.study.RadiologyStudy;
  * RadiologyOrder represents a radiology examination
  */
 public class RadiologyOrder extends TestOrder {
-	
-	private RadiologyStudy study;
-	
-	public RadiologyStudy getStudy() {
-		return study;
-	}
-	
-	/**
-	 * Set the Order.study to the given RadiologyStudy. Keeps the bi-directional (one-to-one) association
-	 * between RadiologyOrder and RadiologyStudy in sync.
-	 *
-	 * @param study study which should be associated with this radiology order
-	 * @should set the study attribute to given study
-	 * @should set the radiology order of given study to this radiology order
-	 * @should not fail given null
-	 */
-	public void setStudy(RadiologyStudy radiologyStudy) {
-		if (radiologyStudy != null) {
-			radiologyStudy.setRadiologyOrder(this);
-		}
-		this.study = radiologyStudy;
-	}
-	
-	/**
-	 * Returns true if study is in progress and false otherwise.
-	 * 
-	 * @return true if study is in progress and false otherwise
-	 * @should return false if associated study is null
-	 * @should return false if associated study is not in progress
-	 * @should return true if associated study is in progress
-	 */
-	public boolean isInProgress() {
-		
-		if (this.study == null) {
-			return false;
-		} else {
-			return this.study.isInProgress();
-		}
-	}
-	
-	/**
-	 * Returns true if study is not in progress and false otherwise.
-	 * 
-	 * @return true if study is not in progress and false otherwise
-	 * @should return true if associated study is null
-	 * @should return true if associated study is not in progress
-	 * @should return false if associated study in progress
-	 */
-	public boolean isNotInProgress() {
-		
-		return !this.isInProgress();
-	}
-	
-	/**
-	 * Returns true when this RadiologyOrder has a completed RadiologyStudy and false otherwise.
-	 * 
-	 * @return true if order has completed study and false otherwise
-	 * @should return false if associated study is null
-	 * @should return false if associated study is not completed
-	 * @should return true if associated study is completed
-	 */
-	public boolean isCompleted() {
-		
-		if (this.study == null) {
-			return false;
-		} else {
-			return this.study.isCompleted();
-		}
-	}
-	
-	/**
-	 * Returns true when this RadiologyOrder does not have a completed RadiologyStudy and false otherwise.
-	 * 
-	 * @return true if order has no completed study and false otherwise
-	 * @should return true if associated study is null
-	 * @should return true if associated study is not completed
-	 * @should return false if associated study is completed
-	 */
-	public boolean isNotCompleted() {
-		
-		return !this.isCompleted();
-	}
-	
-	/**
-	 * Returns true when this RadiologyOrder can be discontinued and false otherwise.
-	 * 
-	 * @return true if radiology order can be discontinued and false otherwise
-	 * @should return false if order is not active
-	 * @should return false if radiology order is in progress
-	 * @should return false if radiology order is completed
-	 * @should return true if radiology order is active not in progress and not completed
-	 */
-	public boolean isDiscontinuationAllowed() {
-		
-		return this.isActive() && this.isNotInProgress() && this.isNotCompleted();
-	}
+    
+    private RadiologyStudy study;
+    
+    public RadiologyStudy getStudy() {
+        return study;
+    }
+    
+    /**
+     * Set the Order.study to the given RadiologyStudy. Keeps the bi-directional (one-to-one) association
+     * between RadiologyOrder and RadiologyStudy in sync.
+     *
+     * @param study study which should be associated with this radiology order
+     * @should set the study attribute to given study
+     * @should set the radiology order of given study to this radiology order
+     * @should not fail given null
+     */
+    public void setStudy(RadiologyStudy radiologyStudy) {
+        if (radiologyStudy != null) {
+            radiologyStudy.setRadiologyOrder(this);
+        }
+        this.study = radiologyStudy;
+    }
+    
+    /**
+     * Returns true if study is in progress and false otherwise.
+     * 
+     * @return true if study is in progress and false otherwise
+     * @should return false if associated study is null
+     * @should return false if associated study is not in progress
+     * @should return true if associated study is in progress
+     */
+    public boolean isInProgress() {
+        
+        if (this.study == null) {
+            return false;
+        } else {
+            return this.study.isInProgress();
+        }
+    }
+    
+    /**
+     * Returns true if study is not in progress and false otherwise.
+     * 
+     * @return true if study is not in progress and false otherwise
+     * @should return true if associated study is null
+     * @should return true if associated study is not in progress
+     * @should return false if associated study in progress
+     */
+    public boolean isNotInProgress() {
+        
+        return !this.isInProgress();
+    }
+    
+    /**
+     * Returns true when this RadiologyOrder has a completed RadiologyStudy and false otherwise.
+     * 
+     * @return true if order has completed study and false otherwise
+     * @should return false if associated study is null
+     * @should return false if associated study is not completed
+     * @should return true if associated study is completed
+     */
+    public boolean isCompleted() {
+        
+        if (this.study == null) {
+            return false;
+        } else {
+            return this.study.isCompleted();
+        }
+    }
+    
+    /**
+     * Returns true when this RadiologyOrder does not have a completed RadiologyStudy and false otherwise.
+     * 
+     * @return true if order has no completed study and false otherwise
+     * @should return true if associated study is null
+     * @should return true if associated study is not completed
+     * @should return false if associated study is completed
+     */
+    public boolean isNotCompleted() {
+        
+        return !this.isCompleted();
+    }
+    
+    /**
+     * Returns true when this RadiologyOrder can be discontinued and false otherwise.
+     * 
+     * @return true if radiology order can be discontinued and false otherwise
+     * @should return false if order is not active
+     * @should return false if radiology order is in progress
+     * @should return false if radiology order is completed
+     * @should return true if radiology order is active not in progress and not completed
+     */
+    public boolean isDiscontinuationAllowed() {
+        
+        return this.isActive() && this.isNotInProgress() && this.isNotCompleted();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
@@ -19,21 +19,21 @@ import org.openmrs.Patient;
  * @see org.openmrs.module.radiology.order.RadiologyOrderService
  */
 interface RadiologyOrderDAO {
-	
-	/**
-	 * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
-	 */
-	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId);
-	
-	/**
-	 * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
-	 */
-	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient);
-	
-	/**
-	 * @see
-	 *      org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-	 */
-	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients);
-	
+    
+    /**
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     */
+    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId);
+    
+    /**
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
+     */
+    public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient);
+    
+    /**
+     * @see
+     *      org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
+     */
+    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients);
+    
 }

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -21,88 +21,88 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public interface RadiologyOrderService extends OpenmrsService {
-	
-	/**
-	 * Save given <code>RadiologyOrder</code> and its <code>RadiologyOrder.study</code> to the
-	 * database
-	 *
-	 * @param radiologyOrder radiology order to be created
-	 * @return RadiologyOrder who was created
-	 * @throws IllegalArgumentException if radiologyOrder is null
-	 * @throws IllegalArgumentException if radiologyOrder orderId is not null
-	 * @throws IllegalArgumentException if radiologyOrder.study is null
-	 * @should create new radiology order and study from given radiology order object
-	 * @should create radiology order encounter with orderer and attached to existing active visit if patient has active
-	 *         visit
-	 * @should create radiology order encounter with orderer attached to new active visit if patient without active visit
-	 * @should throw illegal argument exception given null
-	 * @should throw illegal argument exception given existing radiology order
-	 * @should throw illegal argument exception if given radiology order has no study
-	 * @should throw illegal argument exception if given study modality is null
-	 */
-	@Authorized(RadiologyPrivileges.ADD_RADIOLOGY_ORDERS)
-	public RadiologyOrder placeRadiologyOrder(RadiologyOrder radiologyOrder) throws IllegalArgumentException;
-	
-	/**
-	 * Discontinue given <code>RadiologyOrder</code>
-	 *
-	 * @param radiologyOrder radiology order to be discontinued
-	 * @return Order who was created to discontinue RadiologyOrder
-	 * @throws IllegalArgumentException if radiologyOrder is null
-	 * @throws IllegalArgumentException if radiologyOrder orderId is null
-	 * @throws IllegalArgumentException if radiologyOrder is not active
-	 * @throws IllegalArgumentException if provider is null
-	 * @should create discontinuation order which discontinues given radiology order that is not in progress or completed
-	 * @should create discontinuation order with encounter attached to existing active visit if patient has active visit
-	 * @should create discontinuation order with encounter attached to new active visit if patient without active visit
-	 * @should throw illegal argument exception given empty radiology order
-	 * @should throw illegal argument exception given radiology order with orderId null
-	 * @should throw illegal argument exception if radiology order is not active
-	 * @should throw illegal argument exception if radiology order is in progress
-	 * @should throw illegal argument exception if radiology order is completed
-	 * @should throw illegal argument exception given empty provider
-	 */
-	@Authorized({ RadiologyPrivileges.DELETE_RADIOLOGY_ORDERS })
-	public Order discontinueRadiologyOrder(RadiologyOrder radiologyOrder, Provider orderer, String discontinueReason)
-			throws Exception;
-	
-	/**
-	 * Get RadiologyOrder by its orderId
-	 *
-	 * @param orderId of wanted RadiologyOrder
-	 * @return RadiologyOrder matching given orderId
-	 * @throws IllegalArgumentException if order id is null
-	 * @should return radiology order matching order id
-	 * @should return null if no match was found
-	 * @should throw illegal argument exception given null
-	 */
-	@Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
-	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) throws IllegalArgumentException;
-	
-	/**
-	 * Get RadiologyOrder's by its associated Patient
-	 *
-	 * @param patient patient of wanted RadiologyOrders
-	 * @return RadiologyOrders associated with given patient
-	 * @throws IllegalArgumentException if patient is null
-	 * @should return all radiology orders associated with given patient
-	 * @should return empty list given patient without associated radiology orders
-	 * @should throw illegal argument exception given null
-	 */
-	@Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
-	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) throws IllegalArgumentException;
-	
-	/**
-	 * Get RadiologyOrder's by its associated Patients
-	 *
-	 * @param patients list of patients for which RadiologyOrders are queried
-	 * @return RadiologyOrders associated with given patients
-	 * @throws IllegalArgumentException if patients is null
-	 * @should return all radiology orders associated with given patients
-	 * @should return all radiology orders given empty patient list
-	 * @should return empty list given patient list without associated radiology orders
-	 * @should throw illegal argument exception given null
-	 */
-	@Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
-	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) throws IllegalArgumentException;
+    
+    /**
+     * Save given <code>RadiologyOrder</code> and its <code>RadiologyOrder.study</code> to the
+     * database
+     *
+     * @param radiologyOrder radiology order to be created
+     * @return RadiologyOrder who was created
+     * @throws IllegalArgumentException if radiologyOrder is null
+     * @throws IllegalArgumentException if radiologyOrder orderId is not null
+     * @throws IllegalArgumentException if radiologyOrder.study is null
+     * @should create new radiology order and study from given radiology order object
+     * @should create radiology order encounter with orderer and attached to existing active visit if patient has active
+     *         visit
+     * @should create radiology order encounter with orderer attached to new active visit if patient without active visit
+     * @should throw illegal argument exception given null
+     * @should throw illegal argument exception given existing radiology order
+     * @should throw illegal argument exception if given radiology order has no study
+     * @should throw illegal argument exception if given study modality is null
+     */
+    @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_ORDERS)
+    public RadiologyOrder placeRadiologyOrder(RadiologyOrder radiologyOrder) throws IllegalArgumentException;
+    
+    /**
+     * Discontinue given <code>RadiologyOrder</code>
+     *
+     * @param radiologyOrder radiology order to be discontinued
+     * @return Order who was created to discontinue RadiologyOrder
+     * @throws IllegalArgumentException if radiologyOrder is null
+     * @throws IllegalArgumentException if radiologyOrder orderId is null
+     * @throws IllegalArgumentException if radiologyOrder is not active
+     * @throws IllegalArgumentException if provider is null
+     * @should create discontinuation order which discontinues given radiology order that is not in progress or completed
+     * @should create discontinuation order with encounter attached to existing active visit if patient has active visit
+     * @should create discontinuation order with encounter attached to new active visit if patient without active visit
+     * @should throw illegal argument exception given empty radiology order
+     * @should throw illegal argument exception given radiology order with orderId null
+     * @should throw illegal argument exception if radiology order is not active
+     * @should throw illegal argument exception if radiology order is in progress
+     * @should throw illegal argument exception if radiology order is completed
+     * @should throw illegal argument exception given empty provider
+     */
+    @Authorized({ RadiologyPrivileges.DELETE_RADIOLOGY_ORDERS })
+    public Order discontinueRadiologyOrder(RadiologyOrder radiologyOrder, Provider orderer, String discontinueReason)
+            throws Exception;
+    
+    /**
+     * Get RadiologyOrder by its orderId
+     *
+     * @param orderId of wanted RadiologyOrder
+     * @return RadiologyOrder matching given orderId
+     * @throws IllegalArgumentException if order id is null
+     * @should return radiology order matching order id
+     * @should return null if no match was found
+     * @should throw illegal argument exception given null
+     */
+    @Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
+    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) throws IllegalArgumentException;
+    
+    /**
+     * Get RadiologyOrder's by its associated Patient
+     *
+     * @param patient patient of wanted RadiologyOrders
+     * @return RadiologyOrders associated with given patient
+     * @throws IllegalArgumentException if patient is null
+     * @should return all radiology orders associated with given patient
+     * @should return empty list given patient without associated radiology orders
+     * @should throw illegal argument exception given null
+     */
+    @Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
+    public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) throws IllegalArgumentException;
+    
+    /**
+     * Get RadiologyOrder's by its associated Patients
+     *
+     * @param patients list of patients for which RadiologyOrders are queried
+     * @return RadiologyOrders associated with given patients
+     * @throws IllegalArgumentException if patients is null
+     * @should return all radiology orders associated with given patients
+     * @should return all radiology orders given empty patient list
+     * @should return empty list given patient list without associated radiology orders
+     * @should throw illegal argument exception given null
+     */
+    @Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
+    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) throws IllegalArgumentException;
 }

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
@@ -32,170 +32,170 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyOrderService {
-	
-	private static final Log log = LogFactory.getLog(RadiologyOrderServiceImpl.class);
-	
-	@Autowired
-	private RadiologyOrderDAO radiologyOrderDAO;
-	
-	@Autowired
-	private RadiologyStudyService radiologyStudyService;
-	
-	@Autowired
-	private OrderService orderService;
-	
-	@Autowired
-	private EncounterService encounterService;
-	
-	@Autowired
-	private EmrEncounterService emrEncounterService;
-	
-	@Autowired
-	private RadiologyProperties radiologyProperties;
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 */
-	@Transactional
-	@Override
-	public RadiologyOrder placeRadiologyOrder(RadiologyOrder radiologyOrder) {
-		if (radiologyOrder == null) {
-			throw new IllegalArgumentException("radiologyOrder is required");
-		}
-		
-		if (radiologyOrder.getOrderId() != null) {
-			throw new IllegalArgumentException("Cannot edit an existing order!");
-		}
-		
-		if (radiologyOrder.getStudy() == null) {
-			throw new IllegalArgumentException("radiologyOrder.study is required");
-		}
-		
-		if (radiologyOrder.getStudy()
-				.getModality() == null) {
-			throw new IllegalArgumentException("radiologyOrder.study.modality is required");
-		}
-		
-		final Encounter encounter = saveRadiologyOrderEncounter(radiologyOrder.getPatient(), radiologyOrder.getOrderer(),
-			new Date());
-		encounter.addOrder(radiologyOrder);
-		
-		final OrderContext orderContext = new OrderContext();
-		orderContext.setCareSetting(radiologyProperties.getRadiologyCareSetting());
-		orderContext.setOrderType(radiologyProperties.getRadiologyTestOrderType());
-		
-		final RadiologyOrder result = (RadiologyOrder) orderService.saveOrder(radiologyOrder, orderContext);
-		this.radiologyStudyService.saveStudy(result.getStudy());
-		return result;
-	}
-	
-	/**
-	 * Save radiology order encounter for given parameters
-	 * 
-	 * @param patient the encounter patient
-	 * @param provider the encounter provider
-	 * @param encounterDateTime the encounter date
-	 * @return radiology order encounter for given parameters
-	 * @should create radiology order encounter attached to existing active visit given patient with active visit
-	 * @should create radiology order encounter attached to new active visit given patient without active visit
-	 */
-	@Transactional
-	private Encounter saveRadiologyOrderEncounter(Patient patient, Provider provider, Date encounterDateTime) {
-		
-		final EncounterTransaction encounterTransaction = new EncounterTransaction();
-		encounterTransaction.setPatientUuid(patient.getUuid());
-		final EncounterTransaction.Provider encounterProvider = new EncounterTransaction.Provider();
-		encounterProvider.setEncounterRoleUuid(radiologyProperties.getRadiologyOrderingProviderEncounterRole()
-				.getUuid());
-		// sets the provider of the encounterprovider
-		encounterProvider.setUuid(provider.getUuid());
-		final Set<EncounterTransaction.Provider> encounterProviderSet = new HashSet<EncounterTransaction.Provider>();
-		encounterProviderSet.add(encounterProvider);
-		encounterTransaction.setProviders(encounterProviderSet);
-		encounterTransaction.setEncounterDateTime(encounterDateTime);
-		encounterTransaction.setVisitTypeUuid(this.radiologyProperties.getRadiologyVisitType()
-				.getUuid());
-		encounterTransaction.setEncounterTypeUuid(this.radiologyProperties.getRadiologyOrderEncounterType()
-				.getUuid());
-		
-		return this.encounterService.getEncounterByUuid(this.emrEncounterService.save(encounterTransaction)
-				.getEncounterUuid());
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
-	 */
-	@Transactional
-	@Override
-	public Order discontinueRadiologyOrder(RadiologyOrder radiologyOrderToDiscontinue, Provider orderer,
-			String nonCodedDiscontinueReason) throws Exception {
-		
-		if (radiologyOrderToDiscontinue == null) {
-			throw new IllegalArgumentException("radiologyOrder is required");
-		}
-		
-		if (radiologyOrderToDiscontinue.getOrderId() == null) {
-			throw new IllegalArgumentException("orderId is null");
-		}
-		
-		if (!radiologyOrderToDiscontinue.isActive()) {
-			throw new IllegalArgumentException("order is not active");
-		}
-		
-		if (radiologyOrderToDiscontinue.isInProgress()) {
-			throw new IllegalArgumentException("radiologyOrder is in progress");
-		}
-		
-		if (radiologyOrderToDiscontinue.isCompleted()) {
-			throw new IllegalArgumentException("radiologyOrder is completed");
-		}
-		
-		if (orderer == null) {
-			throw new IllegalArgumentException("provider is required");
-		}
-		
-		final Encounter encounter = this.saveRadiologyOrderEncounter(radiologyOrderToDiscontinue.getPatient(), orderer, null);
-		
-		return this.orderService.discontinueOrder(radiologyOrderToDiscontinue, nonCodedDiscontinueReason, null, orderer,
-			encounter);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
-		if (orderId == null) {
-			throw new IllegalArgumentException("orderId is required");
-		}
-		
-		return radiologyOrderDAO.getRadiologyOrderByOrderId(orderId);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
-		if (patient == null) {
-			throw new IllegalArgumentException("patient is required");
-		}
-		
-		return radiologyOrderDAO.getRadiologyOrdersByPatient(patient);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
-		if (patients == null) {
-			throw new IllegalArgumentException("patients is required");
-		}
-		
-		return radiologyOrderDAO.getRadiologyOrdersByPatients(patients);
-	}
+    
+    private static final Log log = LogFactory.getLog(RadiologyOrderServiceImpl.class);
+    
+    @Autowired
+    private RadiologyOrderDAO radiologyOrderDAO;
+    
+    @Autowired
+    private RadiologyStudyService radiologyStudyService;
+    
+    @Autowired
+    private OrderService orderService;
+    
+    @Autowired
+    private EncounterService encounterService;
+    
+    @Autowired
+    private EmrEncounterService emrEncounterService;
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     */
+    @Transactional
+    @Override
+    public RadiologyOrder placeRadiologyOrder(RadiologyOrder radiologyOrder) {
+        if (radiologyOrder == null) {
+            throw new IllegalArgumentException("radiologyOrder is required");
+        }
+        
+        if (radiologyOrder.getOrderId() != null) {
+            throw new IllegalArgumentException("Cannot edit an existing order!");
+        }
+        
+        if (radiologyOrder.getStudy() == null) {
+            throw new IllegalArgumentException("radiologyOrder.study is required");
+        }
+        
+        if (radiologyOrder.getStudy()
+                .getModality() == null) {
+            throw new IllegalArgumentException("radiologyOrder.study.modality is required");
+        }
+        
+        final Encounter encounter = saveRadiologyOrderEncounter(radiologyOrder.getPatient(), radiologyOrder.getOrderer(),
+            new Date());
+        encounter.addOrder(radiologyOrder);
+        
+        final OrderContext orderContext = new OrderContext();
+        orderContext.setCareSetting(radiologyProperties.getRadiologyCareSetting());
+        orderContext.setOrderType(radiologyProperties.getRadiologyTestOrderType());
+        
+        final RadiologyOrder result = (RadiologyOrder) orderService.saveOrder(radiologyOrder, orderContext);
+        this.radiologyStudyService.saveStudy(result.getStudy());
+        return result;
+    }
+    
+    /**
+     * Save radiology order encounter for given parameters
+     * 
+     * @param patient the encounter patient
+     * @param provider the encounter provider
+     * @param encounterDateTime the encounter date
+     * @return radiology order encounter for given parameters
+     * @should create radiology order encounter attached to existing active visit given patient with active visit
+     * @should create radiology order encounter attached to new active visit given patient without active visit
+     */
+    @Transactional
+    private Encounter saveRadiologyOrderEncounter(Patient patient, Provider provider, Date encounterDateTime) {
+        
+        final EncounterTransaction encounterTransaction = new EncounterTransaction();
+        encounterTransaction.setPatientUuid(patient.getUuid());
+        final EncounterTransaction.Provider encounterProvider = new EncounterTransaction.Provider();
+        encounterProvider.setEncounterRoleUuid(radiologyProperties.getRadiologyOrderingProviderEncounterRole()
+                .getUuid());
+        // sets the provider of the encounterprovider
+        encounterProvider.setUuid(provider.getUuid());
+        final Set<EncounterTransaction.Provider> encounterProviderSet = new HashSet<EncounterTransaction.Provider>();
+        encounterProviderSet.add(encounterProvider);
+        encounterTransaction.setProviders(encounterProviderSet);
+        encounterTransaction.setEncounterDateTime(encounterDateTime);
+        encounterTransaction.setVisitTypeUuid(this.radiologyProperties.getRadiologyVisitType()
+                .getUuid());
+        encounterTransaction.setEncounterTypeUuid(this.radiologyProperties.getRadiologyOrderEncounterType()
+                .getUuid());
+        
+        return this.encounterService.getEncounterByUuid(this.emrEncounterService.save(encounterTransaction)
+                .getEncounterUuid());
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
+     */
+    @Transactional
+    @Override
+    public Order discontinueRadiologyOrder(RadiologyOrder radiologyOrderToDiscontinue, Provider orderer,
+            String nonCodedDiscontinueReason) throws Exception {
+        
+        if (radiologyOrderToDiscontinue == null) {
+            throw new IllegalArgumentException("radiologyOrder is required");
+        }
+        
+        if (radiologyOrderToDiscontinue.getOrderId() == null) {
+            throw new IllegalArgumentException("orderId is null");
+        }
+        
+        if (!radiologyOrderToDiscontinue.isActive()) {
+            throw new IllegalArgumentException("order is not active");
+        }
+        
+        if (radiologyOrderToDiscontinue.isInProgress()) {
+            throw new IllegalArgumentException("radiologyOrder is in progress");
+        }
+        
+        if (radiologyOrderToDiscontinue.isCompleted()) {
+            throw new IllegalArgumentException("radiologyOrder is completed");
+        }
+        
+        if (orderer == null) {
+            throw new IllegalArgumentException("provider is required");
+        }
+        
+        final Encounter encounter = this.saveRadiologyOrderEncounter(radiologyOrderToDiscontinue.getPatient(), orderer, null);
+        
+        return this.orderService.discontinueOrder(radiologyOrderToDiscontinue, nonCodedDiscontinueReason, null, orderer,
+            encounter);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
+        if (orderId == null) {
+            throw new IllegalArgumentException("orderId is required");
+        }
+        
+        return radiologyOrderDAO.getRadiologyOrderByOrderId(orderId);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
+        if (patient == null) {
+            throw new IllegalArgumentException("patient is required");
+        }
+        
+        return radiologyOrderDAO.getRadiologyOrdersByPatient(patient);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
+        if (patients == null) {
+            throw new IllegalArgumentException("patients is required");
+        }
+        
+        return radiologyOrderDAO.getRadiologyOrdersByPatients(patients);
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderValidator.java
@@ -27,92 +27,92 @@ import org.springframework.validation.Validator;
 @Handler(supports = { RadiologyOrder.class })
 @Component
 public class RadiologyOrderValidator implements Validator {
-	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
-	
-	/**
-	 * Determines if the command object being submitted is a valid type
-	 *
-	 * @see org.springframework.validation.Validator#supports(java.lang.Class)
-	 * @should return true for RadiologyOrder objects
-	 * @should return false for other object types
-	 */
-	public boolean supports(Class clazz) {
-		return RadiologyOrder.class.isAssignableFrom(clazz);
-	}
-	
-	/**
-	 * Checks the form object for any inconsistencies/errors
-	 *
-	 * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
-	 * @should fail validation if radiologyOrder is null
-	 * @should fail validation if voided is null
-	 * @should fail validation if concept is null
-	 * @should fail validation if patient is null
-	 * @should fail validation if orderer is null
-	 * @should fail validation if urgency is null
-	 * @should fail validation if action is null
-	 * @should fail validation if dateActivated after dateStopped
-	 * @should fail validation if dateActivated after autoExpireDate
-	 * @should fail validation if scheduledDate is set and urgency is not set as ON_SCHEDULED_DATE
-	 * @should fail validation if scheduledDate is null when urgency is ON_SCHEDULED_DATE
-	 * @should pass validation if all fields are correct
-	 * @should not allow a future dateActivated
-	 */
-	public void validate(Object obj, Errors errors) {
-		final RadiologyOrder radiologyOrder = (RadiologyOrder) obj;
-		if (radiologyOrder == null) {
-			errors.reject("error.general");
-		} else {
-			// for the following elements Order.hbm.xml says: not-null="true"
-			ValidationUtils.rejectIfEmpty(errors, "voided", "error.null");
-			ValidationUtils.rejectIfEmpty(errors, "concept", "Concept.noConceptSelected");
-			ValidationUtils.rejectIfEmpty(errors, "patient", "error.null");
-			ValidationUtils.rejectIfEmpty(errors, "orderer", "error.null");
-			ValidationUtils.rejectIfEmpty(errors, "urgency", "error.null");
-			ValidationUtils.rejectIfEmpty(errors, "action", "error.null");
-			// Order.encounter and
-			// Order.orderType
-			// have not null constraint as well, but are set in RadiologyOrderService.saveRadiologyOrder
-			validateDateActivated(radiologyOrder, errors);
-			validateScheduledDate(radiologyOrder, errors);
-		}
-	}
-	
-	private void validateDateActivated(Order order, Errors errors) {
-		final Date dateActivated = order.getDateActivated();
-		if (dateActivated != null) {
-			if (dateActivated.after(new Date())) {
-				errors.rejectValue("dateActivated", "Order.error.dateActivatedInFuture");
-				return;
-			}
-			final Date dateStopped = order.getDateStopped();
-			if (dateStopped != null && dateActivated.after(dateStopped)) {
-				errors.rejectValue("dateActivated", "Order.error.dateActivatedAfterDiscontinuedDate");
-				errors.rejectValue("dateStopped", "Order.error.dateActivatedAfterDiscontinuedDate");
-			}
-			final Date autoExpireDate = order.getAutoExpireDate();
-			if (autoExpireDate != null && dateActivated.after(autoExpireDate)) {
-				errors.rejectValue("dateActivated", "Order.error.dateActivatedAfterAutoExpireDate");
-				errors.rejectValue("autoExpireDate", "Order.error.dateActivatedAfterAutoExpireDate");
-			}
-			final Encounter encounter = order.getEncounter();
-			if (encounter != null && encounter.getEncounterDatetime() != null && encounter.getEncounterDatetime()
-					.after(dateActivated)) {
-				errors.rejectValue("dateActivated", "Order.error.dateActivatedAfterEncounterDatetime");
-			}
-		}
-	}
-	
-	private void validateScheduledDate(Order order, Errors errors) {
-		final boolean isUrgencyOnScheduledDate = order.getUrgency() != null && order.getUrgency()
-				.equals(Order.Urgency.ON_SCHEDULED_DATE);
-		if (order.getScheduledDate() != null && !isUrgencyOnScheduledDate) {
-			errors.rejectValue("urgency", "Order.error.urgencyNotOnScheduledDate");
-		}
-		if (isUrgencyOnScheduledDate && order.getScheduledDate() == null) {
-			errors.rejectValue("scheduledDate", "Order.error.scheduledDateNullForOnScheduledDateUrgency");
-		}
-	}
+    
+    /** Log for this class and subclasses */
+    protected final Log log = LogFactory.getLog(getClass());
+    
+    /**
+     * Determines if the command object being submitted is a valid type
+     *
+     * @see org.springframework.validation.Validator#supports(java.lang.Class)
+     * @should return true for RadiologyOrder objects
+     * @should return false for other object types
+     */
+    public boolean supports(Class clazz) {
+        return RadiologyOrder.class.isAssignableFrom(clazz);
+    }
+    
+    /**
+     * Checks the form object for any inconsistencies/errors
+     *
+     * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
+     * @should fail validation if radiologyOrder is null
+     * @should fail validation if voided is null
+     * @should fail validation if concept is null
+     * @should fail validation if patient is null
+     * @should fail validation if orderer is null
+     * @should fail validation if urgency is null
+     * @should fail validation if action is null
+     * @should fail validation if dateActivated after dateStopped
+     * @should fail validation if dateActivated after autoExpireDate
+     * @should fail validation if scheduledDate is set and urgency is not set as ON_SCHEDULED_DATE
+     * @should fail validation if scheduledDate is null when urgency is ON_SCHEDULED_DATE
+     * @should pass validation if all fields are correct
+     * @should not allow a future dateActivated
+     */
+    public void validate(Object obj, Errors errors) {
+        final RadiologyOrder radiologyOrder = (RadiologyOrder) obj;
+        if (radiologyOrder == null) {
+            errors.reject("error.general");
+        } else {
+            // for the following elements Order.hbm.xml says: not-null="true"
+            ValidationUtils.rejectIfEmpty(errors, "voided", "error.null");
+            ValidationUtils.rejectIfEmpty(errors, "concept", "Concept.noConceptSelected");
+            ValidationUtils.rejectIfEmpty(errors, "patient", "error.null");
+            ValidationUtils.rejectIfEmpty(errors, "orderer", "error.null");
+            ValidationUtils.rejectIfEmpty(errors, "urgency", "error.null");
+            ValidationUtils.rejectIfEmpty(errors, "action", "error.null");
+            // Order.encounter and
+            // Order.orderType
+            // have not null constraint as well, but are set in RadiologyOrderService.saveRadiologyOrder
+            validateDateActivated(radiologyOrder, errors);
+            validateScheduledDate(radiologyOrder, errors);
+        }
+    }
+    
+    private void validateDateActivated(Order order, Errors errors) {
+        final Date dateActivated = order.getDateActivated();
+        if (dateActivated != null) {
+            if (dateActivated.after(new Date())) {
+                errors.rejectValue("dateActivated", "Order.error.dateActivatedInFuture");
+                return;
+            }
+            final Date dateStopped = order.getDateStopped();
+            if (dateStopped != null && dateActivated.after(dateStopped)) {
+                errors.rejectValue("dateActivated", "Order.error.dateActivatedAfterDiscontinuedDate");
+                errors.rejectValue("dateStopped", "Order.error.dateActivatedAfterDiscontinuedDate");
+            }
+            final Date autoExpireDate = order.getAutoExpireDate();
+            if (autoExpireDate != null && dateActivated.after(autoExpireDate)) {
+                errors.rejectValue("dateActivated", "Order.error.dateActivatedAfterAutoExpireDate");
+                errors.rejectValue("autoExpireDate", "Order.error.dateActivatedAfterAutoExpireDate");
+            }
+            final Encounter encounter = order.getEncounter();
+            if (encounter != null && encounter.getEncounterDatetime() != null && encounter.getEncounterDatetime()
+                    .after(dateActivated)) {
+                errors.rejectValue("dateActivated", "Order.error.dateActivatedAfterEncounterDatetime");
+            }
+        }
+    }
+    
+    private void validateScheduledDate(Order order, Errors errors) {
+        final boolean isUrgencyOnScheduledDate = order.getUrgency() != null && order.getUrgency()
+                .equals(Order.Urgency.ON_SCHEDULED_DATE);
+        if (order.getScheduledDate() != null && !isUrgencyOnScheduledDate) {
+            errors.rejectValue("urgency", "Order.error.urgencyNotOnScheduledDate");
+        }
+        if (isUrgencyOnScheduledDate && order.getScheduledDate() == null) {
+            errors.rejectValue("scheduledDate", "Order.error.scheduledDateNullForOnScheduledDateUrgency");
+        }
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -27,95 +27,95 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 class HibernateRadiologyReportDAO implements RadiologyReportDAO {
-	
-	@Autowired
-	private SessionFactory sessionFactory;
-	
-	/**
-	 * Set session factory that allows us to connect to the database that Hibernate knows about.
-	 *
-	 * @param sessionFactory SessionFactory
-	 */
-	public void setSessionFactory(SessionFactory sessionFactory) {
-		this.sessionFactory = sessionFactory;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
-	 */
-	@Override
-	public RadiologyReport getRadiologyReportById(Integer radiologyReportId) {
-		return (RadiologyReport) sessionFactory.getCurrentSession()
-				.get(RadiologyReport.class, radiologyReportId);
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReport(RadiologyReport)
-	 */
-	@Override
-	public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) {
-		sessionFactory.getCurrentSession()
-				.saveOrUpdate(radiologyReport);
-		return radiologyReport;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
-	 *      (RadiologyReport)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder) {
-		final List<RadiologyReport> radiologyReports = sessionFactory.getCurrentSession()
-				.createCriteria(RadiologyReport.class)
-				.add(Restrictions.eq("radiologyOrder", radiologyOrder))
-				.add(Restrictions.eq("reportStatus", RadiologyReportStatus.COMPLETED))
-				.list();
-		return radiologyReports.size() == 1;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
-	 */
-	@SuppressWarnings("unchecked")
-	public boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder) {
-		final List<RadiologyReport> radiologyReports = sessionFactory.getCurrentSession()
-				.createCriteria(RadiologyReport.class)
-				.add(Restrictions.eq("radiologyOrder", radiologyOrder))
-				.add(Restrictions.eq("reportStatus", RadiologyReportStatus.CLAIMED))
-				.list();
-		return radiologyReports.size() == 1;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      RadiologyReportStatus)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(RadiologyOrder radiologyOrder,
-			RadiologyReportStatus radiologyReportStatus) {
-		
-		final List<RadiologyReport> result = sessionFactory.getCurrentSession()
-				.createCriteria(RadiologyReport.class)
-				.add(Restrictions.eq("radiologyOrder", radiologyOrder))
-				.add(Restrictions.eq("reportStatus", radiologyReportStatus))
-				.list();
-		return result == null ? new ArrayList<RadiologyReport>() : result;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
-	 */
-	@Override
-	public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder) {
-		return (RadiologyReport) sessionFactory.getCurrentSession()
-				.createCriteria(RadiologyReport.class)
-				.add(Restrictions.eq("radiologyOrder", radiologyOrder))
-				.add(Restrictions.disjunction()
-						.add(Restrictions.eq("reportStatus", RadiologyReportStatus.CLAIMED))
-						.add(Restrictions.eq("reportStatus", RadiologyReportStatus.COMPLETED)))
-				.list()
-				.get(0);
-	}
+    
+    @Autowired
+    private SessionFactory sessionFactory;
+    
+    /**
+     * Set session factory that allows us to connect to the database that Hibernate knows about.
+     *
+     * @param sessionFactory SessionFactory
+     */
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
+     */
+    @Override
+    public RadiologyReport getRadiologyReportById(Integer radiologyReportId) {
+        return (RadiologyReport) sessionFactory.getCurrentSession()
+                .get(RadiologyReport.class, radiologyReportId);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReport(RadiologyReport)
+     */
+    @Override
+    public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) {
+        sessionFactory.getCurrentSession()
+                .saveOrUpdate(radiologyReport);
+        return radiologyReport;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
+     *      (RadiologyReport)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder) {
+        final List<RadiologyReport> radiologyReports = sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyReport.class)
+                .add(Restrictions.eq("radiologyOrder", radiologyOrder))
+                .add(Restrictions.eq("reportStatus", RadiologyReportStatus.COMPLETED))
+                .list();
+        return radiologyReports.size() == 1;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
+     */
+    @SuppressWarnings("unchecked")
+    public boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder) {
+        final List<RadiologyReport> radiologyReports = sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyReport.class)
+                .add(Restrictions.eq("radiologyOrder", radiologyOrder))
+                .add(Restrictions.eq("reportStatus", RadiologyReportStatus.CLAIMED))
+                .list();
+        return radiologyReports.size() == 1;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      RadiologyReportStatus)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(RadiologyOrder radiologyOrder,
+            RadiologyReportStatus radiologyReportStatus) {
+        
+        final List<RadiologyReport> result = sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyReport.class)
+                .add(Restrictions.eq("radiologyOrder", radiologyOrder))
+                .add(Restrictions.eq("reportStatus", radiologyReportStatus))
+                .list();
+        return result == null ? new ArrayList<RadiologyReport>() : result;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
+     */
+    @Override
+    public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder) {
+        return (RadiologyReport) sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyReport.class)
+                .add(Restrictions.eq("radiologyOrder", radiologyOrder))
+                .add(Restrictions.disjunction()
+                        .add(Restrictions.eq("reportStatus", RadiologyReportStatus.CLAIMED))
+                        .add(Restrictions.eq("reportStatus", RadiologyReportStatus.COMPLETED)))
+                .list()
+                .get(0);
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
@@ -20,175 +20,175 @@ import org.openmrs.module.radiology.order.RadiologyOrder;
  * order is completed
  */
 public class RadiologyReport extends BaseOpenmrsData {
-	
-	private Integer radiologyReportId;
-	
-	private RadiologyOrder radiologyOrder;
-	
-	private Date reportDate;
-	
-	private Provider principalResultsInterpreter;
-	
-	private RadiologyReportStatus reportStatus;
-	
-	private String reportBody;
-	
-	/**
-	 * Instantiate a RadiologyReport
-	 */
-	private RadiologyReport() {
-		// needed by hibernate to instantiate a bean
-	}
-	
-	/**
-	 * Instantiate a RadiologyReport for given RadiologyOrder
-	 * 
-	 * @param radiologyOrder RadiologyOrder which is being/was reported
-	 * @throws IllegalArgumentException if given radiology order is null
-	 * @throws IllegalArgumentException if given radiology order is not completed
-	 * @should set radiology order to given radiology order and report status to claimed
-	 * @should throw an illegal argument exception if given radiology order is null
-	 * @should throw an illegal argument exception if given radiology order is not completed
-	 */
-	public RadiologyReport(RadiologyOrder radiologyOrder) {
-		
-		if (radiologyOrder == null) {
-			throw new IllegalArgumentException("radiologyOrder cannot be null");
-		}
-		
-		if (radiologyOrder.isNotCompleted()) {
-			throw new IllegalArgumentException("radiologyOrder is not completed");
-		}
-		
-		this.radiologyOrder = radiologyOrder;
-		this.reportStatus = RadiologyReportStatus.CLAIMED;
-	}
-	
-	/**
-	 * Get RadiologyOrder which is being/was reported.
-	 * 
-	 * @return RadiologyOrder which is being/was reported
-	 */
-	public RadiologyOrder getRadiologyOrder() {
-		return radiologyOrder;
-	}
-	
-	/**
-	 * Set RadiologyOrder which is being/was reported.
-	 * 
-	 * @param radiologyOrder RadiologyOrder which is being/was reported
-	 */
-	public void setRadiologyOrder(RadiologyOrder radiologyOrder) {
-		this.radiologyOrder = radiologyOrder;
-	}
-	
-	/**
-	 * Get Provider which is the report author.
-	 * 
-	 * @return Provider which is the report author
-	 */
-	public Provider getPrincipalResultsInterpreter() {
-		return principalResultsInterpreter;
-	}
-	
-	/**
-	 * Set Provider which is the report author.
-	 * 
-	 * @param principalResultsInterpreter Provider which is the report author
-	 */
-	public void setPrincipalResultsInterpreter(Provider principalResultsInterpreter) {
-		this.principalResultsInterpreter = principalResultsInterpreter;
-	}
-	
-	/**
-	 * Get radiologyReportId of RadiologyReport.
-	 * 
-	 * @return radiologyReportId of RadiologyReport
-	 */
-	@Override
-	public Integer getId() {
-		return getRadiologyReportId();
-	}
-	
-	/**
-	 * Set radiologyReportId of RadiologyReport.
-	 * 
-	 * @param radiologyReportId Id of RadiologyReport
-	 */
-	@Override
-	public void setId(Integer radiologyReportId) {
-		setRadiologyReportId(radiologyReportId);
-	}
-	
-	/**
-	 * Get radiologyReportId of RadiologyReport.
-	 * 
-	 * @return radiologyReportId of RadiologyReport
-	 */
-	private Integer getRadiologyReportId() {
-		return this.radiologyReportId;
-	}
-	
-	/**
-	 * Set radiologyReportId of RadiologyReport.
-	 * 
-	 * @param radiologyReportId Id of RadiologyReport
-	 */
-	private void setRadiologyReportId(Integer radiologyReportId) {
-		this.radiologyReportId = radiologyReportId;
-	}
-	
-	/**
-	 * Get reportDate of RadiologyReport.
-	 * 
-	 * @return reportDate of RadiologyReport
-	 */
-	public Date getReportDate() {
-		return reportDate;
-	}
-	
-	/**
-	 * Set reportDate of RadiologyReport.
-	 * 
-	 * @param reportDate date of RadiologyReport
-	 */
-	public void setReportDate(Date reportDate) {
-		this.reportDate = reportDate;
-	}
-	
-	/**
-	 * Get reportStatus of RadiologyReport.
-	 * 
-	 * @return reportStatus of RadiologyReport
-	 */
-	public RadiologyReportStatus getReportStatus() {
-		return reportStatus;
-	}
-	
-	/**
-	 * Set reportStatus of RadiologyReport.
-	 * 
-	 * @param reportStatus status of RadiologyReport
-	 */
-	public void setReportStatus(RadiologyReportStatus reportStatus) {
-		this.reportStatus = reportStatus;
-	}
-	
-	/**
-	 * Get reportBody of RadiologyReport.
-	 * 
-	 * @return reportBody of RadiologyReport
-	 */
-	public String getReportBody() {
-		return reportBody;
-	}
-	
-	/**
-	 * Set reportBody of RadiologyReport.
-	 * 
-	 * @param reportBody body of RadiologyReport
-	 */
-	public void setReportBody(String reportBody) {
-		this.reportBody = reportBody;
-	}
+    
+    private Integer radiologyReportId;
+    
+    private RadiologyOrder radiologyOrder;
+    
+    private Date reportDate;
+    
+    private Provider principalResultsInterpreter;
+    
+    private RadiologyReportStatus reportStatus;
+    
+    private String reportBody;
+    
+    /**
+     * Instantiate a RadiologyReport
+     */
+    private RadiologyReport() {
+        // needed by hibernate to instantiate a bean
+    }
+    
+    /**
+     * Instantiate a RadiologyReport for given RadiologyOrder
+     * 
+     * @param radiologyOrder RadiologyOrder which is being/was reported
+     * @throws IllegalArgumentException if given radiology order is null
+     * @throws IllegalArgumentException if given radiology order is not completed
+     * @should set radiology order to given radiology order and report status to claimed
+     * @should throw an illegal argument exception if given radiology order is null
+     * @should throw an illegal argument exception if given radiology order is not completed
+     */
+    public RadiologyReport(RadiologyOrder radiologyOrder) {
+        
+        if (radiologyOrder == null) {
+            throw new IllegalArgumentException("radiologyOrder cannot be null");
+        }
+        
+        if (radiologyOrder.isNotCompleted()) {
+            throw new IllegalArgumentException("radiologyOrder is not completed");
+        }
+        
+        this.radiologyOrder = radiologyOrder;
+        this.reportStatus = RadiologyReportStatus.CLAIMED;
+    }
+    
+    /**
+     * Get RadiologyOrder which is being/was reported.
+     * 
+     * @return RadiologyOrder which is being/was reported
+     */
+    public RadiologyOrder getRadiologyOrder() {
+        return radiologyOrder;
+    }
+    
+    /**
+     * Set RadiologyOrder which is being/was reported.
+     * 
+     * @param radiologyOrder RadiologyOrder which is being/was reported
+     */
+    public void setRadiologyOrder(RadiologyOrder radiologyOrder) {
+        this.radiologyOrder = radiologyOrder;
+    }
+    
+    /**
+     * Get Provider which is the report author.
+     * 
+     * @return Provider which is the report author
+     */
+    public Provider getPrincipalResultsInterpreter() {
+        return principalResultsInterpreter;
+    }
+    
+    /**
+     * Set Provider which is the report author.
+     * 
+     * @param principalResultsInterpreter Provider which is the report author
+     */
+    public void setPrincipalResultsInterpreter(Provider principalResultsInterpreter) {
+        this.principalResultsInterpreter = principalResultsInterpreter;
+    }
+    
+    /**
+     * Get radiologyReportId of RadiologyReport.
+     * 
+     * @return radiologyReportId of RadiologyReport
+     */
+    @Override
+    public Integer getId() {
+        return getRadiologyReportId();
+    }
+    
+    /**
+     * Set radiologyReportId of RadiologyReport.
+     * 
+     * @param radiologyReportId Id of RadiologyReport
+     */
+    @Override
+    public void setId(Integer radiologyReportId) {
+        setRadiologyReportId(radiologyReportId);
+    }
+    
+    /**
+     * Get radiologyReportId of RadiologyReport.
+     * 
+     * @return radiologyReportId of RadiologyReport
+     */
+    private Integer getRadiologyReportId() {
+        return this.radiologyReportId;
+    }
+    
+    /**
+     * Set radiologyReportId of RadiologyReport.
+     * 
+     * @param radiologyReportId Id of RadiologyReport
+     */
+    private void setRadiologyReportId(Integer radiologyReportId) {
+        this.radiologyReportId = radiologyReportId;
+    }
+    
+    /**
+     * Get reportDate of RadiologyReport.
+     * 
+     * @return reportDate of RadiologyReport
+     */
+    public Date getReportDate() {
+        return reportDate;
+    }
+    
+    /**
+     * Set reportDate of RadiologyReport.
+     * 
+     * @param reportDate date of RadiologyReport
+     */
+    public void setReportDate(Date reportDate) {
+        this.reportDate = reportDate;
+    }
+    
+    /**
+     * Get reportStatus of RadiologyReport.
+     * 
+     * @return reportStatus of RadiologyReport
+     */
+    public RadiologyReportStatus getReportStatus() {
+        return reportStatus;
+    }
+    
+    /**
+     * Set reportStatus of RadiologyReport.
+     * 
+     * @param reportStatus status of RadiologyReport
+     */
+    public void setReportStatus(RadiologyReportStatus reportStatus) {
+        this.reportStatus = reportStatus;
+    }
+    
+    /**
+     * Get reportBody of RadiologyReport.
+     * 
+     * @return reportBody of RadiologyReport
+     */
+    public String getReportBody() {
+        return reportBody;
+    }
+    
+    /**
+     * Set reportBody of RadiologyReport.
+     * 
+     * @param reportBody body of RadiologyReport
+     */
+    public void setReportBody(String reportBody) {
+        this.reportBody = reportBody;
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
@@ -19,36 +19,36 @@ import org.openmrs.module.radiology.order.RadiologyOrder;
  * @see org.openmrs.module.radiology.report.RadiologyReportService
  */
 interface RadiologyReportDAO {
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
-	 */
-	RadiologyReport getRadiologyReportById(Integer radiologyReportId);
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReport(RadiologyReport)
-	 */
-	RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport);
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
-	 */
-	boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder);
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
-	 */
-	boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder);
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      RadiologyReportStatus)
-	 */
-	List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(RadiologyOrder radiologyOrder,
-			RadiologyReportStatus radiologyReportStatus);
-	
-	/**
-	 * @see org.openmrs.module.radiology.report.RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
-	 */
-	RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
+     */
+    RadiologyReport getRadiologyReportById(Integer radiologyReportId);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReport(RadiologyReport)
+     */
+    RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
+     */
+    boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
+     */
+    boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      RadiologyReportStatus)
+     */
+    List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(RadiologyOrder radiologyOrder,
+            RadiologyReportStatus radiologyReportStatus);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
+     */
+    RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -20,158 +20,158 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public interface RadiologyReportService extends OpenmrsService {
-	
-	/**
-	 * Creates a RadiologyReport and sets the radiologyReportStatus to claimed
-	 *
-	 * @param radiologyOrder RadiologyOrder
-	 * @return a new claimed RadiologyReport
-	 * @throws IllegalArgumentException if given RadiologyOrder is null
-	 * @throws IllegalArgumentException if Study of given radiologyReport is null
-	 * @throws IllegalArgumentException if Study of given RadiologyOrder is not completed
-	 * @throws UnsupportedOperationException if given order has a completed RadiologyReport
-	 * @throws UnsupportedOperationException if given order has a claimed RadiologyReport
-	 * @should create a radiology order with report status claimed given a completed radiology order
-	 * @should throw an illegal argument exception if given radiology order is null
-	 * @should throw an illegal argument exception if given radiology order is not completed
-	 * @should throw an UnsupportedOperationException if given order has a completed RadiologyReport
-	 * @should throw an UnsupportedOperationException if given order has a claimed RadiologyReport
-	 */
-	@Authorized(RadiologyPrivileges.ADD_RADIOLOGY_REPORTS)
-	public RadiologyReport createAndClaimRadiologyReport(RadiologyOrder radiologyOrder) throws IllegalArgumentException,
-			UnsupportedOperationException;
-	
-	/**
-	 * Save the given radiologyReport
-	 *
-	 * @param radiologyReport RadiologyReport to be saved
-	 * @return the saved radiologyReport
-	 * @throws IllegalArgumentException if radiologyReport is null
-	 * @throws IllegalArgumentException if radiologyReportStatus is null
-	 * @throws UnsupportedOperationException if radiologyReport is discontinued
-	 * @throws UnsupportedOperationException if radiologyReport is completed
-	 * @should save radiologyReport in database and return it
-	 * @should throw an IllegalArgumentException if radiologyReport is null
-	 * @should throw an IllegalArgumentException if radiologyReportStatus is null
-	 * @should throw an UnsupportedOperationException if radiologyReport is discontinued
-	 * @should throw an UnsupportedOperationException if radiologyReport is completed
-	 */
-	@Authorized(RadiologyPrivileges.EDIT_RADIOLOGY_REPORTS)
-	public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
-			UnsupportedOperationException;
-	
-	/**
-	 * Unclaims the given radiologyReport and sets the radiologyReportStatus to discontinued
-	 *
-	 * @param radiologyReport RadiologyReport to be unclaimed
-	 * @return the discontinued RadiologyReport
-	 * @throws IllegalArgumentException if radiologyReport is null
-	 * @throws IllegalArgumentException if radiologyReportStatus is null
-	 * @throws UnsupportedOperationException if radiologyReport is discontinued
-	 * @throws UnsupportedOperationException if radiologyReport is completed
-	 * @should set the radiologyReportStatus of radiologyReport to discontinued
-	 * @should throw an IllegalArgumentException if radiologyReport is null
-	 * @should throw an IllegalArgumentException if radiologyReportStatus is null
-	 * @should throw an UnsupportedOperationException if radiologyReport is discontinued
-	 * @should throw an UnsupportedOperationException if radiologyReport is completed
-	 */
-	@Authorized(RadiologyPrivileges.DELETE_RADIOLOGY_REPORTS)
-	public RadiologyReport unclaimRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
-			UnsupportedOperationException;
-	
-	/**
-	 * Completes the given radiologyReport and sets the radiologyReportStatus to completed
-	 *
-	 * @param radiologyReport RadiologyReport to be completed
-	 * @param principalResultsInterpreter which the RadiologyReport should be set to
-	 * @return completed RadiologyReport matching given radiologyReport with
-	 *         principalResultsInterpreter
-	 * @throws IllegalArgumentException if radiologyReport is null
-	 * @throws IllegalArgumentException if principalResultsInterpreter is null
-	 * @throws IllegalArgumentException if radiologyReportStatus is null
-	 * @throws UnsupportedOperationException if radiologyReport is discontinued
-	 * @throws UnsupportedOperationException if radiologyReport is completed
-	 * @should set the reportDate of the radiologyReport to the day the RadiologyReport was
-	 *         completed
-	 * @should set the radiologyReportStatus to complete
-	 * @should throw an IllegalArgumentException if principalResultsInterpreter is null
-	 * @should throw an IllegalArgumentException if radiologyReport is null
-	 * @should throw an IllegalArgumentException if radiologyReportStatus is null
-	 * @should throw an UnsupportedOperationException if radiologyReport is discontinued
-	 * @should throw an UnsupportedOperationException if radiologyReport is completed
-	 */
-	@Authorized(RadiologyPrivileges.EDIT_RADIOLOGY_REPORTS)
-	public RadiologyReport completeRadiologyReport(RadiologyReport radiologyReport, Provider principalResultsInterpreter)
-			throws IllegalArgumentException, UnsupportedOperationException;
-	
-	/**
-	 * Get a RadiologyReport matching the radiologyReportId
-	 *
-	 * @param radiologyReportId of RadiologyReport
-	 * @return RadiologyReport matching given radiologyReportId
-	 * @throws IllegalArgumentException if radiologyReportId is null
-	 * @should fetch RadiologyReport matching given radiologyReportId
-	 * @should throw IllegalArgumentException if radiologyReportId is null
-	 */
-	@Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
-	RadiologyReport getRadiologyReportByRadiologyReportId(Integer radiologyReportId) throws IllegalArgumentException;
-	
-	/**
-	 * Get all RadiologyReports fetched by radiologyOrder and radiologyReportStatus
-	 *
-	 * @param radiologyOrder RadiologyOrder for which the RadiologyReport should be fetched
-	 * @param reportStatus RadiologyReportStatus the RadiologyReport should have
-	 * @return List with RadiologyReport filtered by radiologyOrder and reportStatus
-	 * @throws IllegalArgumentException if given radiologyOrder is null
-	 * @throws IllegalArgumentException if given reportStatus is null
-	 * @should return a list of completed RadiologyReport if reportStatus is completed
-	 * @should return a list of claimed RadiologyReport if reportStatus is claimed
-	 * @should return a list of discontinued RadiologyReport if reportStatus is discontinued
-	 * @should return an empty list if there are no RadiologyReports for this radiologyOrder
-	 * @should throw an IllegalArgumentException if given radiologyOrder is null
-	 * @should throw an IllegalArgumentException if given reportStatus is null
-	 */
-	@Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
-	public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder radiologyOrder,
-			RadiologyReportStatus reportStatus) throws IllegalArgumentException;
-	
-	/**
-	 * Convenience method to check if a RadiologyOrder has a claimed RadiologyReport
-	 *
-	 * @param radiologyOrder RadiologyOrder the radiologyOrder which should be checked
-	 * @return true if RadiologyOrder has a claimed RadiologyReport, otherwise false and also if RadiologyOrder is null
-	 * @should return true if the RadiologyOrder has a claimed RadiologyReport
-	 * @should return false if the RadiologyOrder has no claimed RadiologyReport
-	 * @should return false if the RadiologyOrder is null
-	 */
-	@Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
-	public boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder);
-	
-	/**
-	 * Convenience method to check if a RadiologyOrder has a completed RadiologyReport
-	 *
-	 * @param radiologyOrder RadiologyOrder the radiologyOrder which should be checked
-	 * @return true if RadiologyOrder has a completed RadiologyReport, otherwise false
-	 * @throws IllegalArgumentException if radiologyOrder is null
-	 * @should return true if the RadiologyOrder has a completed RadiologyReport
-	 * @should return false if the RadiologyOrder has no completed RadiologyReport
-	 * @should throw an IllegalArgumentException if radiologyOrder is null
-	 */
-	@Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
-	public boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder);
-	
-	/**
-	 * Get the active (can be claimed or completed) RadiologyReport matching the radiologyOrder
-	 *
-	 * @param radiologyOrder RadiologyOrder the radiologyOrder which should be checked
-	 * @return RadiologyReport filtered by radiologyOrder and radiologyReportStatus not equal to
-	 *         discontinued
-	 * @throws IllegalArgumentException if radiologyOrder is null
-	 * @should return a RadiologyReport if the reportStatus is completed
-	 * @should return a RadiologyReport if the reportStatus is claimed
-	 * @should return null if
-	 * @should throw an IllegalArgumentException if radiologyOrder is null
-	 */
-	@Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
-	public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
+    
+    /**
+     * Creates a RadiologyReport and sets the radiologyReportStatus to claimed
+     *
+     * @param radiologyOrder RadiologyOrder
+     * @return a new claimed RadiologyReport
+     * @throws IllegalArgumentException if given RadiologyOrder is null
+     * @throws IllegalArgumentException if Study of given radiologyReport is null
+     * @throws IllegalArgumentException if Study of given RadiologyOrder is not completed
+     * @throws UnsupportedOperationException if given order has a completed RadiologyReport
+     * @throws UnsupportedOperationException if given order has a claimed RadiologyReport
+     * @should create a radiology order with report status claimed given a completed radiology order
+     * @should throw an illegal argument exception if given radiology order is null
+     * @should throw an illegal argument exception if given radiology order is not completed
+     * @should throw an UnsupportedOperationException if given order has a completed RadiologyReport
+     * @should throw an UnsupportedOperationException if given order has a claimed RadiologyReport
+     */
+    @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_REPORTS)
+    public RadiologyReport createAndClaimRadiologyReport(RadiologyOrder radiologyOrder) throws IllegalArgumentException,
+            UnsupportedOperationException;
+    
+    /**
+     * Save the given radiologyReport
+     *
+     * @param radiologyReport RadiologyReport to be saved
+     * @return the saved radiologyReport
+     * @throws IllegalArgumentException if radiologyReport is null
+     * @throws IllegalArgumentException if radiologyReportStatus is null
+     * @throws UnsupportedOperationException if radiologyReport is discontinued
+     * @throws UnsupportedOperationException if radiologyReport is completed
+     * @should save radiologyReport in database and return it
+     * @should throw an IllegalArgumentException if radiologyReport is null
+     * @should throw an IllegalArgumentException if radiologyReportStatus is null
+     * @should throw an UnsupportedOperationException if radiologyReport is discontinued
+     * @should throw an UnsupportedOperationException if radiologyReport is completed
+     */
+    @Authorized(RadiologyPrivileges.EDIT_RADIOLOGY_REPORTS)
+    public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
+            UnsupportedOperationException;
+    
+    /**
+     * Unclaims the given radiologyReport and sets the radiologyReportStatus to discontinued
+     *
+     * @param radiologyReport RadiologyReport to be unclaimed
+     * @return the discontinued RadiologyReport
+     * @throws IllegalArgumentException if radiologyReport is null
+     * @throws IllegalArgumentException if radiologyReportStatus is null
+     * @throws UnsupportedOperationException if radiologyReport is discontinued
+     * @throws UnsupportedOperationException if radiologyReport is completed
+     * @should set the radiologyReportStatus of radiologyReport to discontinued
+     * @should throw an IllegalArgumentException if radiologyReport is null
+     * @should throw an IllegalArgumentException if radiologyReportStatus is null
+     * @should throw an UnsupportedOperationException if radiologyReport is discontinued
+     * @should throw an UnsupportedOperationException if radiologyReport is completed
+     */
+    @Authorized(RadiologyPrivileges.DELETE_RADIOLOGY_REPORTS)
+    public RadiologyReport unclaimRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
+            UnsupportedOperationException;
+    
+    /**
+     * Completes the given radiologyReport and sets the radiologyReportStatus to completed
+     *
+     * @param radiologyReport RadiologyReport to be completed
+     * @param principalResultsInterpreter which the RadiologyReport should be set to
+     * @return completed RadiologyReport matching given radiologyReport with
+     *         principalResultsInterpreter
+     * @throws IllegalArgumentException if radiologyReport is null
+     * @throws IllegalArgumentException if principalResultsInterpreter is null
+     * @throws IllegalArgumentException if radiologyReportStatus is null
+     * @throws UnsupportedOperationException if radiologyReport is discontinued
+     * @throws UnsupportedOperationException if radiologyReport is completed
+     * @should set the reportDate of the radiologyReport to the day the RadiologyReport was
+     *         completed
+     * @should set the radiologyReportStatus to complete
+     * @should throw an IllegalArgumentException if principalResultsInterpreter is null
+     * @should throw an IllegalArgumentException if radiologyReport is null
+     * @should throw an IllegalArgumentException if radiologyReportStatus is null
+     * @should throw an UnsupportedOperationException if radiologyReport is discontinued
+     * @should throw an UnsupportedOperationException if radiologyReport is completed
+     */
+    @Authorized(RadiologyPrivileges.EDIT_RADIOLOGY_REPORTS)
+    public RadiologyReport completeRadiologyReport(RadiologyReport radiologyReport, Provider principalResultsInterpreter)
+            throws IllegalArgumentException, UnsupportedOperationException;
+    
+    /**
+     * Get a RadiologyReport matching the radiologyReportId
+     *
+     * @param radiologyReportId of RadiologyReport
+     * @return RadiologyReport matching given radiologyReportId
+     * @throws IllegalArgumentException if radiologyReportId is null
+     * @should fetch RadiologyReport matching given radiologyReportId
+     * @should throw IllegalArgumentException if radiologyReportId is null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
+    RadiologyReport getRadiologyReportByRadiologyReportId(Integer radiologyReportId) throws IllegalArgumentException;
+    
+    /**
+     * Get all RadiologyReports fetched by radiologyOrder and radiologyReportStatus
+     *
+     * @param radiologyOrder RadiologyOrder for which the RadiologyReport should be fetched
+     * @param reportStatus RadiologyReportStatus the RadiologyReport should have
+     * @return List with RadiologyReport filtered by radiologyOrder and reportStatus
+     * @throws IllegalArgumentException if given radiologyOrder is null
+     * @throws IllegalArgumentException if given reportStatus is null
+     * @should return a list of completed RadiologyReport if reportStatus is completed
+     * @should return a list of claimed RadiologyReport if reportStatus is claimed
+     * @should return a list of discontinued RadiologyReport if reportStatus is discontinued
+     * @should return an empty list if there are no RadiologyReports for this radiologyOrder
+     * @should throw an IllegalArgumentException if given radiologyOrder is null
+     * @should throw an IllegalArgumentException if given reportStatus is null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
+    public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder radiologyOrder,
+            RadiologyReportStatus reportStatus) throws IllegalArgumentException;
+    
+    /**
+     * Convenience method to check if a RadiologyOrder has a claimed RadiologyReport
+     *
+     * @param radiologyOrder RadiologyOrder the radiologyOrder which should be checked
+     * @return true if RadiologyOrder has a claimed RadiologyReport, otherwise false and also if RadiologyOrder is null
+     * @should return true if the RadiologyOrder has a claimed RadiologyReport
+     * @should return false if the RadiologyOrder has no claimed RadiologyReport
+     * @should return false if the RadiologyOrder is null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
+    public boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder);
+    
+    /**
+     * Convenience method to check if a RadiologyOrder has a completed RadiologyReport
+     *
+     * @param radiologyOrder RadiologyOrder the radiologyOrder which should be checked
+     * @return true if RadiologyOrder has a completed RadiologyReport, otherwise false
+     * @throws IllegalArgumentException if radiologyOrder is null
+     * @should return true if the RadiologyOrder has a completed RadiologyReport
+     * @should return false if the RadiologyOrder has no completed RadiologyReport
+     * @should throw an IllegalArgumentException if radiologyOrder is null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
+    public boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder);
+    
+    /**
+     * Get the active (can be claimed or completed) RadiologyReport matching the radiologyOrder
+     *
+     * @param radiologyOrder RadiologyOrder the radiologyOrder which should be checked
+     * @return RadiologyReport filtered by radiologyOrder and radiologyReportStatus not equal to
+     *         discontinued
+     * @throws IllegalArgumentException if radiologyOrder is null
+     * @should return a RadiologyReport if the reportStatus is completed
+     * @should return a RadiologyReport if the reportStatus is claimed
+     * @should return null if
+     * @should throw an IllegalArgumentException if radiologyOrder is null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
+    public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -13,185 +13,185 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 class RadiologyReportServiceImpl extends BaseOpenmrsService implements RadiologyReportService {
-	
-	private static final Log log = LogFactory.getLog(RadiologyReportServiceImpl.class);
-	
-	@Autowired
-	private RadiologyReportDAO radiologyReportDAO;
-	
-	/**
-	 * @see RadiologyReportService#createAndClaimRadiologyReport(RadiologyOrder)
-	 */
-	@Transactional
-	@Override
-	public RadiologyReport createAndClaimRadiologyReport(RadiologyOrder radiologyOrder) throws IllegalArgumentException,
-			UnsupportedOperationException {
-		
-		if (radiologyOrder == null) {
-			throw new IllegalArgumentException("radiologyOrder cannot be null");
-		}
-		if (radiologyOrder.isNotCompleted()) {
-			throw new IllegalArgumentException("radiologyOrder needs to be completed");
-		}
-		if (radiologyReportDAO.hasRadiologyOrderCompletedRadiologyReport(radiologyOrder)) {
-			throw new UnsupportedOperationException(
-					"cannot create radiologyReport for this radiologyOrder because it is already completed");
-		}
-		if (radiologyReportDAO.hasRadiologyOrderClaimedRadiologyReport(radiologyOrder)) {
-			throw new UnsupportedOperationException(
-					"cannot create radiologyReport for this radiologyOrder because it is already claimed");
-		}
-		final RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
-		return radiologyReportDAO.saveRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
-	 */
-	@Transactional
-	@Override
-	public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
-			UnsupportedOperationException {
-		
-		if (radiologyReport == null) {
-			throw new IllegalArgumentException("radiologyReport cannot be null");
-		}
-		if (radiologyReport.getReportStatus() == null) {
-			throw new IllegalArgumentException("radiologyReportStatus cannot be null");
-		}
-		if (radiologyReport.getReportStatus() == RadiologyReportStatus.DISCONTINUED) {
-			throw new UnsupportedOperationException("a discontinued radiologyReport cannot be saved");
-		}
-		if (radiologyReport.getReportStatus() == RadiologyReportStatus.COMPLETED) {
-			throw new UnsupportedOperationException("a completed radiologyReport cannot be saved");
-		}
-		return radiologyReportDAO.saveRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyReportService#unclaimRadiologyReport(RadiologyReport)
-	 */
-	@Transactional
-	@Override
-	public RadiologyReport unclaimRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
-			UnsupportedOperationException {
-		
-		if (radiologyReport == null) {
-			throw new IllegalArgumentException("radiologyReport cannot be null");
-		}
-		if (radiologyReport.getReportStatus() == null) {
-			throw new IllegalArgumentException("radiologyReportStatus cannot be null");
-		}
-		if (radiologyReport.getReportStatus() == RadiologyReportStatus.DISCONTINUED) {
-			throw new UnsupportedOperationException("a discontinued radiologyReport cannot be unclaimed");
-		}
-		if (radiologyReport.getReportStatus() == RadiologyReportStatus.COMPLETED) {
-			throw new UnsupportedOperationException("a completed radiologyReport cannot be unclaimed");
-		}
-		radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
-		return radiologyReportDAO.saveRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
-	 */
-	@Transactional
-	@Override
-	public RadiologyReport completeRadiologyReport(RadiologyReport radiologyReport, Provider principalResultsInterpreter)
-			throws IllegalArgumentException, UnsupportedOperationException {
-		
-		if (radiologyReport == null) {
-			throw new IllegalArgumentException("radiologyReport cannot be null");
-		}
-		if (principalResultsInterpreter == null) {
-			throw new IllegalArgumentException("principalResultsInterpreter cannot be null");
-		}
-		if (radiologyReport.getReportStatus() == null) {
-			throw new IllegalArgumentException("radiologyReportStatus cannot be null");
-		}
-		if (radiologyReport.getReportStatus() == RadiologyReportStatus.DISCONTINUED) {
-			throw new UnsupportedOperationException("a discontinued radiologyReport cannot be completed");
-		}
-		if (radiologyReport.getReportStatus() == RadiologyReportStatus.COMPLETED) {
-			throw new UnsupportedOperationException("a completed radiologyReport cannot be completed");
-		}
-		radiologyReport.setReportDate(new Date());
-		radiologyReport.setPrincipalResultsInterpreter(principalResultsInterpreter);
-		radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
-		return radiologyReportDAO.saveRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public RadiologyReport getRadiologyReportByRadiologyReportId(Integer radiologyReportId) throws IllegalArgumentException {
-		
-		if (radiologyReportId == null) {
-			throw new IllegalArgumentException("radiologyReportId cannot be null");
-		}
-		return radiologyReportDAO.getRadiologyReportById(radiologyReportId);
-	}
-	
-	/**
-	 * @see RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder, RadiologyReportStatus)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder radiologyOrder,
-			RadiologyReportStatus reportStatus) throws IllegalArgumentException {
-		
-		if (radiologyOrder == null) {
-			throw new IllegalArgumentException("radiologyOrder cannot be null");
-		}
-		if (reportStatus == null) {
-			throw new IllegalArgumentException("radiologyReportStatus cannot be null");
-		}
-		return radiologyReportDAO.getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(radiologyOrder, reportStatus)
-				.size() > 0 ? radiologyReportDAO.getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(radiologyOrder,
-			reportStatus) : new ArrayList<RadiologyReport>();
-	}
-	
-	/**
-	 * @see RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder) {
-		
-		return radiologyOrder == null ? false : radiologyReportDAO.hasRadiologyOrderClaimedRadiologyReport(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder) {
-		
-		if (radiologyOrder == null) {
-			throw new IllegalArgumentException("radiologyOrder cannot be null");
-		}
-		return radiologyReportDAO.hasRadiologyOrderCompletedRadiologyReport(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder) {
-		
-		if (radiologyOrder == null) {
-			throw new IllegalArgumentException("radiologyOrder cannot be null");
-		}
-		if (hasRadiologyOrderCompletedRadiologyReport(radiologyOrder)) {
-			return radiologyReportDAO.getActiveRadiologyReportByRadiologyOrder(radiologyOrder);
-		}
-		if (hasRadiologyOrderClaimedRadiologyReport(radiologyOrder)) {
-			return radiologyReportDAO.getActiveRadiologyReportByRadiologyOrder(radiologyOrder);
-		}
-		return null;
-	}
+    
+    private static final Log log = LogFactory.getLog(RadiologyReportServiceImpl.class);
+    
+    @Autowired
+    private RadiologyReportDAO radiologyReportDAO;
+    
+    /**
+     * @see RadiologyReportService#createAndClaimRadiologyReport(RadiologyOrder)
+     */
+    @Transactional
+    @Override
+    public RadiologyReport createAndClaimRadiologyReport(RadiologyOrder radiologyOrder) throws IllegalArgumentException,
+            UnsupportedOperationException {
+        
+        if (radiologyOrder == null) {
+            throw new IllegalArgumentException("radiologyOrder cannot be null");
+        }
+        if (radiologyOrder.isNotCompleted()) {
+            throw new IllegalArgumentException("radiologyOrder needs to be completed");
+        }
+        if (radiologyReportDAO.hasRadiologyOrderCompletedRadiologyReport(radiologyOrder)) {
+            throw new UnsupportedOperationException(
+                    "cannot create radiologyReport for this radiologyOrder because it is already completed");
+        }
+        if (radiologyReportDAO.hasRadiologyOrderClaimedRadiologyReport(radiologyOrder)) {
+            throw new UnsupportedOperationException(
+                    "cannot create radiologyReport for this radiologyOrder because it is already claimed");
+        }
+        final RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
+        return radiologyReportDAO.saveRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
+     */
+    @Transactional
+    @Override
+    public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
+            UnsupportedOperationException {
+        
+        if (radiologyReport == null) {
+            throw new IllegalArgumentException("radiologyReport cannot be null");
+        }
+        if (radiologyReport.getReportStatus() == null) {
+            throw new IllegalArgumentException("radiologyReportStatus cannot be null");
+        }
+        if (radiologyReport.getReportStatus() == RadiologyReportStatus.DISCONTINUED) {
+            throw new UnsupportedOperationException("a discontinued radiologyReport cannot be saved");
+        }
+        if (radiologyReport.getReportStatus() == RadiologyReportStatus.COMPLETED) {
+            throw new UnsupportedOperationException("a completed radiologyReport cannot be saved");
+        }
+        return radiologyReportDAO.saveRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @see RadiologyReportService#unclaimRadiologyReport(RadiologyReport)
+     */
+    @Transactional
+    @Override
+    public RadiologyReport unclaimRadiologyReport(RadiologyReport radiologyReport) throws IllegalArgumentException,
+            UnsupportedOperationException {
+        
+        if (radiologyReport == null) {
+            throw new IllegalArgumentException("radiologyReport cannot be null");
+        }
+        if (radiologyReport.getReportStatus() == null) {
+            throw new IllegalArgumentException("radiologyReportStatus cannot be null");
+        }
+        if (radiologyReport.getReportStatus() == RadiologyReportStatus.DISCONTINUED) {
+            throw new UnsupportedOperationException("a discontinued radiologyReport cannot be unclaimed");
+        }
+        if (radiologyReport.getReportStatus() == RadiologyReportStatus.COMPLETED) {
+            throw new UnsupportedOperationException("a completed radiologyReport cannot be unclaimed");
+        }
+        radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
+        return radiologyReportDAO.saveRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     */
+    @Transactional
+    @Override
+    public RadiologyReport completeRadiologyReport(RadiologyReport radiologyReport, Provider principalResultsInterpreter)
+            throws IllegalArgumentException, UnsupportedOperationException {
+        
+        if (radiologyReport == null) {
+            throw new IllegalArgumentException("radiologyReport cannot be null");
+        }
+        if (principalResultsInterpreter == null) {
+            throw new IllegalArgumentException("principalResultsInterpreter cannot be null");
+        }
+        if (radiologyReport.getReportStatus() == null) {
+            throw new IllegalArgumentException("radiologyReportStatus cannot be null");
+        }
+        if (radiologyReport.getReportStatus() == RadiologyReportStatus.DISCONTINUED) {
+            throw new UnsupportedOperationException("a discontinued radiologyReport cannot be completed");
+        }
+        if (radiologyReport.getReportStatus() == RadiologyReportStatus.COMPLETED) {
+            throw new UnsupportedOperationException("a completed radiologyReport cannot be completed");
+        }
+        radiologyReport.setReportDate(new Date());
+        radiologyReport.setPrincipalResultsInterpreter(principalResultsInterpreter);
+        radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
+        return radiologyReportDAO.saveRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public RadiologyReport getRadiologyReportByRadiologyReportId(Integer radiologyReportId) throws IllegalArgumentException {
+        
+        if (radiologyReportId == null) {
+            throw new IllegalArgumentException("radiologyReportId cannot be null");
+        }
+        return radiologyReportDAO.getRadiologyReportById(radiologyReportId);
+    }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder, RadiologyReportStatus)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder radiologyOrder,
+            RadiologyReportStatus reportStatus) throws IllegalArgumentException {
+        
+        if (radiologyOrder == null) {
+            throw new IllegalArgumentException("radiologyOrder cannot be null");
+        }
+        if (reportStatus == null) {
+            throw new IllegalArgumentException("radiologyReportStatus cannot be null");
+        }
+        return radiologyReportDAO.getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(radiologyOrder, reportStatus)
+                .size() > 0 ? radiologyReportDAO.getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(radiologyOrder,
+            reportStatus) : new ArrayList<RadiologyReport>();
+    }
+    
+    /**
+     * @see RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder) {
+        
+        return radiologyOrder == null ? false : radiologyReportDAO.hasRadiologyOrderClaimedRadiologyReport(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder) {
+        
+        if (radiologyOrder == null) {
+            throw new IllegalArgumentException("radiologyOrder cannot be null");
+        }
+        return radiologyReportDAO.hasRadiologyOrderCompletedRadiologyReport(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder) {
+        
+        if (radiologyOrder == null) {
+            throw new IllegalArgumentException("radiologyOrder cannot be null");
+        }
+        if (hasRadiologyOrderCompletedRadiologyReport(radiologyOrder)) {
+            return radiologyReportDAO.getActiveRadiologyReportByRadiologyOrder(radiologyOrder);
+        }
+        if (hasRadiologyOrderClaimedRadiologyReport(radiologyOrder)) {
+            return radiologyReportDAO.getActiveRadiologyReportByRadiologyOrder(radiologyOrder);
+        }
+        return null;
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportStatus.java
@@ -13,16 +13,16 @@ package org.openmrs.module.radiology.report;
  * RadiologyReportStatus represents a status for a radiologyReport
  */
 public enum RadiologyReportStatus {
-	/**
-	 * The report is completed and can be given to a patient.
-	 */
-	COMPLETED,
-	/**
-	 * The report is claimed by a physician and currently being worked on.
-	 */
-	CLAIMED,
-	/**
-	 * The report is discontinued and cannot be given to a patient.
-	 */
-	DISCONTINUED
+    /**
+     * The report is completed and can be given to a patient.
+     */
+    COMPLETED,
+    /**
+     * The report is claimed by a physician and currently being worked on.
+     */
+    CLAIMED,
+    /**
+     * The report is discontinued and cannot be given to a patient.
+     */
+    DISCONTINUED
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
@@ -21,36 +21,36 @@ import org.springframework.validation.Validator;
  */
 @Component
 public class RadiologyReportValidator implements Validator {
-	
-	/** Log for this class and subclasses */
-	protected final Log log = LogFactory.getLog(getClass());
-	
-	/**
-	 * Determines if the command object being submitted is a valid type
-	 *
-	 * @see org.springframework.validation.Validator#supports(java.lang.Class)
-	 * @should return true for RadiologyReport objects
-	 * @should return false for other object types
-	 */
-	public boolean supports(Class clazz) {
-		return RadiologyReport.class.isAssignableFrom(clazz);
-	}
-	
-	/**
-	 * Checks the form object for any inconsistencies/errors
-	 *
-	 * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
-	 * @should fail validation if radiologyReport is null
-	 * @should fail validation if principalResultsInterpreter is empty or whitespace
-	 * @should pass validation if all fields are correct
-	 */
-	public void validate(Object obj, Errors errors) {
-		RadiologyReport radiologyReport = (RadiologyReport) obj;
-		if (radiologyReport == null) {
-			errors.reject("error.general");
-		} else {
-			ValidationUtils.rejectIfEmptyOrWhitespace(errors, "principalResultsInterpreter", "error.null",
-				"Provider can not be null");
-		}
-	}
+    
+    /** Log for this class and subclasses */
+    protected final Log log = LogFactory.getLog(getClass());
+    
+    /**
+     * Determines if the command object being submitted is a valid type
+     *
+     * @see org.springframework.validation.Validator#supports(java.lang.Class)
+     * @should return true for RadiologyReport objects
+     * @should return false for other object types
+     */
+    public boolean supports(Class clazz) {
+        return RadiologyReport.class.isAssignableFrom(clazz);
+    }
+    
+    /**
+     * Checks the form object for any inconsistencies/errors
+     *
+     * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
+     * @should fail validation if radiologyReport is null
+     * @should fail validation if principalResultsInterpreter is empty or whitespace
+     * @should pass validation if all fields are correct
+     */
+    public void validate(Object obj, Errors errors) {
+        RadiologyReport radiologyReport = (RadiologyReport) obj;
+        if (radiologyReport == null) {
+            errors.reject("error.general");
+        } else {
+            ValidationUtils.rejectIfEmptyOrWhitespace(errors, "principalResultsInterpreter", "error.null",
+                "Provider can not be null");
+        }
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
@@ -28,92 +28,92 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 class HibernateRadiologyStudyDAO implements RadiologyStudyDAO {
-	
-	@Autowired
-	private SessionFactory sessionFactory;
-	
-	/**
-	 * Set session factory that allows us to connect to the database that Hibernate knows about.
-	 *
-	 * @param sessionFactory
-	 */
-	public void setSessionFactory(SessionFactory sessionFactory) {
-		this.sessionFactory = sessionFactory;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#saveStudy(RadiologyStudy)
-	 */
-	@Override
-	public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy) {
-		sessionFactory.getCurrentSession()
-				.saveOrUpdate(radiologyStudy);
-		return radiologyStudy;
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyId(Integer)
-	 */
-	@Override
-	public RadiologyStudy getStudyByStudyId(Integer studyId) {
-		return (RadiologyStudy) sessionFactory.getCurrentSession()
-				.get(RadiologyStudy.class, studyId);
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByOrderId(Integer)
-	 */
-	@Override
-	public RadiologyStudy getStudyByOrderId(Integer orderId) {
-		final String query = "from RadiologyStudy s where s.radiologyOrder.orderId = '" + orderId + "'";
-		return (RadiologyStudy) sessionFactory.getCurrentSession()
-				.createQuery(query)
-				.uniqueResult();
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyInstanceUid(String)
-	 */
-	@Override
-	public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid) {
-		return (RadiologyStudy) sessionFactory.getCurrentSession()
-				.createCriteria(RadiologyStudy.class)
-				.add(Restrictions.eq("studyInstanceUid", studyInstanceUid))
-				.uniqueResult();
-	}
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudiesByRadiologyOrders(List
-	 *      <RadiologyOrder> radiologyOrders)
-	 */
-	@SuppressWarnings("unchecked")
-	@Override
-	public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
-		List<RadiologyStudy> result = null;
-		if (!radiologyOrders.isEmpty()) {
-			final Criteria studyCriteria = sessionFactory.getCurrentSession()
-					.createCriteria(RadiologyStudy.class);
-			addRestrictionOnRadiologyOrders(studyCriteria, radiologyOrders);
-			result = (List<RadiologyStudy>) studyCriteria.list();
-		}
-		
-		if (result == null) {
-			return new ArrayList<RadiologyStudy>();
-		} else {
-			return result;
-		}
-	}
-	
-	/**
-	 * Adds an in restriction for given radiologyOrders on given criteria if radiologyOrders is not
-	 * empty
-	 *
-	 * @param criteria criteria on which in restriction is set if radiologyOrders is not empty
-	 * @param radiologyOrders radiology order list for which in restriction will be set
-	 */
-	private void addRestrictionOnRadiologyOrders(Criteria criteria, List<RadiologyOrder> radiologyOrders) {
-		if (!radiologyOrders.isEmpty()) {
-			criteria.add(Restrictions.in("radiologyOrder", radiologyOrders));
-		}
-	}
+    
+    @Autowired
+    private SessionFactory sessionFactory;
+    
+    /**
+     * Set session factory that allows us to connect to the database that Hibernate knows about.
+     *
+     * @param sessionFactory
+     */
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#saveStudy(RadiologyStudy)
+     */
+    @Override
+    public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy) {
+        sessionFactory.getCurrentSession()
+                .saveOrUpdate(radiologyStudy);
+        return radiologyStudy;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyId(Integer)
+     */
+    @Override
+    public RadiologyStudy getStudyByStudyId(Integer studyId) {
+        return (RadiologyStudy) sessionFactory.getCurrentSession()
+                .get(RadiologyStudy.class, studyId);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByOrderId(Integer)
+     */
+    @Override
+    public RadiologyStudy getStudyByOrderId(Integer orderId) {
+        final String query = "from RadiologyStudy s where s.radiologyOrder.orderId = '" + orderId + "'";
+        return (RadiologyStudy) sessionFactory.getCurrentSession()
+                .createQuery(query)
+                .uniqueResult();
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyInstanceUid(String)
+     */
+    @Override
+    public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid) {
+        return (RadiologyStudy) sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyStudy.class)
+                .add(Restrictions.eq("studyInstanceUid", studyInstanceUid))
+                .uniqueResult();
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudiesByRadiologyOrders(List
+     *      <RadiologyOrder> radiologyOrders)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
+        List<RadiologyStudy> result = null;
+        if (!radiologyOrders.isEmpty()) {
+            final Criteria studyCriteria = sessionFactory.getCurrentSession()
+                    .createCriteria(RadiologyStudy.class);
+            addRestrictionOnRadiologyOrders(studyCriteria, radiologyOrders);
+            result = (List<RadiologyStudy>) studyCriteria.list();
+        }
+        
+        if (result == null) {
+            return new ArrayList<RadiologyStudy>();
+        } else {
+            return result;
+        }
+    }
+    
+    /**
+     * Adds an in restriction for given radiologyOrders on given criteria if radiologyOrders is not
+     * empty
+     *
+     * @param criteria criteria on which in restriction is set if radiologyOrders is not empty
+     * @param radiologyOrders radiology order list for which in restriction will be set
+     */
+    private void addRestrictionOnRadiologyOrders(Criteria criteria, List<RadiologyOrder> radiologyOrders) {
+        if (!radiologyOrders.isEmpty()) {
+            criteria.add(Restrictions.in("radiologyOrder", radiologyOrders));
+        }
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudy.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudy.java
@@ -19,116 +19,116 @@ import org.openmrs.module.radiology.order.RadiologyOrder;
  * table order_dicom_complment
  */
 public class RadiologyStudy {
-	
-	private Integer studyId;
-	
-	private String studyInstanceUid;
-	
-	private RadiologyOrder radiologyOrder;
-	
-	private ScheduledProcedureStepStatus scheduledStatus;
-	
-	private PerformedProcedureStepStatus performedStatus;
-	
-	private Modality modality;
-	
-	public Integer getStudyId() {
-		return studyId;
-	}
-	
-	public Modality getModality() {
-		return modality;
-	}
-	
-	public RadiologyOrder getRadiologyOrder() {
-		return radiologyOrder;
-	}
-	
-	public PerformedProcedureStepStatus getPerformedStatus() {
-		return performedStatus;
-	}
-	
-	public ScheduledProcedureStepStatus getScheduledStatus() {
-		return scheduledStatus;
-	}
-	
-	public String getStudyInstanceUid() {
-		return studyInstanceUid;
-	}
-	
-	/**
-	 * Returns true when this RadiologyStudy's performedStatus is in progress and false otherwise.
-	 * 
-	 * @return true on performedStatus in progress and false otherwise
-	 * @should return false if performed status is null
-	 * @should return false if performed status is not in progress
-	 * @should return true if performed status is in progress
-	 */
-	public boolean isInProgress() {
-		return performedStatus == PerformedProcedureStepStatus.IN_PROGRESS;
-	}
-	
-	/**
-	 * Returns true when this RadiologyStudy's performedStatus is completed and false otherwise.
-	 * 
-	 * @return true on performedStatus completed and false otherwise
-	 * @should return false if performedStatus is null
-	 * @should return false if performedStatus is not completed
-	 * @should return true if performedStatus is completed
-	 */
-	public boolean isCompleted() {
-		return performedStatus == PerformedProcedureStepStatus.COMPLETED;
-	}
-	
-	/**
-	 * Returns true when this Study's performedStatus is null and false otherwise.
-	 *
-	 * @return true on performedStatus null and false otherwise
-	 * @should return true if performedStatus is null
-	 * @should return false if performedStatus is not null
-	 */
-	public boolean isScheduleable() {
-		return performedStatus == null;
-	}
-	
-	public void setStudyId(Integer studyId) {
-		this.studyId = studyId;
-	}
-	
-	public void setModality(Modality modality) {
-		this.modality = modality;
-	}
-	
-	public void setRadiologyOrder(RadiologyOrder radiologyOrder) {
-		this.radiologyOrder = radiologyOrder;
-	}
-	
-	public void setPerformedStatus(PerformedProcedureStepStatus performedStatus) {
-		this.performedStatus = performedStatus;
-	}
-	
-	public void setScheduledStatus(ScheduledProcedureStepStatus scheduledStatus) {
-		this.scheduledStatus = scheduledStatus;
-	}
-	
-	public void setStudyInstanceUid(String studyInstanceUid) {
-		this.studyInstanceUid = studyInstanceUid;
-	}
-	
-	/**
-	 * @see Object#toString()
-	 * @return String of Study
-	 * @should return string of study with null for members that are null
-	 * @should return string of study
-	 */
-	@Override
-	public String toString() {
-		
-		final StringBuilder result = new StringBuilder();
-		result.append("studyId: ")
-				.append(this.getStudyId())
-				.append(" studyInstanceUid: ")
-				.append(this.getStudyInstanceUid());
-		return result.toString();
-	}
+    
+    private Integer studyId;
+    
+    private String studyInstanceUid;
+    
+    private RadiologyOrder radiologyOrder;
+    
+    private ScheduledProcedureStepStatus scheduledStatus;
+    
+    private PerformedProcedureStepStatus performedStatus;
+    
+    private Modality modality;
+    
+    public Integer getStudyId() {
+        return studyId;
+    }
+    
+    public Modality getModality() {
+        return modality;
+    }
+    
+    public RadiologyOrder getRadiologyOrder() {
+        return radiologyOrder;
+    }
+    
+    public PerformedProcedureStepStatus getPerformedStatus() {
+        return performedStatus;
+    }
+    
+    public ScheduledProcedureStepStatus getScheduledStatus() {
+        return scheduledStatus;
+    }
+    
+    public String getStudyInstanceUid() {
+        return studyInstanceUid;
+    }
+    
+    /**
+     * Returns true when this RadiologyStudy's performedStatus is in progress and false otherwise.
+     * 
+     * @return true on performedStatus in progress and false otherwise
+     * @should return false if performed status is null
+     * @should return false if performed status is not in progress
+     * @should return true if performed status is in progress
+     */
+    public boolean isInProgress() {
+        return performedStatus == PerformedProcedureStepStatus.IN_PROGRESS;
+    }
+    
+    /**
+     * Returns true when this RadiologyStudy's performedStatus is completed and false otherwise.
+     * 
+     * @return true on performedStatus completed and false otherwise
+     * @should return false if performedStatus is null
+     * @should return false if performedStatus is not completed
+     * @should return true if performedStatus is completed
+     */
+    public boolean isCompleted() {
+        return performedStatus == PerformedProcedureStepStatus.COMPLETED;
+    }
+    
+    /**
+     * Returns true when this Study's performedStatus is null and false otherwise.
+     *
+     * @return true on performedStatus null and false otherwise
+     * @should return true if performedStatus is null
+     * @should return false if performedStatus is not null
+     */
+    public boolean isScheduleable() {
+        return performedStatus == null;
+    }
+    
+    public void setStudyId(Integer studyId) {
+        this.studyId = studyId;
+    }
+    
+    public void setModality(Modality modality) {
+        this.modality = modality;
+    }
+    
+    public void setRadiologyOrder(RadiologyOrder radiologyOrder) {
+        this.radiologyOrder = radiologyOrder;
+    }
+    
+    public void setPerformedStatus(PerformedProcedureStepStatus performedStatus) {
+        this.performedStatus = performedStatus;
+    }
+    
+    public void setScheduledStatus(ScheduledProcedureStepStatus scheduledStatus) {
+        this.scheduledStatus = scheduledStatus;
+    }
+    
+    public void setStudyInstanceUid(String studyInstanceUid) {
+        this.studyInstanceUid = studyInstanceUid;
+    }
+    
+    /**
+     * @see Object#toString()
+     * @return String of Study
+     * @should return string of study with null for members that are null
+     * @should return string of study
+     */
+    @Override
+    public String toString() {
+        
+        final StringBuilder result = new StringBuilder();
+        result.append("studyId: ")
+                .append(this.getStudyId())
+                .append(" studyInstanceUid: ")
+                .append(this.getStudyInstanceUid());
+        return result.toString();
+    }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyDAO.java
@@ -19,30 +19,30 @@ import org.openmrs.module.radiology.order.RadiologyOrder;
  * @see org.openmrs.module.radiology.study.RadiologyStudyService
  */
 interface RadiologyStudyDAO {
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#saveStudy(RadiologyStudy)
-	 */
-	public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy);
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyId(Integer)
-	 */
-	public RadiologyStudy getStudyByStudyId(Integer studyId);
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByOrderId(Integer)
-	 */
-	public RadiologyStudy getStudyByOrderId(Integer orderId);
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyInstanceUid(String)
-	 */
-	public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid);
-	
-	/**
-	 * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
-	 */
-	public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders);
-	
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#saveStudy(RadiologyStudy)
+     */
+    public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy);
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyId(Integer)
+     */
+    public RadiologyStudy getStudyByStudyId(Integer studyId);
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByOrderId(Integer)
+     */
+    public RadiologyStudy getStudyByOrderId(Integer orderId);
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudyByStudyInstanceUid(String)
+     */
+    public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid);
+    
+    /**
+     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
+     */
+    public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders);
+    
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
@@ -18,80 +18,80 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 public interface RadiologyStudyService extends OpenmrsService {
-	
-	/**
-	 * <p>
-	 * Save the given <code>RadiologyStudy</code> to the database
-	 * </p>
-	 * Additionally, study and study.order information are written into a DICOM xml file.
-	 * 
-	 * @param radiologyStudy study to be created or updated
-	 * @return study who was created or updated
-	 * @should create new study from given study object
-	 * @should update existing study
-	 */
-	public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy);
-	
-	/**
-	 * <p>
-	 * Update the performedStatus of the <code>RadiologyStudy</code> associated with studyInstanceUid in the database
-	 * </p>
-	 *
-	 * @param studyInstanceUid study instance uid of study whos performedStatus should be updated
-	 * @param performedStatus performed procedure step status to which study should be set to
-	 * @return study whos performedStatus was updated
-	 * @throws IllegalArgumentException if study instance uid is null
-	 * @should update performed status of study associated with given study instance uid
-	 * @should throw illegal argument exception if study instance uid is null
-	 * @should throw illegal argument exception if performed status is null
-	 */
-	public RadiologyStudy updateStudyPerformedStatus(String studyInstanceUid, PerformedProcedureStepStatus performedStatus)
-			throws IllegalArgumentException;
-	
-	/**
-	 * Get RadiologyStudy by studyId
-	 *
-	 * @param studyId of the study
-	 * @return study associated with studyId
-	 * @should return study for given study id
-	 * @should return null if no match was found
-	 */
-	public RadiologyStudy getStudyByStudyId(Integer studyId);
-	
-	/**
-	 * Get RadiologyStudy by its associated RadiologyOrder's orderId
-	 *
-	 * @param orderId of RadiologyOrder associated with wanted RadiologyStudy
-	 * @return RadiologyStudy associated with RadiologyOrder for which orderId is given
-	 * @throws IllegalArgumentException if order id is null
-	 * @should return study associated with radiology order for which order id is given
-	 * @should return null if no match was found
-	 * @should throw illegal argument exception given null
-	 */
-	public RadiologyStudy getStudyByOrderId(Integer orderId) throws IllegalArgumentException;
-	
-	/**
-	 * Get RadiologyStudy by its Study Instance UID
-	 *
-	 * @param studyInstanceUid
-	 * @return study
-	 * @should return study matching study instance uid
-	 * @should return null if no match was found
-	 * @should throw IllegalArgumentException if study instance uid is null
-	 */
-	public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid) throws IllegalArgumentException;
-	
-	/**
-	 * Get all studies corresponding to list of RadiologyOrder's
-	 *
-	 * @param radiologyOrders radiology orders for which studies will be returned
-	 * @return studies corresponding to given radiology orders
-	 * @throws IllegalArgumentException
-	 * @should fetch all studies for given radiology orders
-	 * @should return empty list given radiology orders without associated studies
-	 * @should return empty list given empty radiology order list
-	 * @should throw IllegalArgumentException given null
-	 */
-	public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders)
-			throws IllegalArgumentException;
+    
+    /**
+     * <p>
+     * Save the given <code>RadiologyStudy</code> to the database
+     * </p>
+     * Additionally, study and study.order information are written into a DICOM xml file.
+     * 
+     * @param radiologyStudy study to be created or updated
+     * @return study who was created or updated
+     * @should create new study from given study object
+     * @should update existing study
+     */
+    public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy);
+    
+    /**
+     * <p>
+     * Update the performedStatus of the <code>RadiologyStudy</code> associated with studyInstanceUid in the database
+     * </p>
+     *
+     * @param studyInstanceUid study instance uid of study whos performedStatus should be updated
+     * @param performedStatus performed procedure step status to which study should be set to
+     * @return study whos performedStatus was updated
+     * @throws IllegalArgumentException if study instance uid is null
+     * @should update performed status of study associated with given study instance uid
+     * @should throw illegal argument exception if study instance uid is null
+     * @should throw illegal argument exception if performed status is null
+     */
+    public RadiologyStudy updateStudyPerformedStatus(String studyInstanceUid, PerformedProcedureStepStatus performedStatus)
+            throws IllegalArgumentException;
+    
+    /**
+     * Get RadiologyStudy by studyId
+     *
+     * @param studyId of the study
+     * @return study associated with studyId
+     * @should return study for given study id
+     * @should return null if no match was found
+     */
+    public RadiologyStudy getStudyByStudyId(Integer studyId);
+    
+    /**
+     * Get RadiologyStudy by its associated RadiologyOrder's orderId
+     *
+     * @param orderId of RadiologyOrder associated with wanted RadiologyStudy
+     * @return RadiologyStudy associated with RadiologyOrder for which orderId is given
+     * @throws IllegalArgumentException if order id is null
+     * @should return study associated with radiology order for which order id is given
+     * @should return null if no match was found
+     * @should throw illegal argument exception given null
+     */
+    public RadiologyStudy getStudyByOrderId(Integer orderId) throws IllegalArgumentException;
+    
+    /**
+     * Get RadiologyStudy by its Study Instance UID
+     *
+     * @param studyInstanceUid
+     * @return study
+     * @should return study matching study instance uid
+     * @should return null if no match was found
+     * @should throw IllegalArgumentException if study instance uid is null
+     */
+    public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid) throws IllegalArgumentException;
+    
+    /**
+     * Get all studies corresponding to list of RadiologyOrder's
+     *
+     * @param radiologyOrders radiology orders for which studies will be returned
+     * @return studies corresponding to given radiology orders
+     * @throws IllegalArgumentException
+     * @should fetch all studies for given radiology orders
+     * @should return empty list given radiology orders without associated studies
+     * @should return empty list given empty radiology order list
+     * @should throw IllegalArgumentException given null
+     */
+    public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders)
+            throws IllegalArgumentException;
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
@@ -22,108 +22,108 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyStudyService {
-	
-	private static final Log log = LogFactory.getLog(RadiologyStudyServiceImpl.class);
-	
-	@Autowired
-	private RadiologyStudyDAO radiologyStudyDAO;
-	
-	@Autowired
-	private RadiologyProperties radiologyProperties;
-	
-	/**
-	 * @see RadiologyStudyService#saveStudy(RadiologyStudy)
-	 */
-	@Override
-	@Transactional
-	public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy) {
-		
-		final RadiologyOrder order = radiologyStudy.getRadiologyOrder();
-		
-		if (radiologyStudy.getScheduledStatus() == null && order.getScheduledDate() != null) {
-			radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
-		}
-		
-		try {
-			RadiologyStudy savedStudy = radiologyStudyDAO.saveStudy(radiologyStudy);
-			final String studyInstanceUid = radiologyProperties.getStudyPrefix() + savedStudy.getStudyId();
-			savedStudy.setStudyInstanceUid(studyInstanceUid);
-			savedStudy = radiologyStudyDAO.saveStudy(savedStudy);
-			return savedStudy;
-		}
-		catch (Exception e) {
-			log.error(e.getMessage(), e);
-			log.warn("Can not save study in openmrs or dmc4che.");
-		}
-		return null;
-	}
-	
-	/**
-	 * @see RadiologyStudyService#updateStudyPerformedStatus(String, PerformedProcedureStepStatus)
-	 */
-	@Transactional
-	@Override
-	public RadiologyStudy updateStudyPerformedStatus(String studyInstanceUid, PerformedProcedureStepStatus performedStatus)
-			throws IllegalArgumentException {
-		
-		if (studyInstanceUid == null) {
-			throw new IllegalArgumentException("studyInstanceUid is required");
-		}
-		
-		if (performedStatus == null) {
-			throw new IllegalArgumentException("performedStatus is required");
-		}
-		
-		final RadiologyStudy studyToBeUpdated = radiologyStudyDAO.getStudyByStudyInstanceUid(studyInstanceUid);
-		studyToBeUpdated.setPerformedStatus(performedStatus);
-		return radiologyStudyDAO.saveStudy(studyToBeUpdated);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByStudyId(Integer)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public RadiologyStudy getStudyByStudyId(Integer studyId) {
-		return radiologyStudyDAO.getStudyByStudyId(studyId);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByOrderId(Integer)
-	 */
-	@Transactional(readOnly = true)
-	@Override
-	public RadiologyStudy getStudyByOrderId(Integer orderId) {
-		if (orderId == null) {
-			throw new IllegalArgumentException("orderId is required");
-		}
-		
-		return radiologyStudyDAO.getStudyByOrderId(orderId);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
-	 */
-	@Transactional(readOnly = true)
-	public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid) {
-		if (studyInstanceUid == null) {
-			throw new IllegalArgumentException("studyInstanceUid is required");
-		}
-		
-		return radiologyStudyDAO.getStudyByStudyInstanceUid(studyInstanceUid);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
-	 */
-	@Override
-	@Transactional(readOnly = true)
-	public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
-		if (radiologyOrders == null) {
-			throw new IllegalArgumentException("radiologyOrders are required");
-		}
-		
-		final List<RadiologyStudy> result = radiologyStudyDAO.getStudiesByRadiologyOrders(radiologyOrders);
-		return result;
-	}
+    
+    private static final Log log = LogFactory.getLog(RadiologyStudyServiceImpl.class);
+    
+    @Autowired
+    private RadiologyStudyDAO radiologyStudyDAO;
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    /**
+     * @see RadiologyStudyService#saveStudy(RadiologyStudy)
+     */
+    @Override
+    @Transactional
+    public RadiologyStudy saveStudy(RadiologyStudy radiologyStudy) {
+        
+        final RadiologyOrder order = radiologyStudy.getRadiologyOrder();
+        
+        if (radiologyStudy.getScheduledStatus() == null && order.getScheduledDate() != null) {
+            radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
+        }
+        
+        try {
+            RadiologyStudy savedStudy = radiologyStudyDAO.saveStudy(radiologyStudy);
+            final String studyInstanceUid = radiologyProperties.getStudyPrefix() + savedStudy.getStudyId();
+            savedStudy.setStudyInstanceUid(studyInstanceUid);
+            savedStudy = radiologyStudyDAO.saveStudy(savedStudy);
+            return savedStudy;
+        }
+        catch (Exception e) {
+            log.error(e.getMessage(), e);
+            log.warn("Can not save study in openmrs or dmc4che.");
+        }
+        return null;
+    }
+    
+    /**
+     * @see RadiologyStudyService#updateStudyPerformedStatus(String, PerformedProcedureStepStatus)
+     */
+    @Transactional
+    @Override
+    public RadiologyStudy updateStudyPerformedStatus(String studyInstanceUid, PerformedProcedureStepStatus performedStatus)
+            throws IllegalArgumentException {
+        
+        if (studyInstanceUid == null) {
+            throw new IllegalArgumentException("studyInstanceUid is required");
+        }
+        
+        if (performedStatus == null) {
+            throw new IllegalArgumentException("performedStatus is required");
+        }
+        
+        final RadiologyStudy studyToBeUpdated = radiologyStudyDAO.getStudyByStudyInstanceUid(studyInstanceUid);
+        studyToBeUpdated.setPerformedStatus(performedStatus);
+        return radiologyStudyDAO.saveStudy(studyToBeUpdated);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByStudyId(Integer)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public RadiologyStudy getStudyByStudyId(Integer studyId) {
+        return radiologyStudyDAO.getStudyByStudyId(studyId);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByOrderId(Integer)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public RadiologyStudy getStudyByOrderId(Integer orderId) {
+        if (orderId == null) {
+            throw new IllegalArgumentException("orderId is required");
+        }
+        
+        return radiologyStudyDAO.getStudyByOrderId(orderId);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
+     */
+    @Transactional(readOnly = true)
+    public RadiologyStudy getStudyByStudyInstanceUid(String studyInstanceUid) {
+        if (studyInstanceUid == null) {
+            throw new IllegalArgumentException("studyInstanceUid is required");
+        }
+        
+        return radiologyStudyDAO.getStudyByStudyInstanceUid(studyInstanceUid);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<RadiologyStudy> getStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
+        if (radiologyOrders == null) {
+            throw new IllegalArgumentException("radiologyOrders are required");
+        }
+        
+        final List<RadiologyStudy> result = radiologyStudyDAO.getStudiesByRadiologyOrders(radiologyOrders);
+        return result;
+    }
 }

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -35,7 +35,8 @@
 	<bean parent="serviceContext">
 		<property name="moduleService">
 			<list merge="true">
-				<value>org.openmrs.module.radiology.order.RadiologyOrderService</value>
+				<value>org.openmrs.module.radiology.order.RadiologyOrderService
+				</value>
 				<ref local="radiologyOrderService" />
 			</list>
 		</property>
@@ -47,8 +48,7 @@
 			<ref bean="transactionManager" />
 		</property>
 		<property name="target">
-			<bean
-				class="org.openmrs.module.radiology.study.RadiologyStudyServiceImpl">
+			<bean class="org.openmrs.module.radiology.study.RadiologyStudyServiceImpl">
 			</bean>
 		</property>
 		<property name="preInterceptors">
@@ -62,7 +62,8 @@
 	<bean parent="serviceContext">
 		<property name="moduleService">
 			<list merge="true">
-				<value>org.openmrs.module.radiology.study.RadiologyStudyService</value>
+				<value>org.openmrs.module.radiology.study.RadiologyStudyService
+				</value>
 				<ref local="radiologyStudyService" />
 			</list>
 		</property>
@@ -89,7 +90,8 @@
 	<bean parent="serviceContext">
 		<property name="moduleService">
 			<list merge="true">
-				<value>org.openmrs.module.radiology.report.RadiologyReportService</value>
+				<value>org.openmrs.module.radiology.report.RadiologyReportService
+				</value>
 				<ref local="radiologyReportService" />
 			</list>
 		</property>

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyEncounterMatcherComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyEncounterMatcherComponentTest.java
@@ -20,116 +20,116 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Tests {@link RadiologyEncounterMatcher}
  */
 public class RadiologyEncounterMatcherComponentTest extends BaseModuleContextSensitiveTest {
-	
-	private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyEncounterMatcherComponentTestDataset.xml";
-	
-	private static final int VISIT_ID_WITH_NON_VOIDED_ENCOUNTER = 3003;
-	
-	private static final int VISIT_ID_WITHOUT_ENCOUNTER = 3001;
-	
-	private static final int VISIT_ID_WITH_VOIDED_ENCOUNTER = 3002;
-	
-	private static final String NON_VOIDED_ENCOUNTER_UUID = "7f2dad34-f5a5-11e5-b84b-08002719a237";
-	
-	private static final String VOIDED_ENCOUNTER_UUID = "60db560a-f5a3-11e5-b84b-08002719a237";
-	
-	@Autowired
-	private RadiologyEncounterMatcher radiologyEncounterMatcher;
-	
-	@Autowired
-	private VisitService visitService;
-	
-	@Autowired
-	private RadiologyProperties radiologyProperties;
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	@Before
-	public void setUp() throws Exception {
-		executeDataSet(TEST_DATASET);
-	}
-	
-	/**
-	 * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
-	 * @verifies return encounter if encounter uuid given by encounter parameters is attached to given visit and is not
-	 *           voided
-	 */
-	@Test
-	public void findEncounter_shouldReturnEncounterIfEncounterUuidGivenByEncounterParametersIsAttachedToGivenVisitAndIsNotVoided()
-			throws Exception {
-		// given
-		EncounterParameters encounterParameters = EncounterParameters.instance()
-				.setEncounterType(radiologyProperties.getRadiologyOrderEncounterType())
-				.setEncounterUuid(NON_VOIDED_ENCOUNTER_UUID);
-		Visit visit = visitService.getVisit(VISIT_ID_WITH_NON_VOIDED_ENCOUNTER);
-		
-		Encounter encounter = radiologyEncounterMatcher.findEncounter(visit, encounterParameters);
-		
-		assertThat(encounter, is(notNullValue()));
-		assertThat(encounter.getUuid(), is(NON_VOIDED_ENCOUNTER_UUID));
-	}
-	
-	/**
-	 * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
-	 * @verifies return null given visit without non voided encounters
-	 */
-	@Test
-	public void findEncounter_shouldReturnNullGivenVisitWithoutNonVoidedEncounters() throws Exception {
-		// given
-		EncounterParameters encounterParameters = EncounterParameters.instance()
-				.setEncounterType(radiologyProperties.getRadiologyOrderEncounterType());
-		Visit visit = visitService.getVisit(VISIT_ID_WITHOUT_ENCOUNTER);
-		
-		Encounter encounter = radiologyEncounterMatcher.findEncounter(visit, encounterParameters);
-		
-		assertThat(encounter, is(nullValue()));
-	}
-	
-	/**
-	 * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
-	 * @verifies return null if encounter uuid given by encounter parameters is voided
-	 */
-	@Test
-	public void findEncounter_shouldReturnNullIfEncounterUuidGivenByEncounterParametersIsVoided() throws Exception {
-		// given
-		EncounterParameters encounterParameters = EncounterParameters.instance()
-				.setEncounterType(radiologyProperties.getRadiologyOrderEncounterType())
-				.setEncounterUuid(VOIDED_ENCOUNTER_UUID);
-		Visit visit = visitService.getVisit(VISIT_ID_WITH_VOIDED_ENCOUNTER);
-		
-		Encounter encounter = radiologyEncounterMatcher.findEncounter(visit, encounterParameters);
-		
-		assertThat(encounter, is(nullValue()));
-	}
-	
-	/**
-	 * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
-	 * @verifies throw illegal argument exception if given visit is null
-	 */
-	@Test
-	public void findEncounter_shouldThrowIllegalArgumentExceptionIfGivenVisitIsNull() throws Exception {
-		// given
-		EncounterParameters encounterParameters = EncounterParameters.instance()
-				.setEncounterType(radiologyProperties.getRadiologyOrderEncounterType())
-				.setEncounterUuid(VOIDED_ENCOUNTER_UUID);
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("visit is required");
-		radiologyEncounterMatcher.findEncounter(null, encounterParameters);
-	}
-	
-	/**
-	 * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
-	 * @verifies throw illegal argument exception if given encounterParameters is null
-	 */
-	@Test
-	public void findEncounter_shouldThrowIllegalArgumentExceptionIfGivenEncounterParametersIsNull() throws Exception {
-		// given
-		Visit visit = visitService.getVisit(VISIT_ID_WITH_VOIDED_ENCOUNTER);
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("encounterParameters are required");
-		radiologyEncounterMatcher.findEncounter(visit, null);
-	}
+    
+    private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyEncounterMatcherComponentTestDataset.xml";
+    
+    private static final int VISIT_ID_WITH_NON_VOIDED_ENCOUNTER = 3003;
+    
+    private static final int VISIT_ID_WITHOUT_ENCOUNTER = 3001;
+    
+    private static final int VISIT_ID_WITH_VOIDED_ENCOUNTER = 3002;
+    
+    private static final String NON_VOIDED_ENCOUNTER_UUID = "7f2dad34-f5a5-11e5-b84b-08002719a237";
+    
+    private static final String VOIDED_ENCOUNTER_UUID = "60db560a-f5a3-11e5-b84b-08002719a237";
+    
+    @Autowired
+    private RadiologyEncounterMatcher radiologyEncounterMatcher;
+    
+    @Autowired
+    private VisitService visitService;
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    @Before
+    public void setUp() throws Exception {
+        executeDataSet(TEST_DATASET);
+    }
+    
+    /**
+     * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
+     * @verifies return encounter if encounter uuid given by encounter parameters is attached to given visit and is not
+     *           voided
+     */
+    @Test
+    public void findEncounter_shouldReturnEncounterIfEncounterUuidGivenByEncounterParametersIsAttachedToGivenVisitAndIsNotVoided()
+            throws Exception {
+        // given
+        EncounterParameters encounterParameters = EncounterParameters.instance()
+                .setEncounterType(radiologyProperties.getRadiologyOrderEncounterType())
+                .setEncounterUuid(NON_VOIDED_ENCOUNTER_UUID);
+        Visit visit = visitService.getVisit(VISIT_ID_WITH_NON_VOIDED_ENCOUNTER);
+        
+        Encounter encounter = radiologyEncounterMatcher.findEncounter(visit, encounterParameters);
+        
+        assertThat(encounter, is(notNullValue()));
+        assertThat(encounter.getUuid(), is(NON_VOIDED_ENCOUNTER_UUID));
+    }
+    
+    /**
+     * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
+     * @verifies return null given visit without non voided encounters
+     */
+    @Test
+    public void findEncounter_shouldReturnNullGivenVisitWithoutNonVoidedEncounters() throws Exception {
+        // given
+        EncounterParameters encounterParameters = EncounterParameters.instance()
+                .setEncounterType(radiologyProperties.getRadiologyOrderEncounterType());
+        Visit visit = visitService.getVisit(VISIT_ID_WITHOUT_ENCOUNTER);
+        
+        Encounter encounter = radiologyEncounterMatcher.findEncounter(visit, encounterParameters);
+        
+        assertThat(encounter, is(nullValue()));
+    }
+    
+    /**
+     * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
+     * @verifies return null if encounter uuid given by encounter parameters is voided
+     */
+    @Test
+    public void findEncounter_shouldReturnNullIfEncounterUuidGivenByEncounterParametersIsVoided() throws Exception {
+        // given
+        EncounterParameters encounterParameters = EncounterParameters.instance()
+                .setEncounterType(radiologyProperties.getRadiologyOrderEncounterType())
+                .setEncounterUuid(VOIDED_ENCOUNTER_UUID);
+        Visit visit = visitService.getVisit(VISIT_ID_WITH_VOIDED_ENCOUNTER);
+        
+        Encounter encounter = radiologyEncounterMatcher.findEncounter(visit, encounterParameters);
+        
+        assertThat(encounter, is(nullValue()));
+    }
+    
+    /**
+     * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
+     * @verifies throw illegal argument exception if given visit is null
+     */
+    @Test
+    public void findEncounter_shouldThrowIllegalArgumentExceptionIfGivenVisitIsNull() throws Exception {
+        // given
+        EncounterParameters encounterParameters = EncounterParameters.instance()
+                .setEncounterType(radiologyProperties.getRadiologyOrderEncounterType())
+                .setEncounterUuid(VOIDED_ENCOUNTER_UUID);
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("visit is required");
+        radiologyEncounterMatcher.findEncounter(null, encounterParameters);
+    }
+    
+    /**
+     * @see RadiologyEncounterMatcher#findEncounter(Visit,EncounterParameters)
+     * @verifies throw illegal argument exception if given encounterParameters is null
+     */
+    @Test
+    public void findEncounter_shouldThrowIllegalArgumentExceptionIfGivenEncounterParametersIsNull() throws Exception {
+        // given
+        Visit visit = visitService.getVisit(VISIT_ID_WITH_VOIDED_ENCOUNTER);
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("encounterParameters are required");
+        radiologyEncounterMatcher.findEncounter(visit, null);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
@@ -37,497 +37,497 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * Tests {@link RadiologyProperties}
  */
 public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitiveTest {
-	
-	@Autowired
-	@Qualifier("adminService")
-	private AdministrationService administrationService;
-	
-	@Autowired
-	private OrderService orderService;
-	
-	@Autowired
-	private RadiologyProperties radiologyProperties;
-	
-	@Autowired
-	private EncounterService encounterService;
-	
-	@Autowired
-	private ConceptService conceptService;
-	
-	@Autowired
-	private VisitService visitService;
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	/**
-	 * @see RadiologyProperties#getDicomUIDOrgRoot()
-	 * @verifies return dicom uid org root
-	 */
-	@Test
-	public void getDicomUIDOrgRoot_shouldReturnDicomUidOrgRoot() throws Exception {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_ORG_ROOT,
-				"1.2.826.0.1.3680043.8.2186"));
-		
-		assertThat(radiologyProperties.getDicomUIDOrgRoot(), is("1.2.826.0.1.3680043.8.2186"));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomUIDOrgRoot()
-	 * @verifies throw illegal state exception if global property for dicom uid org root cannot be found
-	 */
-	@Test
-	public void getDicomUIDOrgRoot_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomUidOrgRootCannotBeFound()
-			throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_UID_ORG_ROOT);
-		
-		radiologyProperties.getDicomUIDOrgRoot();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomUIDApplication()
-	 * @verifies return dicom uid application
-	 */
-	@Test
-	public void getDicomUIDApplication_shouldReturnDicomUidApplication() throws Exception {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_APPLICATION, "1"));
-		
-		assertThat(radiologyProperties.getDicomUIDApplication(), is("1"));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomUIDApplication()
-	 * @verifies throw illegal state exception if global property for dicom uid application cannot be found
-	 */
-	@Test
-	public void getDicomUIDApplication_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomUidApplicationCannotBeFound()
-			throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_UID_APPLICATION);
-		
-		radiologyProperties.getDicomUIDApplication();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomUIDTypeStudy()
-	 * @verifies return dicom uid type study
-	 */
-	@Test
-	public void getDicomUIDTypeStudy_shouldReturnDicomUidTypeStudy() throws Exception {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_TYPE_STUDY, "1"));
-		
-		assertThat(radiologyProperties.getDicomUIDTypeStudy(), is("1"));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomUIDTypeStudy()
-	 * @verifies throw illegal state exception if global property for dicom uid type study cannot be found
-	 */
-	@Test
-	public void getDicomUIDTypeStudy_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomUidTypeStudyCannotBeFound()
-			throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_UID_TYPE_STUDY);
-		
-		radiologyProperties.getDicomUIDTypeStudy();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getStudyPrefix()
-	 * @verifies return study prefix consisting of org root and application uid and study uid slug
-	 */
-	@Test
-	public void getStudyPrefix_shouldReturnStudyPrefixConsistingofApplicationUidAndStudyUidSlug() {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_ORG_ROOT,
-				"1.2.826.0.1.3680043.8.2186"));
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_APPLICATION, "1"));
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_TYPE_STUDY, "1"));
-		
-		assertThat(radiologyProperties.getStudyPrefix(), is("1.2.826.0.1.3680043.8.2186.1.1."));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomWebViewerAddress()
-	 * @verifies return dicom web viewer address
-	 */
-	@Test
-	public void getDicomWebViewerAddress_shouldReturnDicomWebViewerAddress() throws Exception {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_ADDRESS,
-				"localhost"));
-		
-		assertThat(radiologyProperties.getDicomWebViewerAddress(), is("localhost"));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomWebViewerAddress()
-	 * @verifies throw illegal state exception if global property for dicom web viewer address
-	 *           cannot be found
-	 */
-	@Test
-	public void getDicomWebViewerAddress_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomWebViewerAddressCannotBeFound()
-			throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_WEB_VIEWER_ADDRESS);
-		
-		radiologyProperties.getDicomWebViewerAddress();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomWebViewerPort()
-	 * @verifies return dicom web viewer port
-	 */
-	@Test
-	public void getDicomWebViewerPort_shouldReturnDicomWebViewerPort() throws Exception {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_PORT, "8081"));
-		
-		assertThat(radiologyProperties.getDicomWebViewerPort(), is("8081"));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomWebViewerPort()
-	 * @verifies throw illegal state exception if global property for dicom web viewer port cannot
-	 *           be found
-	 */
-	@Test
-	public void getDicomWebViewerPort_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomWebViewerPortCannotBeFound()
-			throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_WEB_VIEWER_PORT);
-		
-		radiologyProperties.getDicomWebViewerPort();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomWebViewerBaseUrl()
-	 * @verifies return dicom web viewer base url
-	 */
-	@Test
-	public void getDicomWebViewerBaseUrl_shouldReturnDicomWebViewerBaseUrl() throws Exception {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_BASE_URL,
-				"/weasis-pacs-connector/viewer"));
-		
-		assertThat(radiologyProperties.getDicomWebViewerBaseUrl(), is("/weasis-pacs-connector/viewer"));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomWebViewerBaseUrl()
-	 * @verifies throw illegal state exception if global property for dicom web viewer base url
-	 *           cannot be found
-	 */
-	@Test
-	public void getDicomWebViewerBaseUrl_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomWebViewerBaseUrlCannotBeFound()
-			throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_WEB_VIEWER_BASE_URL);
-		
-		radiologyProperties.getDicomWebViewerBaseUrl();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getDicomWebViewerLocalServerName()
-	 * @verifies return dicom web viewer local server name
-	 */
-	@Test
-	public void getDicomWebViewerLocalServerName_shouldReturnDicomWebViewerLocalServerName() throws Exception {
-		
-		administrationService.saveGlobalProperty(new GlobalProperty(
-				RadiologyConstants.GP_DICOM_WEB_VIEWER_LOCAL_SERVER_NAME, "oviyamlocal"));
-		
-		assertThat(radiologyProperties.getDicomWebViewerLocalServerName(), is("oviyamlocal"));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyCareSetting()
-	 * @verifies return radiology care setting
-	 */
-	@Test
-	public void getRadiologyCareSetting_shouldReturnRadiologyCareSetting() {
-		
-		String outpatientCareSettingUuidInOpenMrsCore = "6f0c9a92-6f24-11e3-af88-005056821db0";
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_CARE_SETTING,
-				outpatientCareSettingUuidInOpenMrsCore));
-		
-		assertThat(radiologyProperties.getRadiologyCareSetting()
-				.getUuid(), is(outpatientCareSettingUuidInOpenMrsCore));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyCareSetting()
-	 * @verifies throw illegal state exception if global property for radiology care setting cannot
-	 *           be found
-	 */
-	@Test
-	public void getRadiologyCareSetting_shouldThrowIllegalStateExceptionIfGlobalPropertyForRadiologyCareSettingCannotBeFound()
-			throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_CARE_SETTING);
-		
-		radiologyProperties.getRadiologyCareSetting();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyCareSetting()
-	 * @verifies throw illegal state exception if radiology care setting cannot be found
-	 */
-	@Test
-	public void getRadiologyCareSetting_shouldThrowIllegalStateExceptionIfRadiologyCareSettingCannotBeFound() {
-		
-		String nonExistingCareSettingUuid = "5a1b8b43-6f24-11e3-af99-005056821db0";
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_CARE_SETTING,
-				nonExistingCareSettingUuid));
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("No existing care setting for uuid: " + RadiologyConstants.GP_RADIOLOGY_CARE_SETTING);
-		
-		radiologyProperties.getRadiologyCareSetting();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyTestOrderType()
-	 * @verifies return order type for radiology test orders
-	 */
-	@Test
-	public void getRadiologyTestOrderType_shouldReturnOrderTypeForRadiologyTestOrders() {
-		
-		String radiologyTestOrderTypeUuid = "dbdb9a9b-56ea-11e5-a47f-08002719a237";
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_TEST_ORDER_TYPE,
-				radiologyTestOrderTypeUuid));
-		
-		OrderType radiologyOrderType = new OrderType("Radiology Order", "Order type for radiology exams",
-				"org.openmrs.module.radiology.order.RadiologyOrder");
-		radiologyOrderType.setUuid(radiologyTestOrderTypeUuid);
-		orderService.saveOrderType(radiologyOrderType);
-		
-		assertThat(radiologyProperties.getRadiologyTestOrderType()
-				.getName(), is("Radiology Order"));
-		assertThat(radiologyProperties.getRadiologyTestOrderType()
-				.getUuid(), is(radiologyTestOrderTypeUuid));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyTestOrderType()
-	 * @verifies throw illegal state exception for non existing radiology test order type
-	 */
-	@Test
-	public void getRadiologyTestOrderType_shouldThrowIllegalStateExceptionForNonExistingRadiologyTestOrderType() {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_TEST_ORDER_TYPE);
-		
-		radiologyProperties.getRadiologyTestOrderType();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyOrderEncounterType()
-	 * @verifies return encounter type for radiology orders
-	 */
-	@Test
-	public void getRadiologyOrderEncounterType_shouldReturnEncounterTypeForRadiologyOrders() {
-		
-		String radiologyEncounterTypeUuid = "19db8c0d-3520-48f2-babd-77f2d450e5c7";
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE,
-				radiologyEncounterTypeUuid));
-		
-		EncounterType encounterType = new EncounterType("Radiology Order Encounter", "Ordering radiology exams");
-		encounterType.setUuid(radiologyEncounterTypeUuid);
-		encounterService.saveEncounterType(encounterType);
-		
-		assertThat(radiologyProperties.getRadiologyOrderEncounterType()
-				.getName(), is("Radiology Order Encounter"));
-		assertThat(radiologyProperties.getRadiologyOrderEncounterType()
-				.getUuid(), is(radiologyEncounterTypeUuid));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyOrderEncounterType()
-	 * @verifies throw illegal state exception for non existing radiology encounter type
-	 */
-	@Test
-	public void getRadiologyOrderEncounterType_shouldThrowIllegalStateExceptionForNonExistingRadiologyEncounterType() {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE);
-		
-		radiologyProperties.getRadiologyOrderEncounterType();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyOrderingProviderEncounterRole()
-	 * @verifies return encounter role for ordering provider
-	 */
-	@Test
-	public void getRadiologyOrderingProviderEncounterRole_shouldReturnEncounterRoleForOrderingProvider() throws Exception {
-		
-		String radiologyOrderingProviderEncounterRoleUuid = "13fc9b4a-49ed-429c-9dde-ca005b387a3d";
-		administrationService.saveGlobalProperty(new GlobalProperty(
-				RadiologyConstants.GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE, radiologyOrderingProviderEncounterRoleUuid));
-		
-		EncounterRole encounterRole = new EncounterRole();
-		encounterRole.setName("Radiology Ordering Provider Encounter Role");
-		encounterRole.setUuid(radiologyOrderingProviderEncounterRoleUuid);
-		encounterService.saveEncounterRole(encounterRole);
-		
-		assertThat(radiologyProperties.getRadiologyOrderingProviderEncounterRole()
-				.getName(), is("Radiology Ordering Provider Encounter Role"));
-		assertThat(radiologyProperties.getRadiologyOrderingProviderEncounterRole()
-				.getUuid(), is(radiologyOrderingProviderEncounterRoleUuid));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyOrderingProviderEncounterRole()
-	 * @verifies throw illegal state exception for non existing ordering provider encounter role
-	 */
-	@Test
-	public void getRadiologyOrderingProviderEncounterRole_shouldThrowIllegalStateExceptionForNonExistingOrderingProviderEncounterRole()
-			throws Exception {
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: "
-				+ RadiologyConstants.GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE);
-		
-		radiologyProperties.getRadiologyOrderingProviderEncounterRole();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyVisitType()
-	 * @verifies return visit type for radiology orders
-	 */
-	@Test
-	public void getRadiologyVisitType_shouldReturnVisitTypeForRadiologyOrders() throws Exception {
-		
-		String radiologyVisitTypeUuid = "fe898a34-1ade-11e1-9c71-00248140a5eb";
-		administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_VISIT_TYPE,
-				radiologyVisitTypeUuid));
-		
-		VisitType visitType = new VisitType();
-		visitType.setName("Radiology Visit");
-		visitType.setUuid(radiologyVisitTypeUuid);
-		visitService.saveVisitType(visitType);
-		
-		assertThat(radiologyProperties.getRadiologyVisitType()
-				.getName(), is("Radiology Visit"));
-		assertThat(radiologyProperties.getRadiologyVisitType()
-				.getUuid(), is(radiologyVisitTypeUuid));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyVisitType()
-	 * @verifies throw illegal state exception for non existing radiology visit type
-	 */
-	@Test
-	public void getRadiologyVisitType_shouldThrowIllegalStateExceptionForNonExistingRadiologyVisitType() throws Exception {
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_VISIT_TYPE);
-		
-		radiologyProperties.getRadiologyVisitType();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyConceptClassNames()
-	 * @verifies returns comma separated list of ConceptClass names configured via ConceptClass
-	 *           UUIDs in global property radiologyConceptClasses
-	 */
-	@Test
-	public void getRadiologyConceptClassNames_shouldReturnsCommaSeparatedListOfConceptClassNamesConfiguredViaConceptClassUUIDsInGlobalPropertyRadiologyConceptClasses()
-			throws Exception {
-		List<ConceptClass> conceptClasses = new LinkedList<ConceptClass>();
-		conceptClasses.add(conceptService.getConceptClassByName("Drug"));
-		conceptClasses.add(conceptService.getConceptClassByName("Test"));
-		conceptClasses.add(conceptService.getConceptClassByName("Anatomy"));
-		conceptClasses.add(conceptService.getConceptClassByName("Question"));
-		String uuidFromConceptClasses = "";
-		String expectedNames = "";
-		for (ConceptClass conceptClass : conceptClasses) {
-			if (expectedNames.equals("")) {
-				uuidFromConceptClasses = conceptClass.getUuid();
-				expectedNames = conceptClass.getName();
-			}
-			uuidFromConceptClasses = uuidFromConceptClasses + "," + conceptClass.getUuid();
-			expectedNames = expectedNames + "," + conceptClass.getName();
-		}
-		administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES, uuidFromConceptClasses);
-		assertThat(radiologyProperties.getRadiologyConceptClassNames(), is(expectedNames));
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyConceptClassNames()
-	 * @verifies throw illegal state exception if global property radiologyConceptClasses is null
-	 */
-	@Test
-	public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesIsNull()
-			throws Exception {
-		administrationService.setGlobalProperty("radiology.radiologyConceptClasses", null);
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: radiology.radiologyConceptClasses");
-		
-		radiologyProperties.getRadiologyConceptClassNames();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyConceptClassNames()
-	 * @verifies throw illegal state exception if global property radiologyConceptClasses is an
-	 *           empty String
-	 */
-	@Test
-	public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesIsAnEmptyString()
-			throws Exception {
-		administrationService.setGlobalProperty("radiology.radiologyConceptClasses", "");
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Configuration required: radiology.radiologyConceptClasses");
-		
-		radiologyProperties.getRadiologyConceptClassNames();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyConceptClassNames()
-	 * @verifies throw illegal state exception if global property radiologyConceptClasses is badly
-	 *           formatted
-	 */
-	@Test
-	public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesIsBadlyFormatted()
-			throws Exception {
-		administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES,
-			"AAAA-bbbbb-1111-2222/AAAA-BBBB-2222-3333");
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Property radiology.radiologyConcepts needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
-		
-		radiologyProperties.getRadiologyConceptClassNames();
-	}
-	
-	/**
-	 * @see RadiologyProperties#getRadiologyConceptClassNames()
-	 * @verifies throw illegal state exception if global property radiologyConceptClasses contains a
-	 *           UUID not found among ConceptClasses
-	 */
-	@Test
-	public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesContainsAUUIDNotFoundAmongConceptClasses()
-			throws Exception {
-		
-		administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES,
-			conceptService.getConceptClassByName("Drug")
-					.getUuid() + "5");
-		
-		expectedException.expect(IllegalStateException.class);
-		expectedException.expectMessage("Property radiology.radiologyConceptClasses contains UUID");
-		
-		radiologyProperties.getRadiologyConceptClassNames();
-	}
+    
+    @Autowired
+    @Qualifier("adminService")
+    private AdministrationService administrationService;
+    
+    @Autowired
+    private OrderService orderService;
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    @Autowired
+    private EncounterService encounterService;
+    
+    @Autowired
+    private ConceptService conceptService;
+    
+    @Autowired
+    private VisitService visitService;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    /**
+     * @see RadiologyProperties#getDicomUIDOrgRoot()
+     * @verifies return dicom uid org root
+     */
+    @Test
+    public void getDicomUIDOrgRoot_shouldReturnDicomUidOrgRoot() throws Exception {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_ORG_ROOT,
+                "1.2.826.0.1.3680043.8.2186"));
+        
+        assertThat(radiologyProperties.getDicomUIDOrgRoot(), is("1.2.826.0.1.3680043.8.2186"));
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomUIDOrgRoot()
+     * @verifies throw illegal state exception if global property for dicom uid org root cannot be found
+     */
+    @Test
+    public void getDicomUIDOrgRoot_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomUidOrgRootCannotBeFound()
+            throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_UID_ORG_ROOT);
+        
+        radiologyProperties.getDicomUIDOrgRoot();
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomUIDApplication()
+     * @verifies return dicom uid application
+     */
+    @Test
+    public void getDicomUIDApplication_shouldReturnDicomUidApplication() throws Exception {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_APPLICATION, "1"));
+        
+        assertThat(radiologyProperties.getDicomUIDApplication(), is("1"));
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomUIDApplication()
+     * @verifies throw illegal state exception if global property for dicom uid application cannot be found
+     */
+    @Test
+    public void getDicomUIDApplication_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomUidApplicationCannotBeFound()
+            throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_UID_APPLICATION);
+        
+        radiologyProperties.getDicomUIDApplication();
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomUIDTypeStudy()
+     * @verifies return dicom uid type study
+     */
+    @Test
+    public void getDicomUIDTypeStudy_shouldReturnDicomUidTypeStudy() throws Exception {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_TYPE_STUDY, "1"));
+        
+        assertThat(radiologyProperties.getDicomUIDTypeStudy(), is("1"));
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomUIDTypeStudy()
+     * @verifies throw illegal state exception if global property for dicom uid type study cannot be found
+     */
+    @Test
+    public void getDicomUIDTypeStudy_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomUidTypeStudyCannotBeFound()
+            throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_UID_TYPE_STUDY);
+        
+        radiologyProperties.getDicomUIDTypeStudy();
+    }
+    
+    /**
+     * @see RadiologyProperties#getStudyPrefix()
+     * @verifies return study prefix consisting of org root and application uid and study uid slug
+     */
+    @Test
+    public void getStudyPrefix_shouldReturnStudyPrefixConsistingofApplicationUidAndStudyUidSlug() {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_ORG_ROOT,
+                "1.2.826.0.1.3680043.8.2186"));
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_APPLICATION, "1"));
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_UID_TYPE_STUDY, "1"));
+        
+        assertThat(radiologyProperties.getStudyPrefix(), is("1.2.826.0.1.3680043.8.2186.1.1."));
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomWebViewerAddress()
+     * @verifies return dicom web viewer address
+     */
+    @Test
+    public void getDicomWebViewerAddress_shouldReturnDicomWebViewerAddress() throws Exception {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_ADDRESS,
+                "localhost"));
+        
+        assertThat(radiologyProperties.getDicomWebViewerAddress(), is("localhost"));
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomWebViewerAddress()
+     * @verifies throw illegal state exception if global property for dicom web viewer address
+     *           cannot be found
+     */
+    @Test
+    public void getDicomWebViewerAddress_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomWebViewerAddressCannotBeFound()
+            throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_WEB_VIEWER_ADDRESS);
+        
+        radiologyProperties.getDicomWebViewerAddress();
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomWebViewerPort()
+     * @verifies return dicom web viewer port
+     */
+    @Test
+    public void getDicomWebViewerPort_shouldReturnDicomWebViewerPort() throws Exception {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_PORT, "8081"));
+        
+        assertThat(radiologyProperties.getDicomWebViewerPort(), is("8081"));
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomWebViewerPort()
+     * @verifies throw illegal state exception if global property for dicom web viewer port cannot
+     *           be found
+     */
+    @Test
+    public void getDicomWebViewerPort_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomWebViewerPortCannotBeFound()
+            throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_WEB_VIEWER_PORT);
+        
+        radiologyProperties.getDicomWebViewerPort();
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomWebViewerBaseUrl()
+     * @verifies return dicom web viewer base url
+     */
+    @Test
+    public void getDicomWebViewerBaseUrl_shouldReturnDicomWebViewerBaseUrl() throws Exception {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_DICOM_WEB_VIEWER_BASE_URL,
+                "/weasis-pacs-connector/viewer"));
+        
+        assertThat(radiologyProperties.getDicomWebViewerBaseUrl(), is("/weasis-pacs-connector/viewer"));
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomWebViewerBaseUrl()
+     * @verifies throw illegal state exception if global property for dicom web viewer base url
+     *           cannot be found
+     */
+    @Test
+    public void getDicomWebViewerBaseUrl_shouldThrowIllegalStateExceptionIfGlobalPropertyForDicomWebViewerBaseUrlCannotBeFound()
+            throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_DICOM_WEB_VIEWER_BASE_URL);
+        
+        radiologyProperties.getDicomWebViewerBaseUrl();
+    }
+    
+    /**
+     * @see RadiologyProperties#getDicomWebViewerLocalServerName()
+     * @verifies return dicom web viewer local server name
+     */
+    @Test
+    public void getDicomWebViewerLocalServerName_shouldReturnDicomWebViewerLocalServerName() throws Exception {
+        
+        administrationService.saveGlobalProperty(new GlobalProperty(
+                RadiologyConstants.GP_DICOM_WEB_VIEWER_LOCAL_SERVER_NAME, "oviyamlocal"));
+        
+        assertThat(radiologyProperties.getDicomWebViewerLocalServerName(), is("oviyamlocal"));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyCareSetting()
+     * @verifies return radiology care setting
+     */
+    @Test
+    public void getRadiologyCareSetting_shouldReturnRadiologyCareSetting() {
+        
+        String outpatientCareSettingUuidInOpenMrsCore = "6f0c9a92-6f24-11e3-af88-005056821db0";
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_CARE_SETTING,
+                outpatientCareSettingUuidInOpenMrsCore));
+        
+        assertThat(radiologyProperties.getRadiologyCareSetting()
+                .getUuid(), is(outpatientCareSettingUuidInOpenMrsCore));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyCareSetting()
+     * @verifies throw illegal state exception if global property for radiology care setting cannot
+     *           be found
+     */
+    @Test
+    public void getRadiologyCareSetting_shouldThrowIllegalStateExceptionIfGlobalPropertyForRadiologyCareSettingCannotBeFound()
+            throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_CARE_SETTING);
+        
+        radiologyProperties.getRadiologyCareSetting();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyCareSetting()
+     * @verifies throw illegal state exception if radiology care setting cannot be found
+     */
+    @Test
+    public void getRadiologyCareSetting_shouldThrowIllegalStateExceptionIfRadiologyCareSettingCannotBeFound() {
+        
+        String nonExistingCareSettingUuid = "5a1b8b43-6f24-11e3-af99-005056821db0";
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_CARE_SETTING,
+                nonExistingCareSettingUuid));
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("No existing care setting for uuid: " + RadiologyConstants.GP_RADIOLOGY_CARE_SETTING);
+        
+        radiologyProperties.getRadiologyCareSetting();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyTestOrderType()
+     * @verifies return order type for radiology test orders
+     */
+    @Test
+    public void getRadiologyTestOrderType_shouldReturnOrderTypeForRadiologyTestOrders() {
+        
+        String radiologyTestOrderTypeUuid = "dbdb9a9b-56ea-11e5-a47f-08002719a237";
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_TEST_ORDER_TYPE,
+                radiologyTestOrderTypeUuid));
+        
+        OrderType radiologyOrderType = new OrderType("Radiology Order", "Order type for radiology exams",
+                "org.openmrs.module.radiology.order.RadiologyOrder");
+        radiologyOrderType.setUuid(radiologyTestOrderTypeUuid);
+        orderService.saveOrderType(radiologyOrderType);
+        
+        assertThat(radiologyProperties.getRadiologyTestOrderType()
+                .getName(), is("Radiology Order"));
+        assertThat(radiologyProperties.getRadiologyTestOrderType()
+                .getUuid(), is(radiologyTestOrderTypeUuid));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyTestOrderType()
+     * @verifies throw illegal state exception for non existing radiology test order type
+     */
+    @Test
+    public void getRadiologyTestOrderType_shouldThrowIllegalStateExceptionForNonExistingRadiologyTestOrderType() {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_TEST_ORDER_TYPE);
+        
+        radiologyProperties.getRadiologyTestOrderType();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderEncounterType()
+     * @verifies return encounter type for radiology orders
+     */
+    @Test
+    public void getRadiologyOrderEncounterType_shouldReturnEncounterTypeForRadiologyOrders() {
+        
+        String radiologyEncounterTypeUuid = "19db8c0d-3520-48f2-babd-77f2d450e5c7";
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE,
+                radiologyEncounterTypeUuid));
+        
+        EncounterType encounterType = new EncounterType("Radiology Order Encounter", "Ordering radiology exams");
+        encounterType.setUuid(radiologyEncounterTypeUuid);
+        encounterService.saveEncounterType(encounterType);
+        
+        assertThat(radiologyProperties.getRadiologyOrderEncounterType()
+                .getName(), is("Radiology Order Encounter"));
+        assertThat(radiologyProperties.getRadiologyOrderEncounterType()
+                .getUuid(), is(radiologyEncounterTypeUuid));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderEncounterType()
+     * @verifies throw illegal state exception for non existing radiology encounter type
+     */
+    @Test
+    public void getRadiologyOrderEncounterType_shouldThrowIllegalStateExceptionForNonExistingRadiologyEncounterType() {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_ORDER_ENCOUNTER_TYPE);
+        
+        radiologyProperties.getRadiologyOrderEncounterType();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderingProviderEncounterRole()
+     * @verifies return encounter role for ordering provider
+     */
+    @Test
+    public void getRadiologyOrderingProviderEncounterRole_shouldReturnEncounterRoleForOrderingProvider() throws Exception {
+        
+        String radiologyOrderingProviderEncounterRoleUuid = "13fc9b4a-49ed-429c-9dde-ca005b387a3d";
+        administrationService.saveGlobalProperty(new GlobalProperty(
+                RadiologyConstants.GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE, radiologyOrderingProviderEncounterRoleUuid));
+        
+        EncounterRole encounterRole = new EncounterRole();
+        encounterRole.setName("Radiology Ordering Provider Encounter Role");
+        encounterRole.setUuid(radiologyOrderingProviderEncounterRoleUuid);
+        encounterService.saveEncounterRole(encounterRole);
+        
+        assertThat(radiologyProperties.getRadiologyOrderingProviderEncounterRole()
+                .getName(), is("Radiology Ordering Provider Encounter Role"));
+        assertThat(radiologyProperties.getRadiologyOrderingProviderEncounterRole()
+                .getUuid(), is(radiologyOrderingProviderEncounterRoleUuid));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderingProviderEncounterRole()
+     * @verifies throw illegal state exception for non existing ordering provider encounter role
+     */
+    @Test
+    public void getRadiologyOrderingProviderEncounterRole_shouldThrowIllegalStateExceptionForNonExistingOrderingProviderEncounterRole()
+            throws Exception {
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: "
+                + RadiologyConstants.GP_RADIOLOGY_ORDERING_PROVIDER_ENCOUNTER_ROLE);
+        
+        radiologyProperties.getRadiologyOrderingProviderEncounterRole();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyVisitType()
+     * @verifies return visit type for radiology orders
+     */
+    @Test
+    public void getRadiologyVisitType_shouldReturnVisitTypeForRadiologyOrders() throws Exception {
+        
+        String radiologyVisitTypeUuid = "fe898a34-1ade-11e1-9c71-00248140a5eb";
+        administrationService.saveGlobalProperty(new GlobalProperty(RadiologyConstants.GP_RADIOLOGY_VISIT_TYPE,
+                radiologyVisitTypeUuid));
+        
+        VisitType visitType = new VisitType();
+        visitType.setName("Radiology Visit");
+        visitType.setUuid(radiologyVisitTypeUuid);
+        visitService.saveVisitType(visitType);
+        
+        assertThat(radiologyProperties.getRadiologyVisitType()
+                .getName(), is("Radiology Visit"));
+        assertThat(radiologyProperties.getRadiologyVisitType()
+                .getUuid(), is(radiologyVisitTypeUuid));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyVisitType()
+     * @verifies throw illegal state exception for non existing radiology visit type
+     */
+    @Test
+    public void getRadiologyVisitType_shouldThrowIllegalStateExceptionForNonExistingRadiologyVisitType() throws Exception {
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: " + RadiologyConstants.GP_RADIOLOGY_VISIT_TYPE);
+        
+        radiologyProperties.getRadiologyVisitType();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyConceptClassNames()
+     * @verifies returns comma separated list of ConceptClass names configured via ConceptClass
+     *           UUIDs in global property radiologyConceptClasses
+     */
+    @Test
+    public void getRadiologyConceptClassNames_shouldReturnsCommaSeparatedListOfConceptClassNamesConfiguredViaConceptClassUUIDsInGlobalPropertyRadiologyConceptClasses()
+            throws Exception {
+        List<ConceptClass> conceptClasses = new LinkedList<ConceptClass>();
+        conceptClasses.add(conceptService.getConceptClassByName("Drug"));
+        conceptClasses.add(conceptService.getConceptClassByName("Test"));
+        conceptClasses.add(conceptService.getConceptClassByName("Anatomy"));
+        conceptClasses.add(conceptService.getConceptClassByName("Question"));
+        String uuidFromConceptClasses = "";
+        String expectedNames = "";
+        for (ConceptClass conceptClass : conceptClasses) {
+            if (expectedNames.equals("")) {
+                uuidFromConceptClasses = conceptClass.getUuid();
+                expectedNames = conceptClass.getName();
+            }
+            uuidFromConceptClasses = uuidFromConceptClasses + "," + conceptClass.getUuid();
+            expectedNames = expectedNames + "," + conceptClass.getName();
+        }
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES, uuidFromConceptClasses);
+        assertThat(radiologyProperties.getRadiologyConceptClassNames(), is(expectedNames));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyConceptClassNames()
+     * @verifies throw illegal state exception if global property radiologyConceptClasses is null
+     */
+    @Test
+    public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesIsNull()
+            throws Exception {
+        administrationService.setGlobalProperty("radiology.radiologyConceptClasses", null);
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: radiology.radiologyConceptClasses");
+        
+        radiologyProperties.getRadiologyConceptClassNames();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyConceptClassNames()
+     * @verifies throw illegal state exception if global property radiologyConceptClasses is an
+     *           empty String
+     */
+    @Test
+    public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesIsAnEmptyString()
+            throws Exception {
+        administrationService.setGlobalProperty("radiology.radiologyConceptClasses", "");
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Configuration required: radiology.radiologyConceptClasses");
+        
+        radiologyProperties.getRadiologyConceptClassNames();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyConceptClassNames()
+     * @verifies throw illegal state exception if global property radiologyConceptClasses is badly
+     *           formatted
+     */
+    @Test
+    public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesIsBadlyFormatted()
+            throws Exception {
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES,
+            "AAAA-bbbbb-1111-2222/AAAA-BBBB-2222-3333");
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Property radiology.radiologyConcepts needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
+        
+        radiologyProperties.getRadiologyConceptClassNames();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyConceptClassNames()
+     * @verifies throw illegal state exception if global property radiologyConceptClasses contains a
+     *           UUID not found among ConceptClasses
+     */
+    @Test
+    public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesContainsAUUIDNotFoundAmongConceptClasses()
+            throws Exception {
+        
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES,
+            conceptService.getConceptClassByName("Drug")
+                    .getUuid() + "5");
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Property radiology.radiologyConceptClasses contains UUID");
+        
+        radiologyProperties.getRadiologyConceptClassNames();
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/DicomWebViewerTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/DicomWebViewerTest.java
@@ -18,80 +18,80 @@ import org.openmrs.test.BaseContextMockTest;
  * Tests {@link DicomWebViewer}
  */
 public class DicomWebViewerTest extends BaseContextMockTest {
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	@Mock
-	private RadiologyProperties radiologyProperties;
-	
-	@InjectMocks
-	private DicomWebViewer dicomviewer = new DicomWebViewer();
-	
-	@Before
-	public void setUp() {
-		when(radiologyProperties.getDicomWebViewerAddress()).thenReturn("localhost");
-		when(radiologyProperties.getDicomWebViewerPort()).thenReturn("8081");
-		when(radiologyProperties.getDicomWebViewerBaseUrl()).thenReturn("/weasis-pacs-connector/viewer");
-	}
-	
-	/**
-	 * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
-	 * @verifies return a url to open dicom images of the given study in the configured dicom viewer
-	 */
-	@Test
-	public void getDicomViewerUrl_shouldReturnAUrlToOpenDicomImagesOfTheGivenStudyInTheConfiguredDicomViewer() {
-		RadiologyStudy radiologyStudy = getMockStudy();
-		assertThat(dicomviewer.getDicomViewerUrl(radiologyStudy),
-			is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=" + radiologyStudy.getStudyInstanceUid()));
-	}
-	
-	RadiologyStudy getMockStudy() {
-		RadiologyStudy mockStudy = new RadiologyStudy();
-		mockStudy.setStudyId(1);
-		mockStudy.setStudyInstanceUid("1.2.826.0.1.3680043.8.2186.1.1");
-		
-		return mockStudy;
-	}
-	
-	/**
-	 * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
-	 * @verifies add query param server name to url if local server name is not blank
-	 */
-	@Test
-	public void getDicomViewerUrl_shouldAddQueryParamServerNameToUrlIfLocalServerNameIsNotBlank() {
-		
-		when(radiologyProperties.getDicomWebViewerBaseUrl()).thenReturn("/oviyam2/viewer.html");
-		when(radiologyProperties.getDicomWebViewerLocalServerName()).thenReturn("oviyamlocal");
-		
-		RadiologyStudy radiologyStudy = getMockStudy();
-		
-		assertThat(dicomviewer.getDicomViewerUrl(radiologyStudy), is("http://localhost:8081/oviyam2/viewer.html?studyUID="
-				+ radiologyStudy.getStudyInstanceUid() + "&serverName=oviyamlocal"));
-	}
-	
-	/**
-	 * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
-	 * @verifies throw an illegal argument exception given null
-	 */
-	@Test
-	public void getDicomViewerUrl_shouldThrowAnIllegalArgumentExceptionGivenNull() throws Exception {
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage(is("study cannot be null"));
-		dicomviewer.getDicomViewerUrl(null);
-	}
-	
-	/**
-	 * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
-	 * @verifies throw an illegal argument exception given study with studyInstanceUid null
-	 */
-	@Test
-	public void getDicomViewerUrl_shouldThrowAnIllegalArgumentExceptionGivenAStudyWithStudyInstanceUidNull()
-			throws Exception {
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage(is("studyInstanceUid cannot be null"));
-		dicomviewer.getDicomViewerUrl(radiologyStudy);
-	}
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    @Mock
+    private RadiologyProperties radiologyProperties;
+    
+    @InjectMocks
+    private DicomWebViewer dicomviewer = new DicomWebViewer();
+    
+    @Before
+    public void setUp() {
+        when(radiologyProperties.getDicomWebViewerAddress()).thenReturn("localhost");
+        when(radiologyProperties.getDicomWebViewerPort()).thenReturn("8081");
+        when(radiologyProperties.getDicomWebViewerBaseUrl()).thenReturn("/weasis-pacs-connector/viewer");
+    }
+    
+    /**
+     * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
+     * @verifies return a url to open dicom images of the given study in the configured dicom viewer
+     */
+    @Test
+    public void getDicomViewerUrl_shouldReturnAUrlToOpenDicomImagesOfTheGivenStudyInTheConfiguredDicomViewer() {
+        RadiologyStudy radiologyStudy = getMockStudy();
+        assertThat(dicomviewer.getDicomViewerUrl(radiologyStudy),
+            is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=" + radiologyStudy.getStudyInstanceUid()));
+    }
+    
+    RadiologyStudy getMockStudy() {
+        RadiologyStudy mockStudy = new RadiologyStudy();
+        mockStudy.setStudyId(1);
+        mockStudy.setStudyInstanceUid("1.2.826.0.1.3680043.8.2186.1.1");
+        
+        return mockStudy;
+    }
+    
+    /**
+     * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
+     * @verifies add query param server name to url if local server name is not blank
+     */
+    @Test
+    public void getDicomViewerUrl_shouldAddQueryParamServerNameToUrlIfLocalServerNameIsNotBlank() {
+        
+        when(radiologyProperties.getDicomWebViewerBaseUrl()).thenReturn("/oviyam2/viewer.html");
+        when(radiologyProperties.getDicomWebViewerLocalServerName()).thenReturn("oviyamlocal");
+        
+        RadiologyStudy radiologyStudy = getMockStudy();
+        
+        assertThat(dicomviewer.getDicomViewerUrl(radiologyStudy), is("http://localhost:8081/oviyam2/viewer.html?studyUID="
+                + radiologyStudy.getStudyInstanceUid() + "&serverName=oviyamlocal"));
+    }
+    
+    /**
+     * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
+     * @verifies throw an illegal argument exception given null
+     */
+    @Test
+    public void getDicomViewerUrl_shouldThrowAnIllegalArgumentExceptionGivenNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(is("study cannot be null"));
+        dicomviewer.getDicomViewerUrl(null);
+    }
+    
+    /**
+     * @see DicomWebViewer#getDicomViewerUrl(RadiologyStudy)
+     * @verifies throw an illegal argument exception given study with studyInstanceUid null
+     */
+    @Test
+    public void getDicomViewerUrl_shouldThrowAnIllegalArgumentExceptionGivenAStudyWithStudyInstanceUidNull()
+            throws Exception {
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(is("studyInstanceUid cannot be null"));
+        dicomviewer.getDicomViewerUrl(radiologyStudy);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatusTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatusTest.java
@@ -13,77 +13,77 @@ import org.openmrs.test.Verifies;
  * Tests {@link PerformedProcedureStepStatus}
  */
 public class PerformedProcedureStepStatusTest {
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	/**
-	 * @see PerformedProcedureStepStatus#getNameOrUnknown(PerformedProcedureStepStatus)
-	 */
-	@Test
-	@Verifies(value = "should return name given performed procedure step status", method = "getNameOrUnknown(PerformedProcedureStepStatus)")
-	public void getNameOrUnknown_shouldReturnDisplayNameGivenPerformedProcedureStepStatus() {
-		assertThat(PerformedProcedureStepStatus.getNameOrUnknown(PerformedProcedureStepStatus.IN_PROGRESS),
-			is("IN_PROGRESS"));
-		assertThat(PerformedProcedureStepStatus.getNameOrUnknown(PerformedProcedureStepStatus.DISCONTINUED),
-			is("DISCONTINUED"));
-		assertThat(PerformedProcedureStepStatus.getNameOrUnknown(PerformedProcedureStepStatus.COMPLETED), is("COMPLETED"));
-	}
-	
-	/**
-	 * @see PerformedProcedureStepStatus#getNameOrUnknown(PerformedProcedureStepStatus)
-	 */
-	@Test
-	@Verifies(value = "should return unknown given null", method = "getNameOrUnknown(PerformedProcedureStepStatus)")
-	public void getNameOrUnknown_shouldReturnUnknownGivenNull() {
-		assertThat(PerformedProcedureStepStatus.getNameOrUnknown(null), is("UNKNOWN"));
-	}
-	
-	/**
-	 * @see PerformedProcedureStepStatus#getMatchForDisplayName(String)
-	 */
-	@Test
-	@Verifies(value = "should return performed procedure step status given display name", method = "getMatchForDisplayName(String)")
-	public void getMatchForDisplayName_shouldReturnPerformedProcedureStepStatusGivenDisplayName() {
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("IN PROGRESS"),
-			is(PerformedProcedureStepStatus.IN_PROGRESS));
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("in progress"),
-			is(PerformedProcedureStepStatus.IN_PROGRESS));
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("In Progress"),
-			is(PerformedProcedureStepStatus.IN_PROGRESS));
-		
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("DISCONTINUED"),
-			is(PerformedProcedureStepStatus.DISCONTINUED));
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("discontinued"),
-			is(PerformedProcedureStepStatus.DISCONTINUED));
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("Discontinued"),
-			is(PerformedProcedureStepStatus.DISCONTINUED));
-		
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("COMPLETED"),
-			is(PerformedProcedureStepStatus.COMPLETED));
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("completed"),
-			is(PerformedProcedureStepStatus.COMPLETED));
-		assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("Completed"),
-			is(PerformedProcedureStepStatus.COMPLETED));
-	}
-	
-	/**
-	 * @see PerformedProcedureStepStatus#getMatchForDisplayName(String)
-	 */
-	@Test
-	@Verifies(value = "should return null given undefined display name", method = "getMatchForDisplayName(String)")
-	public void getMatchForDisplayName_shouldReturnNullGivenUndefinedDisplayName() {
-		assertNull(PerformedProcedureStepStatus.getMatchForDisplayName("NON EXISTING FANTASY PERFORMEDSTATUS"));
-	}
-	
-	/**
-	 * @see PerformedProcedureStepStatus#getMatchForDisplayName(String)
-	 */
-	@Test
-	@Verifies(value = "should throw IllegalArgumentException given null", method = "getMatchForDisplayName(String)")
-	public void getMatchForDisplayName_shouldThrowIllegalArgumentExceptionGivenNull() {
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("displayName is required");
-		PerformedProcedureStepStatus.getMatchForDisplayName(null);
-	}
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    /**
+     * @see PerformedProcedureStepStatus#getNameOrUnknown(PerformedProcedureStepStatus)
+     */
+    @Test
+    @Verifies(value = "should return name given performed procedure step status", method = "getNameOrUnknown(PerformedProcedureStepStatus)")
+    public void getNameOrUnknown_shouldReturnDisplayNameGivenPerformedProcedureStepStatus() {
+        assertThat(PerformedProcedureStepStatus.getNameOrUnknown(PerformedProcedureStepStatus.IN_PROGRESS),
+            is("IN_PROGRESS"));
+        assertThat(PerformedProcedureStepStatus.getNameOrUnknown(PerformedProcedureStepStatus.DISCONTINUED),
+            is("DISCONTINUED"));
+        assertThat(PerformedProcedureStepStatus.getNameOrUnknown(PerformedProcedureStepStatus.COMPLETED), is("COMPLETED"));
+    }
+    
+    /**
+     * @see PerformedProcedureStepStatus#getNameOrUnknown(PerformedProcedureStepStatus)
+     */
+    @Test
+    @Verifies(value = "should return unknown given null", method = "getNameOrUnknown(PerformedProcedureStepStatus)")
+    public void getNameOrUnknown_shouldReturnUnknownGivenNull() {
+        assertThat(PerformedProcedureStepStatus.getNameOrUnknown(null), is("UNKNOWN"));
+    }
+    
+    /**
+     * @see PerformedProcedureStepStatus#getMatchForDisplayName(String)
+     */
+    @Test
+    @Verifies(value = "should return performed procedure step status given display name", method = "getMatchForDisplayName(String)")
+    public void getMatchForDisplayName_shouldReturnPerformedProcedureStepStatusGivenDisplayName() {
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("IN PROGRESS"),
+            is(PerformedProcedureStepStatus.IN_PROGRESS));
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("in progress"),
+            is(PerformedProcedureStepStatus.IN_PROGRESS));
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("In Progress"),
+            is(PerformedProcedureStepStatus.IN_PROGRESS));
+        
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("DISCONTINUED"),
+            is(PerformedProcedureStepStatus.DISCONTINUED));
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("discontinued"),
+            is(PerformedProcedureStepStatus.DISCONTINUED));
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("Discontinued"),
+            is(PerformedProcedureStepStatus.DISCONTINUED));
+        
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("COMPLETED"),
+            is(PerformedProcedureStepStatus.COMPLETED));
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("completed"),
+            is(PerformedProcedureStepStatus.COMPLETED));
+        assertThat(PerformedProcedureStepStatus.getMatchForDisplayName("Completed"),
+            is(PerformedProcedureStepStatus.COMPLETED));
+    }
+    
+    /**
+     * @see PerformedProcedureStepStatus#getMatchForDisplayName(String)
+     */
+    @Test
+    @Verifies(value = "should return null given undefined display name", method = "getMatchForDisplayName(String)")
+    public void getMatchForDisplayName_shouldReturnNullGivenUndefinedDisplayName() {
+        assertNull(PerformedProcedureStepStatus.getMatchForDisplayName("NON EXISTING FANTASY PERFORMEDSTATUS"));
+    }
+    
+    /**
+     * @see PerformedProcedureStepStatus#getMatchForDisplayName(String)
+     */
+    @Test
+    @Verifies(value = "should throw IllegalArgumentException given null", method = "getMatchForDisplayName(String)")
+    public void getMatchForDisplayName_shouldThrowIllegalArgumentExceptionGivenNull() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("displayName is required");
+        PerformedProcedureStepStatus.getMatchForDisplayName(null);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatusTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatusTest.java
@@ -12,29 +12,29 @@ import org.openmrs.test.Verifies;
  * Tests {@link ScheduledProcedureStepStatus}
  */
 public class ScheduledProcedureStepStatusTest {
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	/**
-	 * @see ScheduledProcedureStepStatus#getNameOrUnknown(ScheduledProcedureStepStatus)
-	 */
-	@Test
-	@Verifies(value = "should return name given scheduled procedure step status", method = "getNameOrUnknown(ScheduledProcedureStepStatus)")
-	public void getNameOrUnknown_shouldReturnNameGivenScheduledProcedureStepStatus() {
-		assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.SCHEDULED), is("SCHEDULED"));
-		assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.ARRIVED), is("ARRIVED"));
-		assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.READY), is("READY"));
-		assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.STARTED), is("STARTED"));
-		assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.DEPARTED), is("DEPARTED"));
-	}
-	
-	/**
-	 * @see ScheduledProcedureStepStatus#getNameOrUnknown(ScheduledProcedureStepStatus)
-	 */
-	@Test
-	@Verifies(value = "should return unknown given null", method = "getNameOrUnknown(ScheduledProcedureStepStatus)")
-	public void getNameOrUnknown_shouldReturnUnknownGivenNull() {
-		assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(null), is("UNKNOWN"));
-	}
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    /**
+     * @see ScheduledProcedureStepStatus#getNameOrUnknown(ScheduledProcedureStepStatus)
+     */
+    @Test
+    @Verifies(value = "should return name given scheduled procedure step status", method = "getNameOrUnknown(ScheduledProcedureStepStatus)")
+    public void getNameOrUnknown_shouldReturnNameGivenScheduledProcedureStepStatus() {
+        assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.SCHEDULED), is("SCHEDULED"));
+        assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.ARRIVED), is("ARRIVED"));
+        assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.READY), is("READY"));
+        assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.STARTED), is("STARTED"));
+        assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(ScheduledProcedureStepStatus.DEPARTED), is("DEPARTED"));
+    }
+    
+    /**
+     * @see ScheduledProcedureStepStatus#getNameOrUnknown(ScheduledProcedureStepStatus)
+     */
+    @Test
+    @Verifies(value = "should return unknown given null", method = "getNameOrUnknown(ScheduledProcedureStepStatus)")
+    public void getNameOrUnknown_shouldReturnUnknownGivenNull() {
+        assertThat(ScheduledProcedureStepStatus.getNameOrUnknown(null), is("UNKNOWN"));
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyDiscontinuedOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyDiscontinuedOrderValidatorTest.java
@@ -25,98 +25,98 @@ import org.springframework.validation.Errors;
  * Tests {@link RadiologyDiscontinuedOrderValidator}.
  */
 public class RadiologyDiscontinuedOrderValidatorTest {
-	
-	/**
-	 * @verifies return false for other object types
-	 * @see RadiologyDiscontinuedOrderValidator#supports(Class)
-	 */
-	@Test
-	public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
-		
-		RadiologyDiscontinuedOrderValidator radiologyDiscontinuedOrderValidator = new RadiologyDiscontinuedOrderValidator();
-		assertFalse(radiologyDiscontinuedOrderValidator.supports(Object.class));
-	}
-	
-	/**
-	 * @verifies return true for Order objects and subclasses
-	 * @see RadiologyDiscontinuedOrderValidator#supports(Class)
-	 */
-	@Test
-	public void supports_shouldReturnTrueForOrderObjectsAndSubclasses() throws Exception {
-		
-		RadiologyDiscontinuedOrderValidator radiologyDiscontinuedOrderValidator = new RadiologyDiscontinuedOrderValidator();
-		// true for Orders
-		assertTrue(radiologyDiscontinuedOrderValidator.supports(Order.class));
-		// true for Subclass
-		assertTrue(radiologyDiscontinuedOrderValidator.supports(RadiologyOrder.class));
-	}
-	
-	/**
-	 * @verifies fail validation if order is null
-	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfOrderIsNull() throws Exception {
-		
-		Errors errors = new BindException(new Order(), "order");
-		new RadiologyDiscontinuedOrderValidator().validate(null, errors);
-		
-		assertTrue(errors.hasErrors());
-		assertThat((errors.getAllErrors()).get(0)
-				.getCode(), is("error.general"));
-	}
-	
-	/**
-	 * @verifies fail validation if orderer is null
-	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfOrdererIsNull() throws Exception {
-		
-		Order order = new Order();
-		order.setOrderer(null);
-		order.setOrderReasonNonCoded("Wrong Procedure");
-		
-		Errors errors = new BindException(order, "order");
-		new RadiologyDiscontinuedOrderValidator().validate(order, errors);
-		
-		assertTrue(errors.hasFieldErrors("orderer"));
-		assertFalse(errors.hasFieldErrors("orderReasonNonCoded"));
-	}
-	
-	/**
-	 * @verifies fail validation if orderReasonNonCoded is null
-	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfOrderReasonNonCodedIsNull() throws Exception {
-		
-		Order order = new Order();
-		
-		order.setOrderer(new Provider());
-		order.setOrderReasonNonCoded(null);
-		
-		Errors errors = new BindException(order, "order");
-		new RadiologyDiscontinuedOrderValidator().validate(order, errors);
-		
-		assertFalse(errors.hasFieldErrors("orderer"));
-		assertTrue(errors.hasFieldErrors("orderReasonNonCoded"));
-	}
-	
-	/**
-	 * @verifies pass validation if all fields are correct
-	 * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
-	 */
-	@Test
-	public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
-		
-		Order order = new Order();
-		order.setOrderer(new Provider());
-		order.setOrderReasonNonCoded("Wrong Procedure");
-		
-		Errors errors = new BindException(order, "order");
-		new RadiologyDiscontinuedOrderValidator().validate(order, errors);
-		
-		assertFalse(errors.hasErrors());
-	}
+    
+    /**
+     * @verifies return false for other object types
+     * @see RadiologyDiscontinuedOrderValidator#supports(Class)
+     */
+    @Test
+    public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
+        
+        RadiologyDiscontinuedOrderValidator radiologyDiscontinuedOrderValidator = new RadiologyDiscontinuedOrderValidator();
+        assertFalse(radiologyDiscontinuedOrderValidator.supports(Object.class));
+    }
+    
+    /**
+     * @verifies return true for Order objects and subclasses
+     * @see RadiologyDiscontinuedOrderValidator#supports(Class)
+     */
+    @Test
+    public void supports_shouldReturnTrueForOrderObjectsAndSubclasses() throws Exception {
+        
+        RadiologyDiscontinuedOrderValidator radiologyDiscontinuedOrderValidator = new RadiologyDiscontinuedOrderValidator();
+        // true for Orders
+        assertTrue(radiologyDiscontinuedOrderValidator.supports(Order.class));
+        // true for Subclass
+        assertTrue(radiologyDiscontinuedOrderValidator.supports(RadiologyOrder.class));
+    }
+    
+    /**
+     * @verifies fail validation if order is null
+     * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfOrderIsNull() throws Exception {
+        
+        Errors errors = new BindException(new Order(), "order");
+        new RadiologyDiscontinuedOrderValidator().validate(null, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(), is("error.general"));
+    }
+    
+    /**
+     * @verifies fail validation if orderer is null
+     * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfOrdererIsNull() throws Exception {
+        
+        Order order = new Order();
+        order.setOrderer(null);
+        order.setOrderReasonNonCoded("Wrong Procedure");
+        
+        Errors errors = new BindException(order, "order");
+        new RadiologyDiscontinuedOrderValidator().validate(order, errors);
+        
+        assertTrue(errors.hasFieldErrors("orderer"));
+        assertFalse(errors.hasFieldErrors("orderReasonNonCoded"));
+    }
+    
+    /**
+     * @verifies fail validation if orderReasonNonCoded is null
+     * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfOrderReasonNonCodedIsNull() throws Exception {
+        
+        Order order = new Order();
+        
+        order.setOrderer(new Provider());
+        order.setOrderReasonNonCoded(null);
+        
+        Errors errors = new BindException(order, "order");
+        new RadiologyDiscontinuedOrderValidator().validate(order, errors);
+        
+        assertFalse(errors.hasFieldErrors("orderer"));
+        assertTrue(errors.hasFieldErrors("orderReasonNonCoded"));
+    }
+    
+    /**
+     * @verifies pass validation if all fields are correct
+     * @see RadiologyDiscontinuedOrderValidator#validate(Object, org.springframework.validation.Errors)
+     */
+    @Test
+    public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
+        
+        Order order = new Order();
+        order.setOrderer(new Provider());
+        order.setOrderReasonNonCoded("Wrong Procedure");
+        
+        Errors errors = new BindException(order, "order");
+        new RadiologyDiscontinuedOrderValidator().validate(order, errors);
+        
+        assertFalse(errors.hasErrors());
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
@@ -58,604 +58,604 @@ import org.springframework.beans.factory.annotation.Qualifier;
  * Tests {@link RadiologyOrderService}
  */
 public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensitiveTest {
-	
-	private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml";
-	
-	private static final int PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER = 70011;
-	
-	private static final int PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER = 70021;
-	
-	private static final int PATIENT_ID_WITH_TWO_RADIOLOGY_ORDERS = 70021;
-	
-	private static final int PATIENT_ID_WITH_FIVE_RADIOLOGY_ORDERS = 70022;
-	
-	private static final int PATIENT_ID_WITH_ONE_RADIOLOGY_ORDER_AND_ACTIVE_VISIT = 70055;
-	
-	private static final int PATIENT_ID_WITH_NO_RADIOLOGY_ORDER_AND_NO_EXISTIG_ENCOUNTER_AND_ACTIVE_VISIT = 70033;
-	
-	private static final int EXISTING_RADIOLOGY_ORDER_ID = 2001;
-	
-	private static final int NON_EXISTING_RADIOLOGY_ORDER_ID = 99999;
-	
-	private static final int CONCEPT_ID_FOR_FRACTURE = 178;
-	
-	private static final int TOTAL_NUMBER_OF_RADIOLOGY_ORDERS = 4;
-	
-	private static final int RADIOLOGY_ORDER_WITH_ENCOUNTER_AND_ACTIVE_VISIT = 2009;
-	
-	@Autowired
-	private PatientService patientService;
-	
-	@Autowired
-	private ConceptService conceptService;
-	
-	@Autowired
-	@Qualifier("adminService")
-	private AdministrationService administrationService;
-	
-	@Autowired
-	private EncounterService encounterService;
-	
-	@Autowired
-	private ProviderService providerService;
-	
-	@Autowired
-	private OrderService orderService;
-	
-	@Autowired
-	private RadiologyOrderService radiologyOrderService;
-	
-	@Autowired
-	private VisitService visitService;
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	/**
-	 * Overriding following method is necessary to enable MVCC which is disabled by default in DB h2
-	 * used for the component tests. This prevents following exception:
-	 * org.hibernate.exception.GenericJDBCException: could not load an entity:
-	 * [org.openmrs.GlobalProperty#order.nextOrderNumberSeed] due to "Timeout trying to lock table "
-	 * GLOBAL_PROPERTY"; SQL statement:" which occurs in all tests touching methods that call
-	 * orderService.saveOrder()
-	 */
-	@Override
-	public Properties getRuntimeProperties() {
-		Properties result = super.getRuntimeProperties();
-		String url = result.getProperty(Environment.URL);
-		if (url.contains("jdbc:h2:") && !url.contains(";MVCC=TRUE")) {
-			result.setProperty(Environment.URL, url + ";MVCC=TRUE");
-		}
-		return result;
-	}
-	
-	@Before
-	public void setUp() throws Exception {
-		executeDataSet(TEST_DATASET);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 * @verifies create new radiology order and study from given radiology order object
-	 */
-	@Test
-	public void placeRadiologyOrder_shouldCreateNewRadiologyOrderAndStudyGivenRadiologyOrderObject() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
-		
-		radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-		
-		assertNotNull(radiologyOrder);
-		assertNotNull(radiologyOrder.getOrderId());
-		assertNotNull(radiologyOrder.getStudy());
-		assertNotNull(radiologyOrder.getStudy()
-				.getStudyId());
-		assertNotNull(radiologyOrder.getEncounter());
-	}
-	
-	/**
-	 * Convenience method to get a RadiologyOrder object with all required values filled in but
-	 * which is not yet saved in the database
-	 * 
-	 * @return RadiologyOrder object that can be saved to the database
-	 */
-	public RadiologyOrder getUnsavedRadiologyOrder() {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		
-		radiologyOrder.setPatient(patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER));
-		radiologyOrder.setOrderer(providerService.getProviderByIdentifier("1"));
-		radiologyOrder.setConcept(conceptService.getConcept(CONCEPT_ID_FOR_FRACTURE));
-		radiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
-		
-		Calendar calendar = Calendar.getInstance();
-		calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
-		radiologyOrder.setScheduledDate(calendar.getTime());
-		radiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setModality(Modality.CT);
-		radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
-		radiologyOrder.setStudy(radiologyStudy);
-		
-		return radiologyOrder;
-	}
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 * @verifies create radiology order encounter with orderer and attached to existing active visit if patient has active
-	 *           visit
-	 */
-	@Test
-	public void placeRadiologyOrder_shouldCreateRadiologyOrderEncounterWithOrdererAndAttachedToExistingActiveVisitIfPatientHasActiveVisit()
-			throws Exception {
-		
-		RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
-		radiologyOrder.setPatient(patientService.getPatient(PATIENT_ID_WITH_NO_RADIOLOGY_ORDER_AND_NO_EXISTIG_ENCOUNTER_AND_ACTIVE_VISIT));
-		
-		assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient()), is(empty()));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient()), is(not(empty())));
-		Visit preExistingVisit = visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0);
-		
-		assertThat(radiologyOrder.getEncounter(), is(nullValue()));
-		
-		radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-		
-		Encounter encounter = radiologyOrder.getEncounter();
-		assertThat(encounter, is(not(nullValue())));
-		assertThat(encounter.getEncounterProviders()
-				.size(), is(1));
-		assertThat(encounter.getEncounterProviders()
-				.iterator()
-				.next()
-				.getProvider(), is(radiologyOrder.getOrderer()));
-		assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0), is(preExistingVisit));
-		assertThat(orderService.getAllOrdersByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 * @verifies create radiology order encounter with orderer attached to new active visit if patient without active visit
-	 */
-	@Test
-	public void placeRadiologyOrder_shouldCreateRadiologyOrderEncounterWithOrdererAttachedToNewActiveVisitIfPatientWithoutActiveVisit()
-			throws Exception {
-		RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
-		
-		assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient()), is(empty()));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient()), is(empty()));
-		assertThat(radiologyOrder.getEncounter(), is(nullValue()));
-		
-		radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-		
-		Encounter encounter = radiologyOrder.getEncounter();
-		assertThat(encounter, is(not(nullValue())));
-		assertThat(encounter.getEncounterProviders()
-				.size(), is(1));
-		assertThat(encounter.getEncounterProviders()
-				.iterator()
-				.next()
-				.getProvider(), is(radiologyOrder.getOrderer()));
-		assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters(), hasItem(encounter));
-		assertThat(orderService.getAllOrdersByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		
-	}
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 * @verifies throw illegal argument exception given null
-	 */
-	@Test
-	public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenNull() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder is required");
-		radiologyOrderService.placeRadiologyOrder(null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 * @verifies throw illegal argument exception given existing radiology order
-	 */
-	@Test
-	public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenExistingRadiologyOrder() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
-		
-		radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-		
-		assertNotNull(radiologyOrder);
-		assertNotNull(radiologyOrder.getOrderId());
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("Cannot edit an existing order!");
-		radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 * @verifies throw illegal argument exception if given radiology order has no study
-	 */
-	@Test
-	public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionIfGivenRadiologyOrderHasNoStudy() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
-		radiologyOrder.setStudy(null);
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder.study is required");
-		radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
-	 * @verifies throw illegal argument exception if given study modality is null
-	 */
-	@Test
-	public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionIfGivenStudyModalityIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
-		radiologyOrder.getStudy()
-				.setModality(null);
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder.study.modality is required");
-		radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder,Provider,String)
-	 * @verifies create discontinuation order which discontinues given radiology order that is not
-	 *           in progress or completed
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWhichDiscontinuesGivenRadiologyOrderThatIsNotInProgressOrCompleted()
-			throws Exception {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		radiologyOrder.getStudy()
-				.setPerformedStatus(null);
-		String discontinueReason = "Wrong Procedure";
-		
-		Order discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrder,
-			radiologyOrder.getOrderer(), discontinueReason);
-		
-		assertNotNull(discontinuationOrder);
-		assertThat(discontinuationOrder.getAction(), is(Order.Action.DISCONTINUE));
-		
-		assertThat(discontinuationOrder.getPreviousOrder(), is((Order) radiologyOrder));
-		assertThat(radiologyOrder.isActive(), is(false));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder,Provider,String)
-	 * @verifies create discontinuation order with encounter attached to existing active visit if patient has active visit
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWithEncounterAttachedToExistingActiveVisitIfPatientHasActiveVisit()
-			throws Exception {
-		Patient patient = patientService.getPatient(PATIENT_ID_WITH_ONE_RADIOLOGY_ORDER_AND_ACTIVE_VISIT);
-		
-		assertThat(visitService.getActiveVisitsByPatient(patient), is(not(empty())));
-		assertThat(visitService.getActiveVisitsByPatient(patient)
-				.get(0)
-				.getEncounters(), is(not(empty())));
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_ENCOUNTER_AND_ACTIVE_VISIT);
-		
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters()
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters(), hasItem(radiologyOrder.getEncounter()));
-		
-		String discontinueReason = "Wrong Procedure";
-		
-		assertThat(radiologyOrder.getPatient()
-				.getUuid(), is(not(nullValue())));
-		Order discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrder,
-			radiologyOrder.getOrderer(), discontinueReason);
-		
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters()
-				.size(), is(2));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters(), hasItem(radiologyOrder.getEncounter()));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters(), hasItem(discontinuationOrder.getEncounter()));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder,Provider,String)
-	 * @verifies create discontinuation order with encounter attached to new active visit if patient without active visit
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWithEncounterAttachedToNewActiveVisitIfPatientWithoutActiveVisit()
-			throws Exception {
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient()), is(empty()));
-		
-		radiologyOrder.getStudy()
-				.setPerformedStatus(null);
-		String discontinueReason = "Wrong Procedure";
-		
-		Order discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrder,
-			radiologyOrder.getOrderer(), discontinueReason);
-		
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters()
-				.size(), is(1));
-		assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
-				.get(0)
-				.getEncounters(), hasItem(discontinuationOrder.getEncounter()));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
-	 * @verifies should throw illegal argument exception given empty radiology order
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenEmptyRadiologyOrder() throws Exception {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		String discontinueReason = "Wrong Procedure";
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder is required");
-		radiologyOrderService.discontinueRadiologyOrder(null, radiologyOrder.getOrderer(), discontinueReason);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
-	 * @verifies should throw illegal argument exception given radiology order with orderId null
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenRadiologyOrderWithOrderIdNull()
-			throws Exception {
-		
-		RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
-		String discontinueReason = "Wrong Procedure";
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("orderId is null");
-		radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, Date, String)
-	 * @verifies should throw illegal argument exception if radiology order is not active
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsNotActive() throws Exception {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		radiologyOrder.setAction(Order.Action.DISCONTINUE);
-		String discontinueReason = "Wrong Procedure";
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("order is not active");
-		radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
-	 * @verifies throw illegal argument exception if radiology order is completed
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsCompleted() throws Exception {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		radiologyOrder.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		String discontinueReason = "Wrong Procedure";
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder is in progress");
-		radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
-	 * @verifies throw illegal argument exception if radiology order is in progress
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsInProgress() throws Exception {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		radiologyOrder.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		String discontinueReason = "Wrong Procedure";
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder is completed");
-		radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
-	 * @verifies should throw illegal argument exception given empty provider
-	 */
-	@Test
-	public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenEmptyProvider() throws Exception {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		radiologyOrder.getStudy()
-				.setPerformedStatus(null);
-		String discontinueReason = "Wrong Procedure";
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("provider is required");
-		radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, null, discontinueReason);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
-	 * @verifies should return radiology order matching order id
-	 */
-	@Test
-	public void getRadiologyOrderByOrderId_shouldReturnRadiologyOrderMatchingOrderId() {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		
-		assertNotNull(radiologyOrder);
-		assertThat(radiologyOrder.getOrderId(), is(EXISTING_RADIOLOGY_ORDER_ID));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
-	 * @verifies should return null if no match was found
-	 */
-	@Test
-	public void getRadiologyOrderByOrderId_shouldReturnNullIfNoMatchIsFound() {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(NON_EXISTING_RADIOLOGY_ORDER_ID);
-		
-		assertNull(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
-	 * @verifies should throw illegal argument exception given null
-	 */
-	@Test
-	public void getRadiologyOrderByOrderId_shouldThrowIllegalArgumentExceptionGivenNull() {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("orderId is required");
-		radiologyOrderService.getRadiologyOrderByOrderId(null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
-	 * @verifies should return all radiology orders associated with given patient
-	 */
-	@Test
-	public void getRadiologyOrdersByPatient_shouldReturnAllRadiologyOrdersAssociatedWithGivenPatient() {
-		
-		Patient patientWithTwoRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER);
-		
-		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patientWithTwoRadiologyOrders);
-		
-		assertThat(radiologyOrders.size(), is(2));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
-	 * @verifies should return empty list given patient without associated radiology orders
-	 */
-	@Test
-	public void getRadiologyOrdersByPatient_shouldReturnEmptyListGivenPatientWithoutAssociatedRadiologyOrders() {
-		
-		Patient patientWithoutRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER);
-		
-		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patientWithoutRadiologyOrders);
-		
-		assertThat(radiologyOrders.size(), is(0));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
-	 * @verifies should throw illegal argument exception given null
-	 */
-	@Test
-	public void getRadiologyOrdersByPatient_shouldThrowIllegalArgumentExceptionGivenNull() {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("patient is required");
-		radiologyOrderService.getRadiologyOrdersByPatient(null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-	 * @verifies should return all radiology orders associated with given patients
-	 */
-	@Test
-	public void getRadiologyOrdersByPatients_shouldReturnAllRadiologyOrdersAssociatedWithGivenPatients() {
-		
-		Patient patientWithTwoRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_TWO_RADIOLOGY_ORDERS);
-		assertThat(orderService.getAllOrdersByPatient(patientWithTwoRadiologyOrders)
-				.size(), is(2));
-		Patient patientWithFiveRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_FIVE_RADIOLOGY_ORDERS);
-		assertThat(orderService.getAllOrdersByPatient(patientWithFiveRadiologyOrders)
-				.size(), is(1));
-		Patient patientWithOneRadiologyOrder = patientService.getPatient(PATIENT_ID_WITH_ONE_RADIOLOGY_ORDER_AND_ACTIVE_VISIT);
-		assertThat(orderService.getAllOrdersByPatient(patientWithOneRadiologyOrder)
-				.size(), is(1));
-		List<Patient> allPatientsWithRadiologyOrders = new ArrayList<Patient>();
-		allPatientsWithRadiologyOrders.add(patientWithTwoRadiologyOrders);
-		allPatientsWithRadiologyOrders.add(patientWithFiveRadiologyOrders);
-		allPatientsWithRadiologyOrders.add(patientWithOneRadiologyOrder);
-		
-		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(allPatientsWithRadiologyOrders);
-		
-		assertThat(radiologyOrders.size(), is(TOTAL_NUMBER_OF_RADIOLOGY_ORDERS));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-	 * @verifies should return all radiology orders given empty patient list
-	 */
-	@Test
-	public void getRadiologyOrdersByPatients_shouldReturnAllRadiologyOrdersGivenEmptyPatientList() {
-		
-		List<Patient> emptyPatientList = new ArrayList<Patient>();
-		
-		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(emptyPatientList);
-		
-		assertThat(radiologyOrders.size(), is(TOTAL_NUMBER_OF_RADIOLOGY_ORDERS));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-	 * @verifies should throw illegal argument exception given null
-	 */
-	@Test
-	public void getRadiologyOrdersByPatients_shouldThrowIllegalArgumentExceptionGivenNull() {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("patients is required");
-		radiologyOrderService.getRadiologyOrdersByPatients(null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyOrdersByPatients(List)
-	 * @verifies return empty list given patient list without associated radiology orders
-	 */
-	@Test
-	public void getRadiologyOrdersByPatients_shouldReturnEmptyListGivenPatientListWithoutAssociatedRadiologyOrders()
-			throws Exception {
-		
-		Patient patientWithoutRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER);
-		
-		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(patientWithoutRadiologyOrders));
-		
-		assertThat(radiologyOrders.size(), is(0));
-	}
+    
+    private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml";
+    
+    private static final int PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER = 70011;
+    
+    private static final int PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER = 70021;
+    
+    private static final int PATIENT_ID_WITH_TWO_RADIOLOGY_ORDERS = 70021;
+    
+    private static final int PATIENT_ID_WITH_FIVE_RADIOLOGY_ORDERS = 70022;
+    
+    private static final int PATIENT_ID_WITH_ONE_RADIOLOGY_ORDER_AND_ACTIVE_VISIT = 70055;
+    
+    private static final int PATIENT_ID_WITH_NO_RADIOLOGY_ORDER_AND_NO_EXISTIG_ENCOUNTER_AND_ACTIVE_VISIT = 70033;
+    
+    private static final int EXISTING_RADIOLOGY_ORDER_ID = 2001;
+    
+    private static final int NON_EXISTING_RADIOLOGY_ORDER_ID = 99999;
+    
+    private static final int CONCEPT_ID_FOR_FRACTURE = 178;
+    
+    private static final int TOTAL_NUMBER_OF_RADIOLOGY_ORDERS = 4;
+    
+    private static final int RADIOLOGY_ORDER_WITH_ENCOUNTER_AND_ACTIVE_VISIT = 2009;
+    
+    @Autowired
+    private PatientService patientService;
+    
+    @Autowired
+    private ConceptService conceptService;
+    
+    @Autowired
+    @Qualifier("adminService")
+    private AdministrationService administrationService;
+    
+    @Autowired
+    private EncounterService encounterService;
+    
+    @Autowired
+    private ProviderService providerService;
+    
+    @Autowired
+    private OrderService orderService;
+    
+    @Autowired
+    private RadiologyOrderService radiologyOrderService;
+    
+    @Autowired
+    private VisitService visitService;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    /**
+     * Overriding following method is necessary to enable MVCC which is disabled by default in DB h2
+     * used for the component tests. This prevents following exception:
+     * org.hibernate.exception.GenericJDBCException: could not load an entity:
+     * [org.openmrs.GlobalProperty#order.nextOrderNumberSeed] due to "Timeout trying to lock table "
+     * GLOBAL_PROPERTY"; SQL statement:" which occurs in all tests touching methods that call
+     * orderService.saveOrder()
+     */
+    @Override
+    public Properties getRuntimeProperties() {
+        Properties result = super.getRuntimeProperties();
+        String url = result.getProperty(Environment.URL);
+        if (url.contains("jdbc:h2:") && !url.contains(";MVCC=TRUE")) {
+            result.setProperty(Environment.URL, url + ";MVCC=TRUE");
+        }
+        return result;
+    }
+    
+    @Before
+    public void setUp() throws Exception {
+        executeDataSet(TEST_DATASET);
+    }
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     * @verifies create new radiology order and study from given radiology order object
+     */
+    @Test
+    public void placeRadiologyOrder_shouldCreateNewRadiologyOrderAndStudyGivenRadiologyOrderObject() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
+        
+        radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+        
+        assertNotNull(radiologyOrder);
+        assertNotNull(radiologyOrder.getOrderId());
+        assertNotNull(radiologyOrder.getStudy());
+        assertNotNull(radiologyOrder.getStudy()
+                .getStudyId());
+        assertNotNull(radiologyOrder.getEncounter());
+    }
+    
+    /**
+     * Convenience method to get a RadiologyOrder object with all required values filled in but
+     * which is not yet saved in the database
+     * 
+     * @return RadiologyOrder object that can be saved to the database
+     */
+    public RadiologyOrder getUnsavedRadiologyOrder() {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        
+        radiologyOrder.setPatient(patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER));
+        radiologyOrder.setOrderer(providerService.getProviderByIdentifier("1"));
+        radiologyOrder.setConcept(conceptService.getConcept(CONCEPT_ID_FOR_FRACTURE));
+        radiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
+        
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
+        radiologyOrder.setScheduledDate(calendar.getTime());
+        radiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setModality(Modality.CT);
+        radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
+        radiologyOrder.setStudy(radiologyStudy);
+        
+        return radiologyOrder;
+    }
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     * @verifies create radiology order encounter with orderer and attached to existing active visit if patient has active
+     *           visit
+     */
+    @Test
+    public void placeRadiologyOrder_shouldCreateRadiologyOrderEncounterWithOrdererAndAttachedToExistingActiveVisitIfPatientHasActiveVisit()
+            throws Exception {
+        
+        RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
+        radiologyOrder.setPatient(patientService.getPatient(PATIENT_ID_WITH_NO_RADIOLOGY_ORDER_AND_NO_EXISTIG_ENCOUNTER_AND_ACTIVE_VISIT));
+        
+        assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient()), is(empty()));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient()), is(not(empty())));
+        Visit preExistingVisit = visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0);
+        
+        assertThat(radiologyOrder.getEncounter(), is(nullValue()));
+        
+        radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+        
+        Encounter encounter = radiologyOrder.getEncounter();
+        assertThat(encounter, is(not(nullValue())));
+        assertThat(encounter.getEncounterProviders()
+                .size(), is(1));
+        assertThat(encounter.getEncounterProviders()
+                .iterator()
+                .next()
+                .getProvider(), is(radiologyOrder.getOrderer()));
+        assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0), is(preExistingVisit));
+        assertThat(orderService.getAllOrdersByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+    }
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     * @verifies create radiology order encounter with orderer attached to new active visit if patient without active visit
+     */
+    @Test
+    public void placeRadiologyOrder_shouldCreateRadiologyOrderEncounterWithOrdererAttachedToNewActiveVisitIfPatientWithoutActiveVisit()
+            throws Exception {
+        RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
+        
+        assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient()), is(empty()));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient()), is(empty()));
+        assertThat(radiologyOrder.getEncounter(), is(nullValue()));
+        
+        radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+        
+        Encounter encounter = radiologyOrder.getEncounter();
+        assertThat(encounter, is(not(nullValue())));
+        assertThat(encounter.getEncounterProviders()
+                .size(), is(1));
+        assertThat(encounter.getEncounterProviders()
+                .iterator()
+                .next()
+                .getProvider(), is(radiologyOrder.getOrderer()));
+        assertThat(encounterService.getEncountersByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters(), hasItem(encounter));
+        assertThat(orderService.getAllOrdersByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        
+    }
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     * @verifies throw illegal argument exception given null
+     */
+    @Test
+    public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder is required");
+        radiologyOrderService.placeRadiologyOrder(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     * @verifies throw illegal argument exception given existing radiology order
+     */
+    @Test
+    public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenExistingRadiologyOrder() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
+        
+        radiologyOrder = radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+        
+        assertNotNull(radiologyOrder);
+        assertNotNull(radiologyOrder.getOrderId());
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Cannot edit an existing order!");
+        radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     * @verifies throw illegal argument exception if given radiology order has no study
+     */
+    @Test
+    public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionIfGivenRadiologyOrderHasNoStudy() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
+        radiologyOrder.setStudy(null);
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder.study is required");
+        radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
+     * @verifies throw illegal argument exception if given study modality is null
+     */
+    @Test
+    public void placeRadiologyOrder_shouldThrowIllegalArgumentExceptionIfGivenStudyModalityIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
+        radiologyOrder.getStudy()
+                .setModality(null);
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder.study.modality is required");
+        radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder,Provider,String)
+     * @verifies create discontinuation order which discontinues given radiology order that is not
+     *           in progress or completed
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWhichDiscontinuesGivenRadiologyOrderThatIsNotInProgressOrCompleted()
+            throws Exception {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        radiologyOrder.getStudy()
+                .setPerformedStatus(null);
+        String discontinueReason = "Wrong Procedure";
+        
+        Order discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrder,
+            radiologyOrder.getOrderer(), discontinueReason);
+        
+        assertNotNull(discontinuationOrder);
+        assertThat(discontinuationOrder.getAction(), is(Order.Action.DISCONTINUE));
+        
+        assertThat(discontinuationOrder.getPreviousOrder(), is((Order) radiologyOrder));
+        assertThat(radiologyOrder.isActive(), is(false));
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder,Provider,String)
+     * @verifies create discontinuation order with encounter attached to existing active visit if patient has active visit
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWithEncounterAttachedToExistingActiveVisitIfPatientHasActiveVisit()
+            throws Exception {
+        Patient patient = patientService.getPatient(PATIENT_ID_WITH_ONE_RADIOLOGY_ORDER_AND_ACTIVE_VISIT);
+        
+        assertThat(visitService.getActiveVisitsByPatient(patient), is(not(empty())));
+        assertThat(visitService.getActiveVisitsByPatient(patient)
+                .get(0)
+                .getEncounters(), is(not(empty())));
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_ENCOUNTER_AND_ACTIVE_VISIT);
+        
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters()
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters(), hasItem(radiologyOrder.getEncounter()));
+        
+        String discontinueReason = "Wrong Procedure";
+        
+        assertThat(radiologyOrder.getPatient()
+                .getUuid(), is(not(nullValue())));
+        Order discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrder,
+            radiologyOrder.getOrderer(), discontinueReason);
+        
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters()
+                .size(), is(2));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters(), hasItem(radiologyOrder.getEncounter()));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters(), hasItem(discontinuationOrder.getEncounter()));
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder,Provider,String)
+     * @verifies create discontinuation order with encounter attached to new active visit if patient without active visit
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWithEncounterAttachedToNewActiveVisitIfPatientWithoutActiveVisit()
+            throws Exception {
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient()), is(empty()));
+        
+        radiologyOrder.getStudy()
+                .setPerformedStatus(null);
+        String discontinueReason = "Wrong Procedure";
+        
+        Order discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrder,
+            radiologyOrder.getOrderer(), discontinueReason);
+        
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters()
+                .size(), is(1));
+        assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
+                .get(0)
+                .getEncounters(), hasItem(discontinuationOrder.getEncounter()));
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
+     * @verifies should throw illegal argument exception given empty radiology order
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenEmptyRadiologyOrder() throws Exception {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        String discontinueReason = "Wrong Procedure";
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder is required");
+        radiologyOrderService.discontinueRadiologyOrder(null, radiologyOrder.getOrderer(), discontinueReason);
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
+     * @verifies should throw illegal argument exception given radiology order with orderId null
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenRadiologyOrderWithOrderIdNull()
+            throws Exception {
+        
+        RadiologyOrder radiologyOrder = getUnsavedRadiologyOrder();
+        String discontinueReason = "Wrong Procedure";
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("orderId is null");
+        radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, Date, String)
+     * @verifies should throw illegal argument exception if radiology order is not active
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsNotActive() throws Exception {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        radiologyOrder.setAction(Order.Action.DISCONTINUE);
+        String discontinueReason = "Wrong Procedure";
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("order is not active");
+        radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
+     * @verifies throw illegal argument exception if radiology order is completed
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsCompleted() throws Exception {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        radiologyOrder.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        String discontinueReason = "Wrong Procedure";
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder is in progress");
+        radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
+     * @verifies throw illegal argument exception if radiology order is in progress
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsInProgress() throws Exception {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        radiologyOrder.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        String discontinueReason = "Wrong Procedure";
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder is completed");
+        radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, radiologyOrder.getOrderer(), discontinueReason);
+    }
+    
+    /**
+     * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
+     * @verifies should throw illegal argument exception given empty provider
+     */
+    @Test
+    public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenEmptyProvider() throws Exception {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        radiologyOrder.getStudy()
+                .setPerformedStatus(null);
+        String discontinueReason = "Wrong Procedure";
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("provider is required");
+        radiologyOrderService.discontinueRadiologyOrder(radiologyOrder, null, discontinueReason);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @verifies should return radiology order matching order id
+     */
+    @Test
+    public void getRadiologyOrderByOrderId_shouldReturnRadiologyOrderMatchingOrderId() {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        
+        assertNotNull(radiologyOrder);
+        assertThat(radiologyOrder.getOrderId(), is(EXISTING_RADIOLOGY_ORDER_ID));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @verifies should return null if no match was found
+     */
+    @Test
+    public void getRadiologyOrderByOrderId_shouldReturnNullIfNoMatchIsFound() {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(NON_EXISTING_RADIOLOGY_ORDER_ID);
+        
+        assertNull(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @verifies should throw illegal argument exception given null
+     */
+    @Test
+    public void getRadiologyOrderByOrderId_shouldThrowIllegalArgumentExceptionGivenNull() {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("orderId is required");
+        radiologyOrderService.getRadiologyOrderByOrderId(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
+     * @verifies should return all radiology orders associated with given patient
+     */
+    @Test
+    public void getRadiologyOrdersByPatient_shouldReturnAllRadiologyOrdersAssociatedWithGivenPatient() {
+        
+        Patient patientWithTwoRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER);
+        
+        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patientWithTwoRadiologyOrders);
+        
+        assertThat(radiologyOrders.size(), is(2));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
+     * @verifies should return empty list given patient without associated radiology orders
+     */
+    @Test
+    public void getRadiologyOrdersByPatient_shouldReturnEmptyListGivenPatientWithoutAssociatedRadiologyOrders() {
+        
+        Patient patientWithoutRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER);
+        
+        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patientWithoutRadiologyOrders);
+        
+        assertThat(radiologyOrders.size(), is(0));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
+     * @verifies should throw illegal argument exception given null
+     */
+    @Test
+    public void getRadiologyOrdersByPatient_shouldThrowIllegalArgumentExceptionGivenNull() {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("patient is required");
+        radiologyOrderService.getRadiologyOrdersByPatient(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
+     * @verifies should return all radiology orders associated with given patients
+     */
+    @Test
+    public void getRadiologyOrdersByPatients_shouldReturnAllRadiologyOrdersAssociatedWithGivenPatients() {
+        
+        Patient patientWithTwoRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_TWO_RADIOLOGY_ORDERS);
+        assertThat(orderService.getAllOrdersByPatient(patientWithTwoRadiologyOrders)
+                .size(), is(2));
+        Patient patientWithFiveRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_FIVE_RADIOLOGY_ORDERS);
+        assertThat(orderService.getAllOrdersByPatient(patientWithFiveRadiologyOrders)
+                .size(), is(1));
+        Patient patientWithOneRadiologyOrder = patientService.getPatient(PATIENT_ID_WITH_ONE_RADIOLOGY_ORDER_AND_ACTIVE_VISIT);
+        assertThat(orderService.getAllOrdersByPatient(patientWithOneRadiologyOrder)
+                .size(), is(1));
+        List<Patient> allPatientsWithRadiologyOrders = new ArrayList<Patient>();
+        allPatientsWithRadiologyOrders.add(patientWithTwoRadiologyOrders);
+        allPatientsWithRadiologyOrders.add(patientWithFiveRadiologyOrders);
+        allPatientsWithRadiologyOrders.add(patientWithOneRadiologyOrder);
+        
+        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(allPatientsWithRadiologyOrders);
+        
+        assertThat(radiologyOrders.size(), is(TOTAL_NUMBER_OF_RADIOLOGY_ORDERS));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
+     * @verifies should return all radiology orders given empty patient list
+     */
+    @Test
+    public void getRadiologyOrdersByPatients_shouldReturnAllRadiologyOrdersGivenEmptyPatientList() {
+        
+        List<Patient> emptyPatientList = new ArrayList<Patient>();
+        
+        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(emptyPatientList);
+        
+        assertThat(radiologyOrders.size(), is(TOTAL_NUMBER_OF_RADIOLOGY_ORDERS));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
+     * @verifies should throw illegal argument exception given null
+     */
+    @Test
+    public void getRadiologyOrdersByPatients_shouldThrowIllegalArgumentExceptionGivenNull() {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("patients is required");
+        radiologyOrderService.getRadiologyOrdersByPatients(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List)
+     * @verifies return empty list given patient list without associated radiology orders
+     */
+    @Test
+    public void getRadiologyOrdersByPatients_shouldReturnEmptyListGivenPatientListWithoutAssociatedRadiologyOrders()
+            throws Exception {
+        
+        Patient patientWithoutRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER);
+        
+        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(patientWithoutRadiologyOrders));
+        
+        assertThat(radiologyOrders.size(), is(0));
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderTest.java
@@ -24,273 +24,273 @@ import org.openmrs.module.radiology.study.RadiologyStudy;
  * Tests {@link RadiologyOrder}
  */
 public class RadiologyOrderTest {
-	
-	/**
-	 * @see RadiologyOrder#setStudy(RadiologyStudy)
-	 * @verifies set the study attribute to given study
-	 */
-	@Test
-	public void setStudy_shouldSetTheStudyAttributeToGivenStudy() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		radiologyOrder.setStudy(study);
-		
-		assertThat(radiologyOrder.getStudy(), is(study));
-	}
-	
-	/**
-	 * @see RadiologyOrder#setStudy(RadiologyStudy)
-	 * @verifies set the radiology order of given study to this radiology order
-	 */
-	@Test
-	public void setStudy_shouldSetTheRadiologyOrderOfGivenStudyToThisRadiologyOrder() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		radiologyOrder.setStudy(study);
-		
-		assertThat(study.getRadiologyOrder(), is(radiologyOrder));
-	}
-	
-	/**
-	 * @see RadiologyOrder#setStudy(RadiologyStudy)
-	 * @verifies not fail given null
-	 */
-	@Test
-	public void setStudy_shouldNotFailGivenNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(null);
-		
-		assertNotNull(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrder#isInProgress()
-	 * @verifies return false if associated study is null
-	 */
-	@Test
-	public void isInProgress_shouldReturnFalseIfAssociatedStudyIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(null);
-		
-		assertFalse(radiologyOrder.isInProgress());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isInProgress()
-	 * @verifies return false if associated study is not in progress
-	 */
-	@Test
-	public void isInProgress_shouldReturnFalseIfAssociatedStudyIsNotInProgress() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(study);
-		
-		assertFalse(radiologyOrder.isInProgress());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isInProgress()
-	 * @verifies return true if associated study is in progress
-	 */
-	@Test
-	public void isInProgress_shouldReturnTrueIfAssociatedStudyIsInProgress() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		radiologyOrder.setStudy(study);
-		
-		assertTrue(radiologyOrder.isInProgress());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isNotInProgress()
-	 * @verifies return true if associated study is null
-	 */
-	@Test
-	public void isNotInProgress_shouldReturnTrueIfAssociatedStudyIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(null);
-		
-		assertTrue(radiologyOrder.isNotInProgress());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isNotInProgress()
-	 * @verifies return true if associated study is not in progress
-	 */
-	@Test
-	public void isNotInProgress_shouldReturnTrueIfAssociatedStudyIsNotInProgress() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(study);
-		
-		assertTrue(radiologyOrder.isNotInProgress());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isNotInProgress()
-	 * @verifies return false if associated study in progress
-	 */
-	@Test
-	public void isNotInProgress_shouldReturnFalseIfAssociatedStudyInProgress() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		radiologyOrder.setStudy(study);
-		
-		assertFalse(radiologyOrder.isNotInProgress());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isCompleted()
-	 * @verifies return false if associated study is null
-	 */
-	@Test
-	public void isCompleted_shouldReturnFalseIfAssociatedStudyIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(null);
-		
-		assertFalse(radiologyOrder.isCompleted());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isCompleted()
-	 * @verifies return false if associated study is not completed
-	 */
-	@Test
-	public void isCompleted_shouldReturnFalseIfAssociatedStudyIsNotCompleted() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(new RadiologyStudy());
-		
-		assertFalse(radiologyOrder.isCompleted());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isCompleted()
-	 * @verifies return true if associated study is completed
-	 */
-	@Test
-	public void isCompleted_shouldReturnTrueIfAssociatedStudyIsCompleted() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(study);
-		
-		assertTrue(radiologyOrder.isCompleted());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isNotCompleted()
-	 * @verifies return true if associated study is null
-	 */
-	@Test
-	public void isNotCompleted_shouldReturnTrueIfAssociatedStudyIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(null);
-		
-		assertTrue(radiologyOrder.isNotCompleted());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isNotCompleted()
-	 * @verifies return true if associated study is not completed
-	 */
-	@Test
-	public void isNotCompleted_shouldReturnTrueIfAssociatedStudyIsNotCompleted() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(new RadiologyStudy());
-		
-		assertTrue(radiologyOrder.isNotCompleted());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isNotCompleted()
-	 * @verifies return false if associated study is completed
-	 */
-	@Test
-	public void isNotCompleted_shouldReturnFalseIfAssociatedStudyIsCompleted() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(study);
-		
-		assertFalse(radiologyOrder.isNotCompleted());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isDiscontinuationAllowed()
-	 * @verifies return false if order is not active
-	 */
-	@Test
-	public void isDiscontinuationAllowed_shouldReturnFalseIfOrderIsNotActive() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		radiologyOrder.setStudy(study);
-		radiologyOrder.setAction(Order.Action.DISCONTINUE);
-		
-		assertFalse(radiologyOrder.isDiscontinuationAllowed());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isDiscontinuationAllowed()
-	 * @verifies return false if radiology order is in progress
-	 */
-	@Test
-	public void isDiscontinuationAllowed_shouldReturnFalseIfRadiologyOrderIsInProgress() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		radiologyOrder.setStudy(study);
-		
-		assertFalse(radiologyOrder.isDiscontinuationAllowed());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isDiscontinuationAllowed()
-	 * @verifies return false if radiology order is completed
-	 */
-	@Test
-	public void isDiscontinuationAllowed_shouldReturnFalseIfRadiologyOrderIsCompleted() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy study = new RadiologyStudy();
-		study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(study);
-		
-		assertFalse(radiologyOrder.isDiscontinuationAllowed());
-	}
-	
-	/**
-	 * @see RadiologyOrder#isDiscontinuationAllowed()
-	 * @verifies return true if radiology order is active not in progress and not completed
-	 */
-	@Test
-	public void isDiscontinuationAllowed_shouldReturnTrueIfRadiologyOrderIsActiveNotInProgressAndNotCompleted()
-			throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setStudy(null);
-		
-		assertTrue(radiologyOrder.isDiscontinuationAllowed());
-	}
+    
+    /**
+     * @see RadiologyOrder#setStudy(RadiologyStudy)
+     * @verifies set the study attribute to given study
+     */
+    @Test
+    public void setStudy_shouldSetTheStudyAttributeToGivenStudy() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        radiologyOrder.setStudy(study);
+        
+        assertThat(radiologyOrder.getStudy(), is(study));
+    }
+    
+    /**
+     * @see RadiologyOrder#setStudy(RadiologyStudy)
+     * @verifies set the radiology order of given study to this radiology order
+     */
+    @Test
+    public void setStudy_shouldSetTheRadiologyOrderOfGivenStudyToThisRadiologyOrder() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        radiologyOrder.setStudy(study);
+        
+        assertThat(study.getRadiologyOrder(), is(radiologyOrder));
+    }
+    
+    /**
+     * @see RadiologyOrder#setStudy(RadiologyStudy)
+     * @verifies not fail given null
+     */
+    @Test
+    public void setStudy_shouldNotFailGivenNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(null);
+        
+        assertNotNull(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrder#isInProgress()
+     * @verifies return false if associated study is null
+     */
+    @Test
+    public void isInProgress_shouldReturnFalseIfAssociatedStudyIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(null);
+        
+        assertFalse(radiologyOrder.isInProgress());
+    }
+    
+    /**
+     * @see RadiologyOrder#isInProgress()
+     * @verifies return false if associated study is not in progress
+     */
+    @Test
+    public void isInProgress_shouldReturnFalseIfAssociatedStudyIsNotInProgress() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(study);
+        
+        assertFalse(radiologyOrder.isInProgress());
+    }
+    
+    /**
+     * @see RadiologyOrder#isInProgress()
+     * @verifies return true if associated study is in progress
+     */
+    @Test
+    public void isInProgress_shouldReturnTrueIfAssociatedStudyIsInProgress() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        radiologyOrder.setStudy(study);
+        
+        assertTrue(radiologyOrder.isInProgress());
+    }
+    
+    /**
+     * @see RadiologyOrder#isNotInProgress()
+     * @verifies return true if associated study is null
+     */
+    @Test
+    public void isNotInProgress_shouldReturnTrueIfAssociatedStudyIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(null);
+        
+        assertTrue(radiologyOrder.isNotInProgress());
+    }
+    
+    /**
+     * @see RadiologyOrder#isNotInProgress()
+     * @verifies return true if associated study is not in progress
+     */
+    @Test
+    public void isNotInProgress_shouldReturnTrueIfAssociatedStudyIsNotInProgress() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(study);
+        
+        assertTrue(radiologyOrder.isNotInProgress());
+    }
+    
+    /**
+     * @see RadiologyOrder#isNotInProgress()
+     * @verifies return false if associated study in progress
+     */
+    @Test
+    public void isNotInProgress_shouldReturnFalseIfAssociatedStudyInProgress() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        radiologyOrder.setStudy(study);
+        
+        assertFalse(radiologyOrder.isNotInProgress());
+    }
+    
+    /**
+     * @see RadiologyOrder#isCompleted()
+     * @verifies return false if associated study is null
+     */
+    @Test
+    public void isCompleted_shouldReturnFalseIfAssociatedStudyIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(null);
+        
+        assertFalse(radiologyOrder.isCompleted());
+    }
+    
+    /**
+     * @see RadiologyOrder#isCompleted()
+     * @verifies return false if associated study is not completed
+     */
+    @Test
+    public void isCompleted_shouldReturnFalseIfAssociatedStudyIsNotCompleted() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(new RadiologyStudy());
+        
+        assertFalse(radiologyOrder.isCompleted());
+    }
+    
+    /**
+     * @see RadiologyOrder#isCompleted()
+     * @verifies return true if associated study is completed
+     */
+    @Test
+    public void isCompleted_shouldReturnTrueIfAssociatedStudyIsCompleted() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(study);
+        
+        assertTrue(radiologyOrder.isCompleted());
+    }
+    
+    /**
+     * @see RadiologyOrder#isNotCompleted()
+     * @verifies return true if associated study is null
+     */
+    @Test
+    public void isNotCompleted_shouldReturnTrueIfAssociatedStudyIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(null);
+        
+        assertTrue(radiologyOrder.isNotCompleted());
+    }
+    
+    /**
+     * @see RadiologyOrder#isNotCompleted()
+     * @verifies return true if associated study is not completed
+     */
+    @Test
+    public void isNotCompleted_shouldReturnTrueIfAssociatedStudyIsNotCompleted() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(new RadiologyStudy());
+        
+        assertTrue(radiologyOrder.isNotCompleted());
+    }
+    
+    /**
+     * @see RadiologyOrder#isNotCompleted()
+     * @verifies return false if associated study is completed
+     */
+    @Test
+    public void isNotCompleted_shouldReturnFalseIfAssociatedStudyIsCompleted() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(study);
+        
+        assertFalse(radiologyOrder.isNotCompleted());
+    }
+    
+    /**
+     * @see RadiologyOrder#isDiscontinuationAllowed()
+     * @verifies return false if order is not active
+     */
+    @Test
+    public void isDiscontinuationAllowed_shouldReturnFalseIfOrderIsNotActive() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        radiologyOrder.setStudy(study);
+        radiologyOrder.setAction(Order.Action.DISCONTINUE);
+        
+        assertFalse(radiologyOrder.isDiscontinuationAllowed());
+    }
+    
+    /**
+     * @see RadiologyOrder#isDiscontinuationAllowed()
+     * @verifies return false if radiology order is in progress
+     */
+    @Test
+    public void isDiscontinuationAllowed_shouldReturnFalseIfRadiologyOrderIsInProgress() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        radiologyOrder.setStudy(study);
+        
+        assertFalse(radiologyOrder.isDiscontinuationAllowed());
+    }
+    
+    /**
+     * @see RadiologyOrder#isDiscontinuationAllowed()
+     * @verifies return false if radiology order is completed
+     */
+    @Test
+    public void isDiscontinuationAllowed_shouldReturnFalseIfRadiologyOrderIsCompleted() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy study = new RadiologyStudy();
+        study.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(study);
+        
+        assertFalse(radiologyOrder.isDiscontinuationAllowed());
+    }
+    
+    /**
+     * @see RadiologyOrder#isDiscontinuationAllowed()
+     * @verifies return true if radiology order is active not in progress and not completed
+     */
+    @Test
+    public void isDiscontinuationAllowed_shouldReturnTrueIfRadiologyOrderIsActiveNotInProgressAndNotCompleted()
+            throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setStudy(null);
+        
+        assertTrue(radiologyOrder.isDiscontinuationAllowed());
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
@@ -29,289 +29,289 @@ import org.springframework.validation.Errors;
  * Tests methods on the {@link RadiologyOrderValidator} class.
  */
 public class RadiologyOrderValidatorTest {
-	
-	/**
-	 * helper method to create a valid RadiologyOrder
-	 * 
-	 * @return [RadiologyOrder] radiologyOrder, passes validation
-	 */
-	public RadiologyOrder getValidRadiologyOrder() {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setOrderer(new Provider());
-		radiologyOrder.setPatient(new Patient());
-		radiologyOrder.setConcept(new Concept(88));
-		Calendar cal = Calendar.getInstance();
-		cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
-		radiologyOrder.setDateActivated(cal.getTime());
-		radiologyOrder.setAutoExpireDate(new Date());
-		radiologyOrder.setUrgency(RadiologyOrder.Urgency.ROUTINE);
-		radiologyOrder.setAction(RadiologyOrder.Action.NEW);
-		return radiologyOrder;
-	}
-	
-	/**
-	 * @verifies return false for other object types
-	 * @see RadiologyOrderValidator#supports(Class)
-	 */
-	@Test
-	public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
-		
-		RadiologyOrderValidator radiologyReportValidator = new RadiologyOrderValidator();
-		assertFalse(radiologyReportValidator.supports(Object.class));
-	}
-	
-	/**
-	 * @verifies return true for RadiologyOrder objects
-	 * @see RadiologyOrderValidator#supports(Class)
-	 */
-	@Test
-	public void supports_shouldReturnTrueForRadiologyOrderObjects() throws Exception {
-		
-		RadiologyOrderValidator radiologyReportValidator = new RadiologyOrderValidator();
-		assertTrue(radiologyReportValidator.supports(RadiologyOrder.class));
-	}
-	
-	/**
-	 * @verifies fail validation if action is null
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfActionIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		radiologyOrder.setAction(null);
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertTrue(errors.hasFieldErrors("action"));
-	}
-	
-	/**
-	 * @verifies fail validation if concept is null
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfConceptIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		radiologyOrder.setConcept(null);
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertFalse(errors.hasFieldErrors("discontinued"));
-		assertTrue(errors.hasFieldErrors("concept"));
-		assertFalse(errors.hasFieldErrors("patient"));
-		assertFalse(errors.hasFieldErrors("orderer"));
-	}
-	
-	/**
-	 * @verifies fail validation if dateActivated after autoExpireDate
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfDateActivatedAfterAutoExpireDate() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		Calendar cal = Calendar.getInstance();
-		cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
-		radiologyOrder.setDateActivated(new Date());
-		radiologyOrder.setAutoExpireDate(cal.getTime());
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertTrue(errors.hasFieldErrors("dateActivated"));
-		assertTrue(errors.hasFieldErrors("autoExpireDate"));
-	}
-	
-	/**
-	 * @verifies fail validation if dateActivated after dateStopped
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfDateActivatedAfterDateStopped() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		Calendar cal = Calendar.getInstance();
-		cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
-		radiologyOrder.setDateActivated(new Date());
-		OrderUtilTest.setDateStopped(radiologyOrder, cal.getTime());
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertTrue(errors.hasFieldErrors("dateActivated"));
-		assertTrue(errors.hasFieldErrors("dateStopped"));
-	}
-	
-	/**
-	 * @verifies fail validation if orderer is null
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfOrdererIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		radiologyOrder.setOrderer(null);
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertFalse(errors.hasFieldErrors("discontinued"));
-		assertFalse(errors.hasFieldErrors("concept"));
-		assertTrue(errors.hasFieldErrors("orderer"));
-		assertFalse(errors.hasFieldErrors("patient"));
-	}
-	
-	/**
-	 * @verifies fail validation if patient is null
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfPatientIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		radiologyOrder.setPatient(null);
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertFalse(errors.hasFieldErrors("discontinued"));
-		assertFalse(errors.hasFieldErrors("concept"));
-		assertTrue(errors.hasFieldErrors("patient"));
-		assertFalse(errors.hasFieldErrors("orderer"));
-	}
-	
-	/**
-	 * @verifies fail validation if radiologyOrder is null
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfRadiologyOrderIsNull() throws Exception {
-		
-		Errors errors = new BindException(new RadiologyOrder(), "radiologyOrder");
-		new RadiologyOrderValidator().validate(null, errors);
-		
-		assertTrue(errors.hasErrors());
-		assertThat((errors.getAllErrors()).get(0)
-				.getCode(), is("error.general"));
-	}
-	
-	/**
-	 * @verifies fail validation if scheduledDate is null when urgency is ON_SCHEDULED_DATE
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfScheduledDateIsNullWhenUrgencyIsON_SCHEDULED_DATE() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		
-		radiologyOrder.setUrgency(RadiologyOrder.Urgency.ON_SCHEDULED_DATE);
-		radiologyOrder.setScheduledDate(null);
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		assertTrue(errors.hasFieldErrors("scheduledDate"));
-		
-		radiologyOrder.setScheduledDate(new Date());
-		radiologyOrder.setUrgency(RadiologyOrder.Urgency.STAT);
-		errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		assertFalse(errors.hasFieldErrors("scheduledDate"));
-	}
-	
-	/**
-	 * @verifies fail validation if scheduledDate is set and urgency is not set as ON_SCHEDULED_DATE
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfScheduledDateIsSetAndUrgencyIsNotSetAsON_SCHEDULED_DATE() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		
-		radiologyOrder.setScheduledDate(new Date());
-		radiologyOrder.setUrgency(RadiologyOrder.Urgency.ROUTINE);
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		assertTrue(errors.hasFieldErrors("urgency"));
-		
-		radiologyOrder.setScheduledDate(new Date());
-		radiologyOrder.setUrgency(RadiologyOrder.Urgency.ON_SCHEDULED_DATE);
-		errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		assertFalse(errors.hasFieldErrors("urgency"));
-	}
-	
-	/**
-	 * @verifies fail validation if urgency is null
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfUrgencyIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		radiologyOrder.setUrgency(null);
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertTrue(errors.hasFieldErrors("urgency"));
-	}
-	
-	/**
-	 * @verifies fail validation if voided is null
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfVoidedIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		radiologyOrder.setVoided(null);
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertFalse(errors.hasFieldErrors("discontinued"));
-		assertTrue(errors.hasFieldErrors("voided"));
-		assertFalse(errors.hasFieldErrors("concept"));
-		assertFalse(errors.hasFieldErrors("patient"));
-		assertFalse(errors.hasFieldErrors("orderer"));
-	}
-	
-	/**
-	 * @verifies not allow a future dateActivated
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldNotAllowAFutureDateActivated() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		Calendar cal = Calendar.getInstance();
-		cal.add(Calendar.HOUR_OF_DAY, 1);
-		radiologyOrder.setDateActivated(cal.getTime());
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertTrue(errors.hasFieldErrors("dateActivated"));
-		assertThat(errors.getFieldError("dateActivated")
-				.getCode(), is("Order.error.dateActivatedInFuture"));
-	}
-	
-	/**
-	 * @verifies pass validation if all fields are correct
-	 * @see RadiologyOrderValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
-		
-		RadiologyOrder radiologyOrder = getValidRadiologyOrder();
-		
-		Errors errors = new BindException(radiologyOrder, "radiologyOrder");
-		new RadiologyOrderValidator().validate(radiologyOrder, errors);
-		
-		assertFalse(errors.hasErrors());
-	}
+    
+    /**
+     * helper method to create a valid RadiologyOrder
+     * 
+     * @return [RadiologyOrder] radiologyOrder, passes validation
+     */
+    public RadiologyOrder getValidRadiologyOrder() {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setOrderer(new Provider());
+        radiologyOrder.setPatient(new Patient());
+        radiologyOrder.setConcept(new Concept(88));
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
+        radiologyOrder.setDateActivated(cal.getTime());
+        radiologyOrder.setAutoExpireDate(new Date());
+        radiologyOrder.setUrgency(RadiologyOrder.Urgency.ROUTINE);
+        radiologyOrder.setAction(RadiologyOrder.Action.NEW);
+        return radiologyOrder;
+    }
+    
+    /**
+     * @verifies return false for other object types
+     * @see RadiologyOrderValidator#supports(Class)
+     */
+    @Test
+    public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
+        
+        RadiologyOrderValidator radiologyReportValidator = new RadiologyOrderValidator();
+        assertFalse(radiologyReportValidator.supports(Object.class));
+    }
+    
+    /**
+     * @verifies return true for RadiologyOrder objects
+     * @see RadiologyOrderValidator#supports(Class)
+     */
+    @Test
+    public void supports_shouldReturnTrueForRadiologyOrderObjects() throws Exception {
+        
+        RadiologyOrderValidator radiologyReportValidator = new RadiologyOrderValidator();
+        assertTrue(radiologyReportValidator.supports(RadiologyOrder.class));
+    }
+    
+    /**
+     * @verifies fail validation if action is null
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfActionIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        radiologyOrder.setAction(null);
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertTrue(errors.hasFieldErrors("action"));
+    }
+    
+    /**
+     * @verifies fail validation if concept is null
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfConceptIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        radiologyOrder.setConcept(null);
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertFalse(errors.hasFieldErrors("discontinued"));
+        assertTrue(errors.hasFieldErrors("concept"));
+        assertFalse(errors.hasFieldErrors("patient"));
+        assertFalse(errors.hasFieldErrors("orderer"));
+    }
+    
+    /**
+     * @verifies fail validation if dateActivated after autoExpireDate
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfDateActivatedAfterAutoExpireDate() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
+        radiologyOrder.setDateActivated(new Date());
+        radiologyOrder.setAutoExpireDate(cal.getTime());
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertTrue(errors.hasFieldErrors("dateActivated"));
+        assertTrue(errors.hasFieldErrors("autoExpireDate"));
+    }
+    
+    /**
+     * @verifies fail validation if dateActivated after dateStopped
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfDateActivatedAfterDateStopped() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        Calendar cal = Calendar.getInstance();
+        cal.set(Calendar.DAY_OF_MONTH, cal.get(Calendar.DAY_OF_MONTH) - 1);
+        radiologyOrder.setDateActivated(new Date());
+        OrderUtilTest.setDateStopped(radiologyOrder, cal.getTime());
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertTrue(errors.hasFieldErrors("dateActivated"));
+        assertTrue(errors.hasFieldErrors("dateStopped"));
+    }
+    
+    /**
+     * @verifies fail validation if orderer is null
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfOrdererIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        radiologyOrder.setOrderer(null);
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertFalse(errors.hasFieldErrors("discontinued"));
+        assertFalse(errors.hasFieldErrors("concept"));
+        assertTrue(errors.hasFieldErrors("orderer"));
+        assertFalse(errors.hasFieldErrors("patient"));
+    }
+    
+    /**
+     * @verifies fail validation if patient is null
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfPatientIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        radiologyOrder.setPatient(null);
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertFalse(errors.hasFieldErrors("discontinued"));
+        assertFalse(errors.hasFieldErrors("concept"));
+        assertTrue(errors.hasFieldErrors("patient"));
+        assertFalse(errors.hasFieldErrors("orderer"));
+    }
+    
+    /**
+     * @verifies fail validation if radiologyOrder is null
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfRadiologyOrderIsNull() throws Exception {
+        
+        Errors errors = new BindException(new RadiologyOrder(), "radiologyOrder");
+        new RadiologyOrderValidator().validate(null, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(), is("error.general"));
+    }
+    
+    /**
+     * @verifies fail validation if scheduledDate is null when urgency is ON_SCHEDULED_DATE
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfScheduledDateIsNullWhenUrgencyIsON_SCHEDULED_DATE() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        
+        radiologyOrder.setUrgency(RadiologyOrder.Urgency.ON_SCHEDULED_DATE);
+        radiologyOrder.setScheduledDate(null);
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        assertTrue(errors.hasFieldErrors("scheduledDate"));
+        
+        radiologyOrder.setScheduledDate(new Date());
+        radiologyOrder.setUrgency(RadiologyOrder.Urgency.STAT);
+        errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        assertFalse(errors.hasFieldErrors("scheduledDate"));
+    }
+    
+    /**
+     * @verifies fail validation if scheduledDate is set and urgency is not set as ON_SCHEDULED_DATE
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfScheduledDateIsSetAndUrgencyIsNotSetAsON_SCHEDULED_DATE() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        
+        radiologyOrder.setScheduledDate(new Date());
+        radiologyOrder.setUrgency(RadiologyOrder.Urgency.ROUTINE);
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        assertTrue(errors.hasFieldErrors("urgency"));
+        
+        radiologyOrder.setScheduledDate(new Date());
+        radiologyOrder.setUrgency(RadiologyOrder.Urgency.ON_SCHEDULED_DATE);
+        errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        assertFalse(errors.hasFieldErrors("urgency"));
+    }
+    
+    /**
+     * @verifies fail validation if urgency is null
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfUrgencyIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        radiologyOrder.setUrgency(null);
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertTrue(errors.hasFieldErrors("urgency"));
+    }
+    
+    /**
+     * @verifies fail validation if voided is null
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfVoidedIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        radiologyOrder.setVoided(null);
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertFalse(errors.hasFieldErrors("discontinued"));
+        assertTrue(errors.hasFieldErrors("voided"));
+        assertFalse(errors.hasFieldErrors("concept"));
+        assertFalse(errors.hasFieldErrors("patient"));
+        assertFalse(errors.hasFieldErrors("orderer"));
+    }
+    
+    /**
+     * @verifies not allow a future dateActivated
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldNotAllowAFutureDateActivated() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.HOUR_OF_DAY, 1);
+        radiologyOrder.setDateActivated(cal.getTime());
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertTrue(errors.hasFieldErrors("dateActivated"));
+        assertThat(errors.getFieldError("dateActivated")
+                .getCode(), is("Order.error.dateActivatedInFuture"));
+    }
+    
+    /**
+     * @verifies pass validation if all fields are correct
+     * @see RadiologyOrderValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
+        
+        RadiologyOrder radiologyOrder = getValidRadiologyOrder();
+        
+        Errors errors = new BindException(radiologyOrder, "radiologyOrder");
+        new RadiologyOrderValidator().validate(radiologyOrder, errors);
+        
+        assertFalse(errors.hasErrors());
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -39,631 +39,631 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Tests {@link RadiologyReportService}.
  */
 public class RadiologyReportServiceComponentTest extends BaseModuleContextSensitiveTest {
-	
-	private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml";
-	
-	private static final int EXISTING_RADIOLOGY_ORDER_ID = 2001;
-	
-	private static final int EXISTING_RADIOLOGY_REPORT_ID = 1;
-	
-	private static final int RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT = 2005;
-	
-	private static final int RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT = 2006;
-	
-	private static final int RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT = 2007;
-	
-	private static final int RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT = 2008;
-	
-	@Autowired
-	private ProviderService providerService;
-	
-	@Autowired
-	private RadiologyOrderService radiologyOrderService;
-	
-	@Autowired
-	private RadiologyReportService radiologyReportService;
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	/**
-	 * Overriding following method is necessary to enable MVCC which is disabled by default in DB h2
-	 * used for the component tests. This prevents following exception:
-	 * org.hibernate.exception.GenericJDBCException: could not load an entity:
-	 * [org.openmrs.GlobalProperty#order.nextOrderNumberSeed] due to "Timeout trying to lock table "
-	 * GLOBAL_PROPERTY"; SQL statement:" which occurs in all tests touching methods that call
-	 * orderService.saveOrder()
-	 */
-	@Override
-	public Properties getRuntimeProperties() {
-		Properties result = super.getRuntimeProperties();
-		String url = result.getProperty(Environment.URL);
-		if (url.contains("jdbc:h2:") && !url.contains(";MVCC=TRUE")) {
-			result.setProperty(Environment.URL, url + ";MVCC=TRUE");
-		}
-		return result;
-	}
-	
-	@Before
-	public void setUp() throws Exception {
-		executeDataSet(TEST_DATASET);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
-	 * @verifies create a radiology order with report status claimed given a completed radiology
-	 *           order
-	 */
-	@Test
-	public void createAndClaimRadiologyReport_shouldCreateARadiologyOrderWithReportStatusClaimedGivenACompletedRadiologyOrder()
-			throws Exception {
-		
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		radiologyOrder.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		RadiologyReport radiologyReport = radiologyReportService.createAndClaimRadiologyReport(radiologyOrder);
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.CLAIMED));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
-	 * @verifies throw an illegal argument exception if given radiology order is null
-	 */
-	@Test
-	public void createAndClaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNull()
-			throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder cannot be null");
-		radiologyReportService.createAndClaimRadiologyReport(null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
-	 * @verifies throw an illegal argument exception if given radiology order is not completed
-	 */
-	@Test
-	public void createAndClaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNotCompleted()
-			throws Exception {
-		
-		RadiologyOrder existingRadiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT);
-		existingRadiologyOrder.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder needs to be completed");
-		radiologyReportService.createAndClaimRadiologyReport(existingRadiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
-	 * @verifies throw an UnsupportedOperationException if given order has a completed
-	 *           RadiologyReport
-	 */
-	@Test
-	public void createAndClaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfGivenOrderHasACompletedRadiologyReport()
-			throws Exception {
-		RadiologyOrder existingRadiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT);
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		existingRadiologyReport.setReportStatus(RadiologyReportStatus.CLAIMED);
-		radiologyReportService.saveRadiologyReport(existingRadiologyReport);
-		radiologyReportService.completeRadiologyReport(existingRadiologyReport, providerService.getProvider(1));
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("cannot create radiologyReport for this radiologyOrder because it is already completed");
-		radiologyReportService.createAndClaimRadiologyReport(existingRadiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
-	 * @verifies throw an UnsupportedOperationException if given order has a claimed RadiologyReport
-	 */
-	@Test
-	public void createAndClaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfGivenOrderHasAClaimedRadiologyReport()
-			throws Exception {
-		
-		RadiologyOrder existingRadiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT);
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("cannot create radiologyReport for this radiologyOrder because it is already claimed");
-		radiologyReportService.createAndClaimRadiologyReport(existingRadiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 * @verifies save RadiologyReport in database and return it
-	 */
-	@Test
-	public void saveRadiologyReport_shouldSaveRadiologyReportInDatabaseAndReturnIt() throws Exception {
-		
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		existingRadiologyReport.setReportStatus(RadiologyReportStatus.CLAIMED);
-		existingRadiologyReport.setReportBody("test - text");
-		
-		assertNotNull(radiologyReportService.saveRadiologyReport(existingRadiologyReport));
-		assertThat(radiologyReportService.saveRadiologyReport(existingRadiologyReport)
-				.getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
-		assertThat(radiologyReportService.saveRadiologyReport(existingRadiologyReport)
-				.getReportBody(), is("test - text"));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 * @verifies throw an UnsupportedOperationException if radiologyReport is completed
-	 */
-	@Test
-	public void saveRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
-		
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("a completed radiologyReport cannot be saved");
-		radiologyReportService.saveRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 * @verifies throw an UnsupportedOperationException if radiologyReport is discontinued
-	 */
-	@Test
-	public void saveRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
-		
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("a discontinued radiologyReport cannot be saved");
-		radiologyReportService.saveRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 * @verifies throw an IllegalArgumentException if radiologyReport is null
-	 */
-	@Test
-	public void saveRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportIsNull() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReport cannot be null");
-		radiologyReportService.saveRadiologyReport(null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 * @verifies throw an IllegalArgumentException if radiologyReportStatus is null
-	 */
-	@Test
-	public void saveRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull() throws Exception {
-		
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		existingRadiologyReport.setReportStatus(null);
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReportStatus cannot be null");
-		radiologyReportService.saveRadiologyReport(existingRadiologyReport);
-	}
-	
-	/**
-	 * @verifies set the radiologyReportStatus of radiologyReport to discontinued
-	 * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 */
-	@Test
-	public void unclaimRadiologyReport_shouldSetTheRadiologyReportStatusOfRadiologyReportToDiscontinued() throws Exception {
-		
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		RadiologyReport radiologyReport = radiologyReportService.unclaimRadiologyReport(existingRadiologyReport);
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport.getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
-		assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.DISCONTINUED));
-	}
-	
-	/**
-	 * @verifies throw an IllegalArgumentException if radiologyReport is null
-	 * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 */
-	@Test
-	public void unclaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportIsNull() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReport cannot be null");
-		radiologyReportService.unclaimRadiologyReport(null);
-	}
-	
-	/**
-	 * @verifies throw an IllegalArgumentException if radiologyReportStatus is null
-	 * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 */
-	@Test
-	public void unclaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull() throws Exception {
-		
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		existingRadiologyReport.setReportStatus(null);
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReportStatus cannot be null");
-		radiologyReportService.unclaimRadiologyReport(existingRadiologyReport);
-	}
-	
-	/**
-	 * @verifies throw an UnsupportedOperationException if radiologyReport is completed
-	 * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 */
-	@Test
-	public void unclaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
-		
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("a completed radiologyReport cannot be unclaimed");
-		radiologyReportService.unclaimRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @verifies throw an UnsupportedOperationException if radiologyReport is discontinued
-	 * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
-	 */
-	@Test
-	public void unclaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
-		
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("a discontinued radiologyReport cannot be unclaimed");
-		radiologyReportService.unclaimRadiologyReport(radiologyReport);
-	}
-	
-	/**
-	 * @verifies set the completionDate of the radiologyReport to the day the RadiologyReport was
-	 *           completed
-	 * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
-	 *      org.openmrs.Provider)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldSetTheReportDateOfTheRadiologyReportToTheDayTheRadiologyReportWasCompleted()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.completeRadiologyReport(
-			radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID),
-			radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID)
-					.getPrincipalResultsInterpreter());
-		
-		assertNotNull(radiologyReport);
-		assertNotNull(radiologyReport.getReportDate());
-	}
-	
-	/**
-	 * @verifies set the radiologyReportStatus to complete
-	 * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
-	 *      org.openmrs.Provider)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldSetTheRadiologyReportStatusToComplete() throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.completeRadiologyReport(
-			radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID),
-			radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID)
-					.getPrincipalResultsInterpreter());
-		
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.COMPLETED));
-	}
-	
-	/**
-	 * @verifies throw an IllegalArgumentException if provider is null
-	 * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
-	 *      org.openmrs.Provider)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfPrincipalResultsInterpreterIsNull()
-			throws Exception {
-		
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReport cannot be null");
-		radiologyReportService.completeRadiologyReport(null, existingRadiologyReport.getPrincipalResultsInterpreter());
-	}
-	
-	/**
-	 * @verifies throw an IllegalArgumentException if radiologyReport is null
-	 * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
-	 *      org.openmrs.Provider)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportIsNull() throws Exception {
-		
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		existingRadiologyReport.setPrincipalResultsInterpreter(null);
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("principalResultsInterpreter cannot be null");
-		radiologyReportService.completeRadiologyReport(existingRadiologyReport, null);
-	}
-	
-	/**
-	 * @verifies throw an IllegalArgumentException if radiologyReportStatus is null
-	 * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
-	 *      org.openmrs.Provider)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull()
-			throws Exception {
-		
-		RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		existingRadiologyReport.setReportStatus(null);
-		Provider provider = new Provider();
-		provider.setId(1);
-		provider.setName("doctor");
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReportStatus cannot be null");
-		radiologyReportService.completeRadiologyReport(existingRadiologyReport, provider);
-	}
-	
-	/**
-	 * @verifies throw an UnsupportedOperationException if radiologyReport is completed
-	 * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
-	 *      org.openmrs.Provider)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
-		Provider provider = new Provider();
-		provider.setId(1);
-		provider.setName("doctor");
-		
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("a completed radiologyReport cannot be completed");
-		radiologyReportService.completeRadiologyReport(radiologyReport, provider);
-	}
-	
-	/**
-	 * @verifies throw an UnsupportedOperationException if radiologyReport is discontinued
-	 * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
-	 *      org.openmrs.Provider)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
-		Provider provider = new Provider();
-		provider.setId(1);
-		provider.setName("doctor");
-		
-		expectedException.expect(UnsupportedOperationException.class);
-		expectedException.expectMessage("a discontinued radiologyReport cannot be completed");
-		radiologyReportService.completeRadiologyReport(radiologyReport, provider);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportByRadiologyReportId(Integer)
-	 * @verifies fetch RadiologyReport matching given radiologyReportId
-	 */
-	@Test
-	public void getRadiologyReportByRadiologyReportId_shouldFetchRadiologyReportMatchingGivenRadiologyReportId()
-			throws Exception {
-		
-		RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
-		assertThat(radiologyReport.getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportByRadiologyReportId(Integer)
-	 * @verifies throw IllegalArgumentException if radiologyReportId is null
-	 */
-	@Test
-	public void getRadiologyReportByRadiologyReportId_shouldThrowIllegalArgumentExceptionIfRadiologyReportIdIsNull()
-			throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReportId cannot be null");
-		radiologyReportService.getRadiologyReportByRadiologyReportId(null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      org.openmrs.module.radiology.report.RadiologyReportStatus)
-	 * @verifies return a list of claimed RadiologyReport if radiologyReportStatus is claimed
-	 */
-	@Test
-	public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnAListOfClaimedRadiologyReportIfRadiologyReportStatusIsClaimed()
-			throws Exception {
-		
-		List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-			radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT),
-			RadiologyReportStatus.CLAIMED);
-		assertNotNull(radiologyReports);
-		assertThat(radiologyReports.size(), is(1));
-		
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      org.openmrs.module.radiology.report.RadiologyReportStatus)
-	 * @verifies return a list of completed RadiologyReport if radiologyReportStatus is completed
-	 */
-	@Test
-	public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnAListOfCompletedRadiologyReportIfReportStatusIsCompleted()
-			throws Exception {
-		
-		List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-			radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT),
-			RadiologyReportStatus.COMPLETED);
-		assertNotNull(radiologyReports);
-		assertThat(radiologyReports.size(), is(1));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      org.openmrs.module.radiology.report.RadiologyReportStatus)
-	 * @verifies return a list of discontinued RadiologyReport if radiologyReportStatus is claimed
-	 */
-	@Test
-	public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnAListOfDiscontinuedRadiologyReportIfReportStatusIsClaimed()
-			throws Exception {
-		
-		List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-			radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT),
-			RadiologyReportStatus.DISCONTINUED);
-		assertNotNull(radiologyReports);
-		assertThat(radiologyReports.size(), is(1));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      org.openmrs.module.radiology.report.RadiologyReportStatus)
-	 * @verifies return null if there are no RadiologyReports for this radiologyOrder
-	 */
-	@Test
-	public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnNullIfThereAreNoRadiologyReportsForThisRadiologyOrder()
-			throws Exception {
-		
-		List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-			radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT),
-			RadiologyReportStatus.CLAIMED);
-		assertThat(radiologyReports.size(), is(0));
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      org.openmrs.module.radiology.report.RadiologyReportStatus)
-	 * @verifies throw an IllegalArgumentException if given radiologyOrder is null
-	 */
-	@Test
-	public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNull()
-			throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder cannot be null");
-		radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(null, RadiologyReportStatus.CLAIMED);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-	 *      org.openmrs.module.radiology.report.RadiologyReportStatus)
-	 * @verifies throw an IllegalArgumentException if given radiologyReportStatus is null
-	 */
-	@Test
-	public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldThrowAnIllegalArgumentExceptionIfGivenReportStatusIsNull()
-			throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyReportStatus cannot be null");
-		radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-			radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT), null);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
-	 * @verifies return false if the RadiologyOrder has no claimed RadiologyReport
-	 */
-	@Test
-	public void hasRadiologyOrderClaimedRadiologyReport_shouldReturnFalseIfTheRadiologyOrderHasNoClaimedRadiologyReport()
-			throws Exception {
-		
-		boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
-		assertFalse(hasRadiologyOrderClaimedRadiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
-	 * @verifies return true if the RadiologyOrder has a claimed RadiologyReport
-	 */
-	@Test
-	public void hasRadiologyOrderClaimedRadiologyReport_shouldReturnTrueIfTheRadiologyOrderHasAClaimedRadiologyReport()
-			throws Exception {
-		
-		boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
-		assertTrue(hasRadiologyOrderClaimedRadiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
-	 * @verifies return false if radiologyOrder is null
-	 */
-	@Test
-	public void hasRadiologyOrderClaimedRadiologyReport_shouldReturnFalseIfTheRadiologyOrderIsNull() {
-		boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(null);
-		assertFalse(hasRadiologyOrderClaimedRadiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
-	 * @verifies return false if the RadiologyOrder has no completed RadiologyReport
-	 */
-	@Test
-	public void hasRadiologyOrderCompletedRadiologyReport_shouldReturnFalseIfTheRadiologyOrderHasNoCompletedRadiologyReport()
-			throws Exception {
-		
-		boolean hasRadiologyOrderCompletedRadiologyReport = radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
-		assertFalse(hasRadiologyOrderCompletedRadiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
-	 * @verifies return true if the RadiologyOrder has a completed RadiologyReport
-	 */
-	@Test
-	public void hasRadiologyOrderCompletedRadiologyReport_shouldReturnTrueIfTheRadiologyOrderHasACompletedRadiologyReport()
-			throws Exception {
-		
-		boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
-		assertTrue(hasRadiologyOrderClaimedRadiologyReport);
-	}
-	
-	/**
-	 * @see RadiologyOrderService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
-	 * @verifies throw an IllegalArgumentException if radiologyOrder is null
-	 */
-	@Test
-	public void hasRadiologyOrderCompletedRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyOrderIsNull()
-			throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder cannot be null");
-		radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(null);
-	}
-	
-	/**
-	 * @verifies return a RadiologyReport if the reportStatus is claimed
-	 * @see RadiologyOrderService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
-	 */
-	@Test
-	public void getActiveRadiologyReportByRadiologyOrder_shouldReturnARadiologyReportIfTheReportStatusIsClaimed()
-			throws Exception {
-		
-		RadiologyReport activeReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
-		
-		assertNotNull(activeReport);
-	}
-	
-	/**
-	 * @verifies return true a RadiologyReport if the reportStatus is completed
-	 * @see RadiologyOrderService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
-	 */
-	@Test
-	public void getActiveRadiologyReportByRadiologyOrder_shouldReturnTrueARadiologyReportIfTheReportStatusIsCompleted()
-			throws Exception {
-		
-		RadiologyReport activeReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
-		
-		assertNotNull(activeReport);
-	}
-	
-	/**
-	 * @verifies throw an IllegalArgumentException if radiologyOrder is null
-	 * @see RadiologyOrderService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
-	 */
-	@Test
-	public void getActiveRadiologyReportByRadiologyOrder_shouldThrowAnIllegalArgumentExceptionIfRadiologyOrderIsNull()
-			throws Exception {
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder cannot be null");
-		radiologyReportService.getActiveRadiologyReportByRadiologyOrder(null);
-	}
+    
+    private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml";
+    
+    private static final int EXISTING_RADIOLOGY_ORDER_ID = 2001;
+    
+    private static final int EXISTING_RADIOLOGY_REPORT_ID = 1;
+    
+    private static final int RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT = 2005;
+    
+    private static final int RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT = 2006;
+    
+    private static final int RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT = 2007;
+    
+    private static final int RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT = 2008;
+    
+    @Autowired
+    private ProviderService providerService;
+    
+    @Autowired
+    private RadiologyOrderService radiologyOrderService;
+    
+    @Autowired
+    private RadiologyReportService radiologyReportService;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    /**
+     * Overriding following method is necessary to enable MVCC which is disabled by default in DB h2
+     * used for the component tests. This prevents following exception:
+     * org.hibernate.exception.GenericJDBCException: could not load an entity:
+     * [org.openmrs.GlobalProperty#order.nextOrderNumberSeed] due to "Timeout trying to lock table "
+     * GLOBAL_PROPERTY"; SQL statement:" which occurs in all tests touching methods that call
+     * orderService.saveOrder()
+     */
+    @Override
+    public Properties getRuntimeProperties() {
+        Properties result = super.getRuntimeProperties();
+        String url = result.getProperty(Environment.URL);
+        if (url.contains("jdbc:h2:") && !url.contains(";MVCC=TRUE")) {
+            result.setProperty(Environment.URL, url + ";MVCC=TRUE");
+        }
+        return result;
+    }
+    
+    @Before
+    public void setUp() throws Exception {
+        executeDataSet(TEST_DATASET);
+    }
+    
+    /**
+     * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
+     * @verifies create a radiology order with report status claimed given a completed radiology
+     *           order
+     */
+    @Test
+    public void createAndClaimRadiologyReport_shouldCreateARadiologyOrderWithReportStatusClaimedGivenACompletedRadiologyOrder()
+            throws Exception {
+        
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        radiologyOrder.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        RadiologyReport radiologyReport = radiologyReportService.createAndClaimRadiologyReport(radiologyOrder);
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.CLAIMED));
+    }
+    
+    /**
+     * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
+     * @verifies throw an illegal argument exception if given radiology order is null
+     */
+    @Test
+    public void createAndClaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNull()
+            throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder cannot be null");
+        radiologyReportService.createAndClaimRadiologyReport(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
+     * @verifies throw an illegal argument exception if given radiology order is not completed
+     */
+    @Test
+    public void createAndClaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNotCompleted()
+            throws Exception {
+        
+        RadiologyOrder existingRadiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT);
+        existingRadiologyOrder.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder needs to be completed");
+        radiologyReportService.createAndClaimRadiologyReport(existingRadiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
+     * @verifies throw an UnsupportedOperationException if given order has a completed
+     *           RadiologyReport
+     */
+    @Test
+    public void createAndClaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfGivenOrderHasACompletedRadiologyReport()
+            throws Exception {
+        RadiologyOrder existingRadiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        existingRadiologyReport.setReportStatus(RadiologyReportStatus.CLAIMED);
+        radiologyReportService.saveRadiologyReport(existingRadiologyReport);
+        radiologyReportService.completeRadiologyReport(existingRadiologyReport, providerService.getProvider(1));
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("cannot create radiologyReport for this radiologyOrder because it is already completed");
+        radiologyReportService.createAndClaimRadiologyReport(existingRadiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrderService#createAndClaimRadiologyReport(RadiologyOrder)
+     * @verifies throw an UnsupportedOperationException if given order has a claimed RadiologyReport
+     */
+    @Test
+    public void createAndClaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfGivenOrderHasAClaimedRadiologyReport()
+            throws Exception {
+        
+        RadiologyOrder existingRadiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT);
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("cannot create radiologyReport for this radiologyOrder because it is already claimed");
+        radiologyReportService.createAndClaimRadiologyReport(existingRadiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     * @verifies save RadiologyReport in database and return it
+     */
+    @Test
+    public void saveRadiologyReport_shouldSaveRadiologyReportInDatabaseAndReturnIt() throws Exception {
+        
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        existingRadiologyReport.setReportStatus(RadiologyReportStatus.CLAIMED);
+        existingRadiologyReport.setReportBody("test - text");
+        
+        assertNotNull(radiologyReportService.saveRadiologyReport(existingRadiologyReport));
+        assertThat(radiologyReportService.saveRadiologyReport(existingRadiologyReport)
+                .getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
+        assertThat(radiologyReportService.saveRadiologyReport(existingRadiologyReport)
+                .getReportBody(), is("test - text"));
+    }
+    
+    /**
+     * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     * @verifies throw an UnsupportedOperationException if radiologyReport is completed
+     */
+    @Test
+    public void saveRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
+        
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("a completed radiologyReport cannot be saved");
+        radiologyReportService.saveRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     * @verifies throw an UnsupportedOperationException if radiologyReport is discontinued
+     */
+    @Test
+    public void saveRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
+        
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("a discontinued radiologyReport cannot be saved");
+        radiologyReportService.saveRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     * @verifies throw an IllegalArgumentException if radiologyReport is null
+     */
+    @Test
+    public void saveRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportIsNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReport cannot be null");
+        radiologyReportService.saveRadiologyReport(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#saveRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     * @verifies throw an IllegalArgumentException if radiologyReportStatus is null
+     */
+    @Test
+    public void saveRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull() throws Exception {
+        
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        existingRadiologyReport.setReportStatus(null);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReportStatus cannot be null");
+        radiologyReportService.saveRadiologyReport(existingRadiologyReport);
+    }
+    
+    /**
+     * @verifies set the radiologyReportStatus of radiologyReport to discontinued
+     * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     */
+    @Test
+    public void unclaimRadiologyReport_shouldSetTheRadiologyReportStatusOfRadiologyReportToDiscontinued() throws Exception {
+        
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.unclaimRadiologyReport(existingRadiologyReport);
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport.getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
+        assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.DISCONTINUED));
+    }
+    
+    /**
+     * @verifies throw an IllegalArgumentException if radiologyReport is null
+     * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     */
+    @Test
+    public void unclaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportIsNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReport cannot be null");
+        radiologyReportService.unclaimRadiologyReport(null);
+    }
+    
+    /**
+     * @verifies throw an IllegalArgumentException if radiologyReportStatus is null
+     * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     */
+    @Test
+    public void unclaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull() throws Exception {
+        
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        existingRadiologyReport.setReportStatus(null);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReportStatus cannot be null");
+        radiologyReportService.unclaimRadiologyReport(existingRadiologyReport);
+    }
+    
+    /**
+     * @verifies throw an UnsupportedOperationException if radiologyReport is completed
+     * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     */
+    @Test
+    public void unclaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
+        
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("a completed radiologyReport cannot be unclaimed");
+        radiologyReportService.unclaimRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @verifies throw an UnsupportedOperationException if radiologyReport is discontinued
+     * @see RadiologyOrderService#unclaimRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport)
+     */
+    @Test
+    public void unclaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
+        
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("a discontinued radiologyReport cannot be unclaimed");
+        radiologyReportService.unclaimRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @verifies set the completionDate of the radiologyReport to the day the RadiologyReport was
+     *           completed
+     * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
+     *      org.openmrs.Provider)
+     */
+    @Test
+    public void completeRadiologyReport_shouldSetTheReportDateOfTheRadiologyReportToTheDayTheRadiologyReportWasCompleted()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.completeRadiologyReport(
+            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID),
+            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID)
+                    .getPrincipalResultsInterpreter());
+        
+        assertNotNull(radiologyReport);
+        assertNotNull(radiologyReport.getReportDate());
+    }
+    
+    /**
+     * @verifies set the radiologyReportStatus to complete
+     * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
+     *      org.openmrs.Provider)
+     */
+    @Test
+    public void completeRadiologyReport_shouldSetTheRadiologyReportStatusToComplete() throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.completeRadiologyReport(
+            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID),
+            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID)
+                    .getPrincipalResultsInterpreter());
+        
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.COMPLETED));
+    }
+    
+    /**
+     * @verifies throw an IllegalArgumentException if provider is null
+     * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
+     *      org.openmrs.Provider)
+     */
+    @Test
+    public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfPrincipalResultsInterpreterIsNull()
+            throws Exception {
+        
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReport cannot be null");
+        radiologyReportService.completeRadiologyReport(null, existingRadiologyReport.getPrincipalResultsInterpreter());
+    }
+    
+    /**
+     * @verifies throw an IllegalArgumentException if radiologyReport is null
+     * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
+     *      org.openmrs.Provider)
+     */
+    @Test
+    public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportIsNull() throws Exception {
+        
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        existingRadiologyReport.setPrincipalResultsInterpreter(null);
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("principalResultsInterpreter cannot be null");
+        radiologyReportService.completeRadiologyReport(existingRadiologyReport, null);
+    }
+    
+    /**
+     * @verifies throw an IllegalArgumentException if radiologyReportStatus is null
+     * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
+     *      org.openmrs.Provider)
+     */
+    @Test
+    public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull()
+            throws Exception {
+        
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        existingRadiologyReport.setReportStatus(null);
+        Provider provider = new Provider();
+        provider.setId(1);
+        provider.setName("doctor");
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReportStatus cannot be null");
+        radiologyReportService.completeRadiologyReport(existingRadiologyReport, provider);
+    }
+    
+    /**
+     * @verifies throw an UnsupportedOperationException if radiologyReport is completed
+     * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
+     *      org.openmrs.Provider)
+     */
+    @Test
+    public void completeRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
+        Provider provider = new Provider();
+        provider.setId(1);
+        provider.setName("doctor");
+        
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("a completed radiologyReport cannot be completed");
+        radiologyReportService.completeRadiologyReport(radiologyReport, provider);
+    }
+    
+    /**
+     * @verifies throw an UnsupportedOperationException if radiologyReport is discontinued
+     * @see RadiologyOrderService#completeRadiologyReport(org.openmrs.module.radiology.report.RadiologyReport,
+     *      org.openmrs.Provider)
+     */
+    @Test
+    public void completeRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
+        Provider provider = new Provider();
+        provider.setId(1);
+        provider.setName("doctor");
+        
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("a discontinued radiologyReport cannot be completed");
+        radiologyReportService.completeRadiologyReport(radiologyReport, provider);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportByRadiologyReportId(Integer)
+     * @verifies fetch RadiologyReport matching given radiologyReportId
+     */
+    @Test
+    public void getRadiologyReportByRadiologyReportId_shouldFetchRadiologyReportMatchingGivenRadiologyReportId()
+            throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        assertThat(radiologyReport.getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportByRadiologyReportId(Integer)
+     * @verifies throw IllegalArgumentException if radiologyReportId is null
+     */
+    @Test
+    public void getRadiologyReportByRadiologyReportId_shouldThrowIllegalArgumentExceptionIfRadiologyReportIdIsNull()
+            throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReportId cannot be null");
+        radiologyReportService.getRadiologyReportByRadiologyReportId(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      org.openmrs.module.radiology.report.RadiologyReportStatus)
+     * @verifies return a list of claimed RadiologyReport if radiologyReportStatus is claimed
+     */
+    @Test
+    public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnAListOfClaimedRadiologyReportIfRadiologyReportStatusIsClaimed()
+            throws Exception {
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
+            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT),
+            RadiologyReportStatus.CLAIMED);
+        assertNotNull(radiologyReports);
+        assertThat(radiologyReports.size(), is(1));
+        
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      org.openmrs.module.radiology.report.RadiologyReportStatus)
+     * @verifies return a list of completed RadiologyReport if radiologyReportStatus is completed
+     */
+    @Test
+    public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnAListOfCompletedRadiologyReportIfReportStatusIsCompleted()
+            throws Exception {
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
+            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT),
+            RadiologyReportStatus.COMPLETED);
+        assertNotNull(radiologyReports);
+        assertThat(radiologyReports.size(), is(1));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      org.openmrs.module.radiology.report.RadiologyReportStatus)
+     * @verifies return a list of discontinued RadiologyReport if radiologyReportStatus is claimed
+     */
+    @Test
+    public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnAListOfDiscontinuedRadiologyReportIfReportStatusIsClaimed()
+            throws Exception {
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
+            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT),
+            RadiologyReportStatus.DISCONTINUED);
+        assertNotNull(radiologyReports);
+        assertThat(radiologyReports.size(), is(1));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      org.openmrs.module.radiology.report.RadiologyReportStatus)
+     * @verifies return null if there are no RadiologyReports for this radiologyOrder
+     */
+    @Test
+    public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldReturnNullIfThereAreNoRadiologyReportsForThisRadiologyOrder()
+            throws Exception {
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
+            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT),
+            RadiologyReportStatus.CLAIMED);
+        assertThat(radiologyReports.size(), is(0));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      org.openmrs.module.radiology.report.RadiologyReportStatus)
+     * @verifies throw an IllegalArgumentException if given radiologyOrder is null
+     */
+    @Test
+    public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNull()
+            throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder cannot be null");
+        radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(null, RadiologyReportStatus.CLAIMED);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
+     *      org.openmrs.module.radiology.report.RadiologyReportStatus)
+     * @verifies throw an IllegalArgumentException if given radiologyReportStatus is null
+     */
+    @Test
+    public void getRadiologyReportsByRadiologyOrderAndReportStatus_shouldThrowAnIllegalArgumentExceptionIfGivenReportStatusIsNull()
+            throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReportStatus cannot be null");
+        radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
+            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT), null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
+     * @verifies return false if the RadiologyOrder has no claimed RadiologyReport
+     */
+    @Test
+    public void hasRadiologyOrderClaimedRadiologyReport_shouldReturnFalseIfTheRadiologyOrderHasNoClaimedRadiologyReport()
+            throws Exception {
+        
+        boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
+        assertFalse(hasRadiologyOrderClaimedRadiologyReport);
+    }
+    
+    /**
+     * @see RadiologyOrderService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
+     * @verifies return true if the RadiologyOrder has a claimed RadiologyReport
+     */
+    @Test
+    public void hasRadiologyOrderClaimedRadiologyReport_shouldReturnTrueIfTheRadiologyOrderHasAClaimedRadiologyReport()
+            throws Exception {
+        
+        boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
+        assertTrue(hasRadiologyOrderClaimedRadiologyReport);
+    }
+    
+    /**
+     * @see RadiologyOrderService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
+     * @verifies return false if radiologyOrder is null
+     */
+    @Test
+    public void hasRadiologyOrderClaimedRadiologyReport_shouldReturnFalseIfTheRadiologyOrderIsNull() {
+        boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(null);
+        assertFalse(hasRadiologyOrderClaimedRadiologyReport);
+    }
+    
+    /**
+     * @see RadiologyOrderService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
+     * @verifies return false if the RadiologyOrder has no completed RadiologyReport
+     */
+    @Test
+    public void hasRadiologyOrderCompletedRadiologyReport_shouldReturnFalseIfTheRadiologyOrderHasNoCompletedRadiologyReport()
+            throws Exception {
+        
+        boolean hasRadiologyOrderCompletedRadiologyReport = radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
+        assertFalse(hasRadiologyOrderCompletedRadiologyReport);
+    }
+    
+    /**
+     * @see RadiologyOrderService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
+     * @verifies return true if the RadiologyOrder has a completed RadiologyReport
+     */
+    @Test
+    public void hasRadiologyOrderCompletedRadiologyReport_shouldReturnTrueIfTheRadiologyOrderHasACompletedRadiologyReport()
+            throws Exception {
+        
+        boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
+        assertTrue(hasRadiologyOrderClaimedRadiologyReport);
+    }
+    
+    /**
+     * @see RadiologyOrderService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
+     * @verifies throw an IllegalArgumentException if radiologyOrder is null
+     */
+    @Test
+    public void hasRadiologyOrderCompletedRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyOrderIsNull()
+            throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder cannot be null");
+        radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(null);
+    }
+    
+    /**
+     * @verifies return a RadiologyReport if the reportStatus is claimed
+     * @see RadiologyOrderService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
+     */
+    @Test
+    public void getActiveRadiologyReportByRadiologyOrder_shouldReturnARadiologyReportIfTheReportStatusIsClaimed()
+            throws Exception {
+        
+        RadiologyReport activeReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
+        
+        assertNotNull(activeReport);
+    }
+    
+    /**
+     * @verifies return true a RadiologyReport if the reportStatus is completed
+     * @see RadiologyOrderService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
+     */
+    @Test
+    public void getActiveRadiologyReportByRadiologyOrder_shouldReturnTrueARadiologyReportIfTheReportStatusIsCompleted()
+            throws Exception {
+        
+        RadiologyReport activeReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
+        
+        assertNotNull(activeReport);
+    }
+    
+    /**
+     * @verifies throw an IllegalArgumentException if radiologyOrder is null
+     * @see RadiologyOrderService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
+     */
+    @Test
+    public void getActiveRadiologyReportByRadiologyOrder_shouldThrowAnIllegalArgumentExceptionIfRadiologyOrderIsNull()
+            throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder cannot be null");
+        radiologyReportService.getActiveRadiologyReportByRadiologyOrder(null);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
@@ -30,78 +30,78 @@ import org.openmrs.module.radiology.study.RadiologyStudy;
  * Tests {@link RadiologyReport}
  */
 public class RadiologyReportTest {
-	
-	private RadiologyOrder radiologyOrder;
-	
-	private RadiologyReport radiologyReport;
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	@Before
-	public void setUp() {
-		
-		final OrderType radiologyOrderType = new OrderType("Radiology Order", "Order type for radiology exams",
-				"org.openmrs.module.radiology.order.RadiologyOrder");
-		final Provider principalResultsInterpreter = new Provider();
-		principalResultsInterpreter.setId(1);
-		principalResultsInterpreter.setName("doctor");
-		
-		radiologyOrder = new RadiologyOrder();
-		radiologyOrder.setOrderId(1);
-		radiologyOrder.setOrderType(radiologyOrderType);
-		radiologyOrder.setPatient(new Patient());
-		Calendar calendar = Calendar.getInstance();
-		calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
-		radiologyOrder.setScheduledDate(calendar.getTime());
-		radiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
-		radiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
-		radiologyOrder.setVoided(false);
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setStudyId(1);
-		radiologyStudy.setStudyInstanceUid("1.2.826.0.1.3680043.8.2186.1.1");
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(radiologyStudy);
-		
-		radiologyReport = new RadiologyReport(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyReport#RadiologyReport(RadiologyOrder)
-	 * @verifies set radiology order to given radiology order and report status to claimed
-	 */
-	@Test
-	public void RadiologyReport_shouldSetRadiologyOrderToGivenRadiologyOrderAndReportStatusToClaimed() throws Exception {
-		
-		radiologyReport = new RadiologyReport(radiologyOrder);
-		
-		assertThat(radiologyReport.getRadiologyOrder(), is(radiologyOrder));
-		assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.CLAIMED));
-	}
-	
-	/**
-	 * @see RadiologyReport#RadiologyReport(RadiologyOrder)
-	 * @verifies throw an illegal argument exception if given radiology order is not completed
-	 */
-	@Test
-	public void RadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNotCompleted() throws Exception {
-		
-		radiologyOrder.setStudy(new RadiologyStudy());
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder is not completed");
-		radiologyReport = new RadiologyReport(radiologyOrder);
-	}
-	
-	/**
-	 * @see RadiologyReport#RadiologyReport(RadiologyOrder)
-	 * @verifies throw an illegal argument exception if given radiology order is null
-	 */
-	@Test
-	public void RadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNull() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrder cannot be null");
-		radiologyReport = new RadiologyReport(null);
-	}
+    
+    private RadiologyOrder radiologyOrder;
+    
+    private RadiologyReport radiologyReport;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    @Before
+    public void setUp() {
+        
+        final OrderType radiologyOrderType = new OrderType("Radiology Order", "Order type for radiology exams",
+                "org.openmrs.module.radiology.order.RadiologyOrder");
+        final Provider principalResultsInterpreter = new Provider();
+        principalResultsInterpreter.setId(1);
+        principalResultsInterpreter.setName("doctor");
+        
+        radiologyOrder = new RadiologyOrder();
+        radiologyOrder.setOrderId(1);
+        radiologyOrder.setOrderType(radiologyOrderType);
+        radiologyOrder.setPatient(new Patient());
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
+        radiologyOrder.setScheduledDate(calendar.getTime());
+        radiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
+        radiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
+        radiologyOrder.setVoided(false);
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setStudyId(1);
+        radiologyStudy.setStudyInstanceUid("1.2.826.0.1.3680043.8.2186.1.1");
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(radiologyStudy);
+        
+        radiologyReport = new RadiologyReport(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyReport#RadiologyReport(RadiologyOrder)
+     * @verifies set radiology order to given radiology order and report status to claimed
+     */
+    @Test
+    public void RadiologyReport_shouldSetRadiologyOrderToGivenRadiologyOrderAndReportStatusToClaimed() throws Exception {
+        
+        radiologyReport = new RadiologyReport(radiologyOrder);
+        
+        assertThat(radiologyReport.getRadiologyOrder(), is(radiologyOrder));
+        assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.CLAIMED));
+    }
+    
+    /**
+     * @see RadiologyReport#RadiologyReport(RadiologyOrder)
+     * @verifies throw an illegal argument exception if given radiology order is not completed
+     */
+    @Test
+    public void RadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNotCompleted() throws Exception {
+        
+        radiologyOrder.setStudy(new RadiologyStudy());
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder is not completed");
+        radiologyReport = new RadiologyReport(radiologyOrder);
+    }
+    
+    /**
+     * @see RadiologyReport#RadiologyReport(RadiologyOrder)
+     * @verifies throw an illegal argument exception if given radiology order is null
+     */
+    @Test
+    public void RadiologyReport_shouldThrowAnIllegalArgumentExceptionIfGivenRadiologyOrderIsNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrder cannot be null");
+        radiologyReport = new RadiologyReport(null);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
@@ -26,87 +26,87 @@ import org.springframework.validation.Errors;
  * Tests {@link RadiologyReportValidator}.
  */
 public class RadiologyReportValidatorTest {
-	
-	/**
-	 * @verifies return false for other object types
-	 * @see RadiologyReportValidator#supports(Class)
-	 */
-	@Test
-	public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
-		
-		RadiologyReportValidator radiologyReportValidator = new RadiologyReportValidator();
-		assertFalse(radiologyReportValidator.supports(Object.class));
-	}
-	
-	/**
-	 * @verifies return true for RadiologyReport objects
-	 * @see RadiologyReportValidator#supports(Class)
-	 */
-	@Test
-	public void supports_shouldReturnTrueForRadiologyReportObjects() throws Exception {
-		
-		RadiologyReportValidator radiologyReportValidator = new RadiologyReportValidator();
-		assertTrue(radiologyReportValidator.supports(RadiologyReport.class));
-	}
-	
-	/**
-	 * @verifies fail validation if principalResultsInterpreter is empty or whitespace
-	 * @see RadiologyReportValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfPrincipalResultsInterpreterIsEmptyOrWhitespace() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(radiologyStudy);
-		RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
-		radiologyReport.setPrincipalResultsInterpreter(null);
-		
-		Errors errors = new BindException(radiologyReport, "radiologyReport");
-		new RadiologyReportValidator().validate(radiologyReport, errors);
-		
-		assertTrue(errors.hasFieldErrors("principalResultsInterpreter"));
-	}
-	
-	/**
-	 * @verifies fail validation if radiologyReport is null
-	 * @see RadiologyReportValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldFailValidationIfRadiologyReportIsNull() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(radiologyStudy);
-		RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
-		
-		Errors errors = new BindException(radiologyReport, "radiologyReport");
-		new RadiologyReportValidator().validate(null, errors);
-		
-		assertTrue(errors.hasErrors());
-		assertThat((errors.getAllErrors()).get(0)
-				.getCode(), is("error.general"));
-	}
-	
-	/**
-	 * @verifies pass validation if all fields are correct
-	 * @see RadiologyReportValidator#validate(Object, Errors)
-	 */
-	@Test
-	public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
-		
-		RadiologyOrder radiologyOrder = new RadiologyOrder();
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		radiologyOrder.setStudy(radiologyStudy);
-		RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
-		radiologyReport.setPrincipalResultsInterpreter(new Provider());
-		
-		Errors errors = new BindException(radiologyReport, "radiologyReport");
-		new RadiologyReportValidator().validate(radiologyReport, errors);
-		
-		assertFalse(errors.hasErrors());
-	}
+    
+    /**
+     * @verifies return false for other object types
+     * @see RadiologyReportValidator#supports(Class)
+     */
+    @Test
+    public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
+        
+        RadiologyReportValidator radiologyReportValidator = new RadiologyReportValidator();
+        assertFalse(radiologyReportValidator.supports(Object.class));
+    }
+    
+    /**
+     * @verifies return true for RadiologyReport objects
+     * @see RadiologyReportValidator#supports(Class)
+     */
+    @Test
+    public void supports_shouldReturnTrueForRadiologyReportObjects() throws Exception {
+        
+        RadiologyReportValidator radiologyReportValidator = new RadiologyReportValidator();
+        assertTrue(radiologyReportValidator.supports(RadiologyReport.class));
+    }
+    
+    /**
+     * @verifies fail validation if principalResultsInterpreter is empty or whitespace
+     * @see RadiologyReportValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfPrincipalResultsInterpreterIsEmptyOrWhitespace() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(radiologyStudy);
+        RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
+        radiologyReport.setPrincipalResultsInterpreter(null);
+        
+        Errors errors = new BindException(radiologyReport, "radiologyReport");
+        new RadiologyReportValidator().validate(radiologyReport, errors);
+        
+        assertTrue(errors.hasFieldErrors("principalResultsInterpreter"));
+    }
+    
+    /**
+     * @verifies fail validation if radiologyReport is null
+     * @see RadiologyReportValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldFailValidationIfRadiologyReportIsNull() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(radiologyStudy);
+        RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
+        
+        Errors errors = new BindException(radiologyReport, "radiologyReport");
+        new RadiologyReportValidator().validate(null, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(), is("error.general"));
+    }
+    
+    /**
+     * @verifies pass validation if all fields are correct
+     * @see RadiologyReportValidator#validate(Object, Errors)
+     */
+    @Test
+    public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
+        
+        RadiologyOrder radiologyOrder = new RadiologyOrder();
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(radiologyStudy);
+        RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
+        radiologyReport.setPrincipalResultsInterpreter(new Provider());
+        
+        Errors errors = new BindException(radiologyReport, "radiologyReport");
+        new RadiologyReportValidator().validate(radiologyReport, errors);
+        
+        assertFalse(errors.hasErrors());
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
@@ -44,322 +44,322 @@ import org.springframework.beans.factory.annotation.Autowired;
  * Tests {@link RadiologyStudyService}
  */
 public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensitiveTest {
-	
-	private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml";
-	
-	private static final int PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER = 70021;
-	
-	private static final int RADIOLOGY_ORDER_ID_WITHOUT_STUDY = 2004;
-	
-	private static final int EXISTING_RADIOLOGY_ORDER_ID = 2001;
-	
-	private static final int NON_EXISTING_RADIOLOGY_ORDER_ID = 99999;
-	
-	private static final String EXISTING_STUDY_INSTANCE_UID = "1.2.826.0.1.3680043.8.2186.1.1";
-	
-	private static final String NON_EXISTING_STUDY_INSTANCE_UID = "1.2.826.0.1.3680043.8.2186.1.9999";
-	
-	private static final int EXISTING_STUDY_ID = 1;
-	
-	private static final int NON_EXISTING_STUDY_ID = 99999;
-	
-	@Autowired
-	private PatientService patientService;
-	
-	@Autowired
-	private RadiologyOrderService radiologyOrderService;
-	
-	@Autowired
-	private RadiologyStudyService radiologyStudyService;
-	
-	@Autowired
-	private RadiologyProperties radiologyProperties;
-	
-	@Rule
-	public ExpectedException expectedException = ExpectedException.none();
-	
-	/**
-	 * Overriding following method is necessary to enable MVCC which is disabled by default in DB h2
-	 * used for the component tests. This prevents following exception:
-	 * org.hibernate.exception.GenericJDBCException: could not load an entity:
-	 * [org.openmrs.GlobalProperty#order.nextOrderNumberSeed] due to "Timeout trying to lock table "
-	 * GLOBAL_PROPERTY"; SQL statement:" which occurs in all tests touching methods that call
-	 * orderService.saveOrder()
-	 */
-	@Override
-	public Properties getRuntimeProperties() {
-		Properties result = super.getRuntimeProperties();
-		String url = result.getProperty(Environment.URL);
-		if (url.contains("jdbc:h2:") && !url.contains(";MVCC=TRUE")) {
-			result.setProperty(Environment.URL, url + ";MVCC=TRUE");
-		}
-		return result;
-	}
-	
-	@Before
-	public void setUp() throws Exception {
-		executeDataSet(TEST_DATASET);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#saveStudy(RadiologyStudy)
-	 * @verifies create new study from given study object
-	 */
-	@Test
-	public void saveStudy_shouldCreateNewStudyFromGivenStudyObject() throws Exception {
-		
-		RadiologyStudy radiologyStudy = getUnsavedStudy();
-		RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
-		radiologyOrder.setStudy(radiologyStudy);
-		
-		RadiologyStudy createdStudy = radiologyStudyService.saveStudy(radiologyStudy);
-		
-		assertNotNull(createdStudy);
-		assertThat(createdStudy, is(radiologyStudy));
-		assertThat(createdStudy.getStudyId(), is(radiologyStudy.getStudyId()));
-		assertNotNull(createdStudy.getStudyInstanceUid());
-		assertThat(createdStudy.getStudyInstanceUid(), is(radiologyProperties.getStudyPrefix() + createdStudy.getStudyId()));
-		assertThat(createdStudy.getModality(), is(radiologyStudy.getModality()));
-		assertThat(createdStudy.getRadiologyOrder(), is(radiologyStudy.getRadiologyOrder()));
-	}
-	
-	/**
-	 * Convenience method to get a RadiologyStudy object with all required values filled (except
-	 * radiologyOrder) in but which is not yet saved in the database
-	 * 
-	 * @return RadiologyStudy object that can be saved to the database
-	 */
-	public RadiologyStudy getUnsavedStudy() {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setModality(Modality.CT);
-		radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
-		return radiologyStudy;
-	}
-	
-	/**
-	 * @see RadiologyStudyService#saveStudy(RadiologyStudy)
-	 * @verifies update existing study
-	 */
-	@Test
-	public void saveStudy_shouldUpdateExistingStudy() throws Exception {
-		
-		RadiologyStudy existingStudy = radiologyStudyService.getStudyByStudyId(EXISTING_STUDY_ID);
-		Modality modalityPreUpdate = existingStudy.getModality();
-		Modality modalityPostUpdate = Modality.XA;
-		existingStudy.setModality(modalityPostUpdate);
-		
-		RadiologyStudy updatedStudy = radiologyStudyService.saveStudy(existingStudy);
-		
-		assertNotNull(updatedStudy);
-		assertThat(updatedStudy, is(existingStudy));
-		assertThat(modalityPreUpdate, is(not(modalityPostUpdate)));
-		assertThat(updatedStudy.getModality(), is(modalityPostUpdate));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByStudyId(Integer)
-	 * @verifies should return study for given study id
-	 */
-	@Test
-	public void getStudyByStudyId_shouldReturnStudyForGivenStudyId() throws Exception {
-		
-		RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyId(EXISTING_STUDY_ID);
-		
-		assertNotNull(radiologyStudy);
-		assertThat(radiologyStudy.getRadiologyOrder()
-				.getOrderId(), is(EXISTING_RADIOLOGY_ORDER_ID));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByStudyId(Integer)
-	 * @verifies should return null if no match was found
-	 */
-	@Test
-	public void getStudyByStudyId_shouldReturnNullIfNoMatchIsFound() throws Exception {
-		
-		RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyId(NON_EXISTING_STUDY_ID);
-		
-		assertNull(radiologyStudy);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByOrderId(Integer)
-	 * @verifies should return study associated with radiology order for which order id is given
-	 */
-	@Test
-	public void getStudyByOrderId_shouldReturnStudyMatching() throws Exception {
-		
-		RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-		
-		assertNotNull(radiologyStudy);
-		assertThat(radiologyStudy.getRadiologyOrder()
-				.getOrderId(), is(EXISTING_RADIOLOGY_ORDER_ID));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByOrderId(Integer)
-	 * @verifies should return null if no match was found
-	 */
-	@Test
-	public void getStudyByOrderId_shouldReturnNullIfNoMatchIsFound() {
-		
-		RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByOrderId(NON_EXISTING_RADIOLOGY_ORDER_ID);
-		
-		assertNull(radiologyStudy);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByOrderId(Integer)
-	 * @verifies should throw illegal argument exception given null
-	 */
-	@Test
-	public void getStudyByOrderId_shouldThrowIllegalArgumentExceptionGivenNull() {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("orderId is required");
-		radiologyStudyService.getStudyByOrderId(null);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
-	 * @verifies should return study matching study instance uid
-	 */
-	@Test
-	public void getStudyByStudyInstanceUid_shouldReturnStudyMatchingUid() throws Exception {
-		RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyInstanceUid(EXISTING_STUDY_INSTANCE_UID);
-		
-		assertNotNull(radiologyStudy);
-		assertThat(radiologyStudy.getStudyInstanceUid(), is(EXISTING_STUDY_INSTANCE_UID));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
-	 * @verifies should return null if no match was found
-	 */
-	@Test
-	public void getStudyByStudyInstanceUid_shouldReturnNullIfNoMatchIsFound() throws Exception {
-		RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyInstanceUid(NON_EXISTING_STUDY_INSTANCE_UID);
-		
-		assertNull(radiologyStudy);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
-	 * @verifies should throw IllegalArgumentException if study instance uid is null
-	 */
-	@Test
-	public void getStudyByStudyInstanceUid_shouldThrowIllegalArgumentExceptionIfUidIsNull() throws Exception {
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("studyInstanceUid is required");
-		radiologyStudyService.getStudyByStudyInstanceUid(null);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
-	 * @verifies should fetch all studies for given radiology orders
-	 */
-	@Test
-	public void getStudiesByRadiologyOrders_shouldFetchAllStudiesForGivenRadiologyOrders() throws Exception {
-		
-		Patient patient = patientService.getPatient(PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER);
-		List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patient);
-		
-		List<RadiologyStudy> radiologyStudies = radiologyStudyService.getStudiesByRadiologyOrders(radiologyOrders);
-		
-		assertThat(radiologyStudies.size(), is(radiologyOrders.size()));
-		assertThat(radiologyStudies.get(0)
-				.getRadiologyOrder(), is(radiologyOrders.get(0)));
-		assertThat(radiologyStudies.get(1)
-				.getRadiologyOrder(), is(radiologyOrders.get(1)));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
-	 * @verifies should return empty list given radiology orders without associated studies
-	 */
-	@Test
-	public void getStudiesByRadiologyOrders_shouldReturnEmptyListGivenRadiologyOrdersWithoutAssociatedStudies()
-			throws Exception {
-		
-		RadiologyOrder radiologyOrderWithoutStudy = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
-		List<RadiologyOrder> radiologyOrders = Arrays.asList(radiologyOrderWithoutStudy);
-		
-		List<RadiologyStudy> radiologyStudies = radiologyStudyService.getStudiesByRadiologyOrders(radiologyOrders);
-		
-		assertThat(radiologyOrders.size(), is(1));
-		assertThat(radiologyStudies.size(), is(0));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
-	 * @verifies should return empty list given empty radiology order list
-	 */
-	@Test
-	public void getStudiesByRadiologyOrders_shouldReturnEmptyListGivenEmptyRadiologyOrderList() throws Exception {
-		
-		List<RadiologyOrder> orders = new ArrayList<RadiologyOrder>();
-		
-		List<RadiologyStudy> radiologyStudies = radiologyStudyService.getStudiesByRadiologyOrders(orders);
-		
-		assertThat(orders.size(), is(0));
-		assertThat(radiologyStudies.size(), is(0));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
-	 * @verifies should throw IllegalArgumentException given null
-	 */
-	@Test
-	public void getStudiesByRadiologyOrders_shouldThrowIllegalArgumentExceptionGivenNull() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("radiologyOrders are required");
-		radiologyStudyService.getStudiesByRadiologyOrders(null);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
-	 * @verifies update performed status of study associated with given study instance uid
-	 */
-	@Test
-	public void updateStudyPerformedStatus_shouldUpdatePerformedStatusOfStudyAssociatedWithGivenStudyInstanceUid()
-			throws Exception {
-		
-		RadiologyStudy existingStudy = radiologyStudyService.getStudyByStudyId(EXISTING_STUDY_ID);
-		PerformedProcedureStepStatus performedStatusPreUpdate = existingStudy.getPerformedStatus();
-		PerformedProcedureStepStatus performedStatusPostUpdate = PerformedProcedureStepStatus.COMPLETED;
-		
-		RadiologyStudy updatedStudy = radiologyStudyService.updateStudyPerformedStatus(existingStudy.getStudyInstanceUid(),
-			performedStatusPostUpdate);
-		
-		assertNotNull(updatedStudy);
-		assertThat(updatedStudy, is(existingStudy));
-		assertThat(performedStatusPreUpdate, is(not(performedStatusPostUpdate)));
-		assertThat(updatedStudy.getPerformedStatus(), is(performedStatusPostUpdate));
-	}
-	
-	/**
-	 * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
-	 * @verifies throw illegal argument exception if study instance uid is null
-	 */
-	@Test
-	public void updateStudyPerformedStatus_shouldThrowIllegalArgumentExceptionIfStudyInstanceUidIsNull() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("studyInstanceUid is required");
-		radiologyStudyService.updateStudyPerformedStatus(null, PerformedProcedureStepStatus.COMPLETED);
-	}
-	
-	/**
-	 * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
-	 * @verifies throw illegal argument exception if performed status is null
-	 */
-	@Test
-	public void updateStudyPerformedStatus_shouldThrowIllegalArgumentExceptionIfPerformedStatusIsNull() throws Exception {
-		
-		expectedException.expect(IllegalArgumentException.class);
-		expectedException.expectMessage("performedStatus is required");
-		radiologyStudyService.updateStudyPerformedStatus(EXISTING_STUDY_INSTANCE_UID, null);
-	}
+    
+    private static final String TEST_DATASET = "org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml";
+    
+    private static final int PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER = 70021;
+    
+    private static final int RADIOLOGY_ORDER_ID_WITHOUT_STUDY = 2004;
+    
+    private static final int EXISTING_RADIOLOGY_ORDER_ID = 2001;
+    
+    private static final int NON_EXISTING_RADIOLOGY_ORDER_ID = 99999;
+    
+    private static final String EXISTING_STUDY_INSTANCE_UID = "1.2.826.0.1.3680043.8.2186.1.1";
+    
+    private static final String NON_EXISTING_STUDY_INSTANCE_UID = "1.2.826.0.1.3680043.8.2186.1.9999";
+    
+    private static final int EXISTING_STUDY_ID = 1;
+    
+    private static final int NON_EXISTING_STUDY_ID = 99999;
+    
+    @Autowired
+    private PatientService patientService;
+    
+    @Autowired
+    private RadiologyOrderService radiologyOrderService;
+    
+    @Autowired
+    private RadiologyStudyService radiologyStudyService;
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    /**
+     * Overriding following method is necessary to enable MVCC which is disabled by default in DB h2
+     * used for the component tests. This prevents following exception:
+     * org.hibernate.exception.GenericJDBCException: could not load an entity:
+     * [org.openmrs.GlobalProperty#order.nextOrderNumberSeed] due to "Timeout trying to lock table "
+     * GLOBAL_PROPERTY"; SQL statement:" which occurs in all tests touching methods that call
+     * orderService.saveOrder()
+     */
+    @Override
+    public Properties getRuntimeProperties() {
+        Properties result = super.getRuntimeProperties();
+        String url = result.getProperty(Environment.URL);
+        if (url.contains("jdbc:h2:") && !url.contains(";MVCC=TRUE")) {
+            result.setProperty(Environment.URL, url + ";MVCC=TRUE");
+        }
+        return result;
+    }
+    
+    @Before
+    public void setUp() throws Exception {
+        executeDataSet(TEST_DATASET);
+    }
+    
+    /**
+     * @see RadiologyStudyService#saveStudy(RadiologyStudy)
+     * @verifies create new study from given study object
+     */
+    @Test
+    public void saveStudy_shouldCreateNewStudyFromGivenStudyObject() throws Exception {
+        
+        RadiologyStudy radiologyStudy = getUnsavedStudy();
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
+        radiologyOrder.setStudy(radiologyStudy);
+        
+        RadiologyStudy createdStudy = radiologyStudyService.saveStudy(radiologyStudy);
+        
+        assertNotNull(createdStudy);
+        assertThat(createdStudy, is(radiologyStudy));
+        assertThat(createdStudy.getStudyId(), is(radiologyStudy.getStudyId()));
+        assertNotNull(createdStudy.getStudyInstanceUid());
+        assertThat(createdStudy.getStudyInstanceUid(), is(radiologyProperties.getStudyPrefix() + createdStudy.getStudyId()));
+        assertThat(createdStudy.getModality(), is(radiologyStudy.getModality()));
+        assertThat(createdStudy.getRadiologyOrder(), is(radiologyStudy.getRadiologyOrder()));
+    }
+    
+    /**
+     * Convenience method to get a RadiologyStudy object with all required values filled (except
+     * radiologyOrder) in but which is not yet saved in the database
+     * 
+     * @return RadiologyStudy object that can be saved to the database
+     */
+    public RadiologyStudy getUnsavedStudy() {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setModality(Modality.CT);
+        radiologyStudy.setScheduledStatus(ScheduledProcedureStepStatus.SCHEDULED);
+        return radiologyStudy;
+    }
+    
+    /**
+     * @see RadiologyStudyService#saveStudy(RadiologyStudy)
+     * @verifies update existing study
+     */
+    @Test
+    public void saveStudy_shouldUpdateExistingStudy() throws Exception {
+        
+        RadiologyStudy existingStudy = radiologyStudyService.getStudyByStudyId(EXISTING_STUDY_ID);
+        Modality modalityPreUpdate = existingStudy.getModality();
+        Modality modalityPostUpdate = Modality.XA;
+        existingStudy.setModality(modalityPostUpdate);
+        
+        RadiologyStudy updatedStudy = radiologyStudyService.saveStudy(existingStudy);
+        
+        assertNotNull(updatedStudy);
+        assertThat(updatedStudy, is(existingStudy));
+        assertThat(modalityPreUpdate, is(not(modalityPostUpdate)));
+        assertThat(updatedStudy.getModality(), is(modalityPostUpdate));
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByStudyId(Integer)
+     * @verifies should return study for given study id
+     */
+    @Test
+    public void getStudyByStudyId_shouldReturnStudyForGivenStudyId() throws Exception {
+        
+        RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyId(EXISTING_STUDY_ID);
+        
+        assertNotNull(radiologyStudy);
+        assertThat(radiologyStudy.getRadiologyOrder()
+                .getOrderId(), is(EXISTING_RADIOLOGY_ORDER_ID));
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByStudyId(Integer)
+     * @verifies should return null if no match was found
+     */
+    @Test
+    public void getStudyByStudyId_shouldReturnNullIfNoMatchIsFound() throws Exception {
+        
+        RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyId(NON_EXISTING_STUDY_ID);
+        
+        assertNull(radiologyStudy);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByOrderId(Integer)
+     * @verifies should return study associated with radiology order for which order id is given
+     */
+    @Test
+    public void getStudyByOrderId_shouldReturnStudyMatching() throws Exception {
+        
+        RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        
+        assertNotNull(radiologyStudy);
+        assertThat(radiologyStudy.getRadiologyOrder()
+                .getOrderId(), is(EXISTING_RADIOLOGY_ORDER_ID));
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByOrderId(Integer)
+     * @verifies should return null if no match was found
+     */
+    @Test
+    public void getStudyByOrderId_shouldReturnNullIfNoMatchIsFound() {
+        
+        RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByOrderId(NON_EXISTING_RADIOLOGY_ORDER_ID);
+        
+        assertNull(radiologyStudy);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByOrderId(Integer)
+     * @verifies should throw illegal argument exception given null
+     */
+    @Test
+    public void getStudyByOrderId_shouldThrowIllegalArgumentExceptionGivenNull() {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("orderId is required");
+        radiologyStudyService.getStudyByOrderId(null);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
+     * @verifies should return study matching study instance uid
+     */
+    @Test
+    public void getStudyByStudyInstanceUid_shouldReturnStudyMatchingUid() throws Exception {
+        RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyInstanceUid(EXISTING_STUDY_INSTANCE_UID);
+        
+        assertNotNull(radiologyStudy);
+        assertThat(radiologyStudy.getStudyInstanceUid(), is(EXISTING_STUDY_INSTANCE_UID));
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
+     * @verifies should return null if no match was found
+     */
+    @Test
+    public void getStudyByStudyInstanceUid_shouldReturnNullIfNoMatchIsFound() throws Exception {
+        RadiologyStudy radiologyStudy = radiologyStudyService.getStudyByStudyInstanceUid(NON_EXISTING_STUDY_INSTANCE_UID);
+        
+        assertNull(radiologyStudy);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudyByStudyInstanceUid(String)
+     * @verifies should throw IllegalArgumentException if study instance uid is null
+     */
+    @Test
+    public void getStudyByStudyInstanceUid_shouldThrowIllegalArgumentExceptionIfUidIsNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("studyInstanceUid is required");
+        radiologyStudyService.getStudyByStudyInstanceUid(null);
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
+     * @verifies should fetch all studies for given radiology orders
+     */
+    @Test
+    public void getStudiesByRadiologyOrders_shouldFetchAllStudiesForGivenRadiologyOrders() throws Exception {
+        
+        Patient patient = patientService.getPatient(PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER);
+        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patient);
+        
+        List<RadiologyStudy> radiologyStudies = radiologyStudyService.getStudiesByRadiologyOrders(radiologyOrders);
+        
+        assertThat(radiologyStudies.size(), is(radiologyOrders.size()));
+        assertThat(radiologyStudies.get(0)
+                .getRadiologyOrder(), is(radiologyOrders.get(0)));
+        assertThat(radiologyStudies.get(1)
+                .getRadiologyOrder(), is(radiologyOrders.get(1)));
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
+     * @verifies should return empty list given radiology orders without associated studies
+     */
+    @Test
+    public void getStudiesByRadiologyOrders_shouldReturnEmptyListGivenRadiologyOrdersWithoutAssociatedStudies()
+            throws Exception {
+        
+        RadiologyOrder radiologyOrderWithoutStudy = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
+        List<RadiologyOrder> radiologyOrders = Arrays.asList(radiologyOrderWithoutStudy);
+        
+        List<RadiologyStudy> radiologyStudies = radiologyStudyService.getStudiesByRadiologyOrders(radiologyOrders);
+        
+        assertThat(radiologyOrders.size(), is(1));
+        assertThat(radiologyStudies.size(), is(0));
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
+     * @verifies should return empty list given empty radiology order list
+     */
+    @Test
+    public void getStudiesByRadiologyOrders_shouldReturnEmptyListGivenEmptyRadiologyOrderList() throws Exception {
+        
+        List<RadiologyOrder> orders = new ArrayList<RadiologyOrder>();
+        
+        List<RadiologyStudy> radiologyStudies = radiologyStudyService.getStudiesByRadiologyOrders(orders);
+        
+        assertThat(orders.size(), is(0));
+        assertThat(radiologyStudies.size(), is(0));
+    }
+    
+    /**
+     * @see RadiologyStudyService#getStudiesByRadiologyOrders(List<RadiologyOrder>)
+     * @verifies should throw IllegalArgumentException given null
+     */
+    @Test
+    public void getStudiesByRadiologyOrders_shouldThrowIllegalArgumentExceptionGivenNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyOrders are required");
+        radiologyStudyService.getStudiesByRadiologyOrders(null);
+    }
+    
+    /**
+     * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
+     * @verifies update performed status of study associated with given study instance uid
+     */
+    @Test
+    public void updateStudyPerformedStatus_shouldUpdatePerformedStatusOfStudyAssociatedWithGivenStudyInstanceUid()
+            throws Exception {
+        
+        RadiologyStudy existingStudy = radiologyStudyService.getStudyByStudyId(EXISTING_STUDY_ID);
+        PerformedProcedureStepStatus performedStatusPreUpdate = existingStudy.getPerformedStatus();
+        PerformedProcedureStepStatus performedStatusPostUpdate = PerformedProcedureStepStatus.COMPLETED;
+        
+        RadiologyStudy updatedStudy = radiologyStudyService.updateStudyPerformedStatus(existingStudy.getStudyInstanceUid(),
+            performedStatusPostUpdate);
+        
+        assertNotNull(updatedStudy);
+        assertThat(updatedStudy, is(existingStudy));
+        assertThat(performedStatusPreUpdate, is(not(performedStatusPostUpdate)));
+        assertThat(updatedStudy.getPerformedStatus(), is(performedStatusPostUpdate));
+    }
+    
+    /**
+     * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
+     * @verifies throw illegal argument exception if study instance uid is null
+     */
+    @Test
+    public void updateStudyPerformedStatus_shouldThrowIllegalArgumentExceptionIfStudyInstanceUidIsNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("studyInstanceUid is required");
+        radiologyStudyService.updateStudyPerformedStatus(null, PerformedProcedureStepStatus.COMPLETED);
+    }
+    
+    /**
+     * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
+     * @verifies throw illegal argument exception if performed status is null
+     */
+    @Test
+    public void updateStudyPerformedStatus_shouldThrowIllegalArgumentExceptionIfPerformedStatusIsNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("performedStatus is required");
+        radiologyStudyService.updateStudyPerformedStatus(EXISTING_STUDY_INSTANCE_UID, null);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyTest.java
@@ -12,124 +12,124 @@ import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
  * Tests {@link RadiologyStudy}.
  */
 public class RadiologyStudyTest {
-	
-	/**
-	 * @see RadiologyStudy#isInProgress()
-	 * @verifies return false if performed status is null
-	 */
-	@Test
-	public void isInProgress_shouldReturnFalseIfPerformedStatusIsNull() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		assertFalse(radiologyStudy.isInProgress());
-	}
-	
-	/**
-	 * @see RadiologyStudy#isInProgress()
-	 * @verifies return false if performed status is not in progress
-	 */
-	@Test
-	public void isInProgress_shouldReturnFalseIfPerformedStatusIsNotInProgress() throws Exception {
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		assertFalse(radiologyStudy.isInProgress());
-	}
-	
-	/**
-	 * @see RadiologyStudy#isInProgress()
-	 * @verifies return true if performed status is in progress
-	 */
-	@Test
-	public void isInProgress_shouldReturnTrueIfPerformedStatusIsInProgress() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		assertTrue(radiologyStudy.isInProgress());
-	}
-	
-	/**
-	 * @see RadiologyStudy#isCompleted()
-	 * @verifies return false if performedStatus is null
-	 */
-	@Test
-	public void isCompleted_shouldReturnFalseIfPerformedStatusIsNull() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		assertFalse(radiologyStudy.isCompleted());
-	}
-	
-	/**
-	 * @see RadiologyStudy#isCompleted()
-	 * @verifies return false if performedStatus is not completed
-	 */
-	@Test
-	public void isCompleted_shouldReturnFalseIfPerformedStatusIsNotCompleted() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		assertFalse(radiologyStudy.isCompleted());
-	}
-	
-	/**
-	 * @see RadiologyStudy#isCompleted()
-	 * @verifies return true if performedStatus is completed
-	 */
-	@Test
-	public void isCompleted_shouldReturnTrueIfPerformedStatusIsCompleted() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		assertTrue(radiologyStudy.isCompleted());
-	}
-	
-	/**
-	 * @see RadiologyStudy#isScheduleable()
-	 * @verifies return true if performedStatus is null
-	 */
-	@Test
-	public void isScheduleable_shouldReturnTrueIfPerformedStatusIsNull() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(null);
-		assertTrue(radiologyStudy.isScheduleable());
-	}
-	
-	/**
-	 * @see RadiologyStudy#isScheduleable()
-	 * @verifies return false if performedStatus is not null
-	 */
-	@Test
-	public void isScheduleable_shouldReturnFalseIfPerformedStatusIsNotNull() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		
-		assertFalse(radiologyStudy.isScheduleable());
-	}
-	
-	/**
-	 * @see RadiologyStudy#toString()
-	 * @verifies return string of study
-	 */
-	@Test
-	public void toString_shouldReturnStringOfStudy() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		radiologyStudy.setStudyId(2);
-		radiologyStudy.setStudyInstanceUid("1.2.4.1.2");
-		
-		assertThat(radiologyStudy.toString(), startsWith("studyId: 2 studyInstanceUid: 1.2.4.1.2"));
-	}
-	
-	/**
-	 * @see RadiologyStudy#toString()
-	 * @verifies return string of study with null for members that are null
-	 */
-	@Test
-	public void toString_shouldReturnStringOfStudyWithNullForMembersThatAreNull() throws Exception {
-		
-		RadiologyStudy radiologyStudy = new RadiologyStudy();
-		
-		assertThat(radiologyStudy.toString(), startsWith("studyId: null studyInstanceUid: null"));
-	}
+    
+    /**
+     * @see RadiologyStudy#isInProgress()
+     * @verifies return false if performed status is null
+     */
+    @Test
+    public void isInProgress_shouldReturnFalseIfPerformedStatusIsNull() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        assertFalse(radiologyStudy.isInProgress());
+    }
+    
+    /**
+     * @see RadiologyStudy#isInProgress()
+     * @verifies return false if performed status is not in progress
+     */
+    @Test
+    public void isInProgress_shouldReturnFalseIfPerformedStatusIsNotInProgress() throws Exception {
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        assertFalse(radiologyStudy.isInProgress());
+    }
+    
+    /**
+     * @see RadiologyStudy#isInProgress()
+     * @verifies return true if performed status is in progress
+     */
+    @Test
+    public void isInProgress_shouldReturnTrueIfPerformedStatusIsInProgress() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        assertTrue(radiologyStudy.isInProgress());
+    }
+    
+    /**
+     * @see RadiologyStudy#isCompleted()
+     * @verifies return false if performedStatus is null
+     */
+    @Test
+    public void isCompleted_shouldReturnFalseIfPerformedStatusIsNull() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        assertFalse(radiologyStudy.isCompleted());
+    }
+    
+    /**
+     * @see RadiologyStudy#isCompleted()
+     * @verifies return false if performedStatus is not completed
+     */
+    @Test
+    public void isCompleted_shouldReturnFalseIfPerformedStatusIsNotCompleted() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        assertFalse(radiologyStudy.isCompleted());
+    }
+    
+    /**
+     * @see RadiologyStudy#isCompleted()
+     * @verifies return true if performedStatus is completed
+     */
+    @Test
+    public void isCompleted_shouldReturnTrueIfPerformedStatusIsCompleted() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        assertTrue(radiologyStudy.isCompleted());
+    }
+    
+    /**
+     * @see RadiologyStudy#isScheduleable()
+     * @verifies return true if performedStatus is null
+     */
+    @Test
+    public void isScheduleable_shouldReturnTrueIfPerformedStatusIsNull() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(null);
+        assertTrue(radiologyStudy.isScheduleable());
+    }
+    
+    /**
+     * @see RadiologyStudy#isScheduleable()
+     * @verifies return false if performedStatus is not null
+     */
+    @Test
+    public void isScheduleable_shouldReturnFalseIfPerformedStatusIsNotNull() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        
+        assertFalse(radiologyStudy.isScheduleable());
+    }
+    
+    /**
+     * @see RadiologyStudy#toString()
+     * @verifies return string of study
+     */
+    @Test
+    public void toString_shouldReturnStringOfStudy() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setStudyId(2);
+        radiologyStudy.setStudyInstanceUid("1.2.4.1.2");
+        
+        assertThat(radiologyStudy.toString(), startsWith("studyId: 2 studyInstanceUid: 1.2.4.1.2"));
+    }
+    
+    /**
+     * @see RadiologyStudy#toString()
+     * @verifies return string of study with null for members that are null
+     */
+    @Test
+    public void toString_shouldReturnStringOfStudyWithNullForMembersThatAreNull() throws Exception {
+        
+        RadiologyStudy radiologyStudy = new RadiologyStudy();
+        
+        assertThat(radiologyStudy.toString(), startsWith("studyId: null studyInstanceUid: null"));
+    }
 }

--- a/api/src/test/resources/test-hibernate.cfg.xml
+++ b/api/src/test/resources/test-hibernate.cfg.xml
@@ -7,6 +7,6 @@
 	<session-factory>
 		<mapping resource="RadiologyOrder.hbm.xml" />
 		<mapping resource="RadiologyStudy.hbm.xml" />
-		<mapping resource="RadiologyReport.hbm.xml"/>
+		<mapping resource="RadiologyReport.hbm.xml" />
 	</session-factory>
 </hibernate-configuration>

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletController.java
@@ -34,25 +34,25 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("**/patientDashboardRadiologyTab.portlet")
 public class PatientDashboardRadiologyTabPortletController extends PortletController {
-	
-	public static final String PATIENT_DASHBOARD_RADIOLOGY_TAB = "patientDashboardRadiologyTab.portlet";
-	
-	@Autowired
-	private RadiologyOrderService radiologyOrderService;
-	
-	/**
-	 * Add radiologyOrders to the <code>model</code> for patient contained in the <code>model</code>.
-	 * 
-	 * @param request HttpServletRequest that holds all information about this request
-	 * @param model holds variables that will be used in the jsp view
-	 * @should model is populated with all radiology orders for given patient
-	 * @should model is populated with an empty list of radiology orders if given patient is unknown
-	 */
-	@Override
-	protected void populateModel(HttpServletRequest request, Map<String, Object> model) {
-		
-		final Patient patient = (Patient) model.get("patient");
-		final List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patient);
-		model.put("radiologyOrders", radiologyOrders);
-	}
+    
+    public static final String PATIENT_DASHBOARD_RADIOLOGY_TAB = "patientDashboardRadiologyTab.portlet";
+    
+    @Autowired
+    private RadiologyOrderService radiologyOrderService;
+    
+    /**
+     * Add radiologyOrders to the <code>model</code> for patient contained in the <code>model</code>.
+     * 
+     * @param request HttpServletRequest that holds all information about this request
+     * @param model holds variables that will be used in the jsp view
+     * @should model is populated with all radiology orders for given patient
+     * @should model is populated with an empty list of radiology orders if given patient is unknown
+     */
+    @Override
+    protected void populateModel(HttpServletRequest request, Map<String, Object> model) {
+        
+        final Patient patient = (Patient) model.get("patient");
+        final List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatient(patient);
+        model.put("radiologyOrders", radiologyOrders);
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/PortletsController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/PortletsController.java
@@ -32,175 +32,175 @@ import org.springframework.web.servlet.ModelAndView;
 
 @Controller
 public class PortletsController {
-	
-	private static final Log log = LogFactory.getLog(PortletsController.class);
-	
-	@Autowired
-	private RadiologyOrderService radiologyOrderService;
-	
-	@Autowired
-	private PatientService patientService;
-	
-	/**
-	 * Get URL to the patientOverview portlet
-	 * 
-	 * @return patient info route
-	 * @should return string with patient info route
-	 */
-	@RequestMapping("/module/radiology/portlets/patientOverview.portlet")
-	String getPatientInfoRoute() {
-		return "module/radiology/portlets/patientOverview";
-	}
-	
-	/**
-	 * Get model and view containing radiology orders and studies for given patient string and date
-	 * range
-	 * 
-	 * @param patientQuery Patient string for which radiology orders and studies should be returned
-	 *        for
-	 * @param startDate Date from which on the radiology orders and studies should be returned for
-	 * @param endDate Date until which the radiology orders and studies should be returned for
-	 * @return model and view containing radiology orders and studies corresponding to given
-	 *         criteria
-	 * @should populate model and view with radiology orders associated with given empty patient and
-	 *         given date range null
-	 * @should not populate model and view with radiology orders if start date is after end date
-	 */
-	@RequestMapping(value = "/module/radiology/portlets/orderSearch.portlet")
-	ModelAndView getRadiologyOrdersByPatientQueryAndDateRange(
-			@RequestParam(value = "patientQuery", required = false) String patientQuery,
-			@RequestParam(value = "startDate", required = false) @DateTimeFormat(iso = ISO.DATE) Date startDate,
-			@RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = ISO.DATE) Date endDate) {
-		final ModelAndView mav = new ModelAndView("module/radiology/portlets/orderSearch");
-		
-		if (isEndDateBeforeStartDate(startDate, endDate)) {
-			mav.addObject("exceptionText", "radiology.crossDate");
-			mav.addObject("radiologyOrders", new ArrayList<RadiologyOrder>());
-			return mav;
-		}
-		
-		List<RadiologyOrder> radiologyOrders = getRadiologyOrdersForPatientQuery(patientQuery);
-		radiologyOrders = filterRadiologyOrdersByDateRange(radiologyOrders, startDate, endDate);
-		mav.addObject("radiologyOrders", radiologyOrders);
-		
-		return mav;
-	}
-	
-	/**
-	 * Get all orders for given date range
-	 * 
-	 * @param unfilteredRadiologyOrders list of orders which matches a patientQuery
-	 * @param startDate Date from which on the radiology orders should be returned for
-	 * @param endDate Date until which the radiology should be returned for
-	 * @return list of radiology orders corresponding to given criteria
-	 * @should return list of orders matching a given date range
-	 * @should return list of all orders with start date if start date is null and end date is null
-	 * @should return empty list of orders with given end date and start date before any order has
-	 *         started
-	 * @should return empty list of orders with given end date and start date after any order has
-	 *         started
-	 * @should return list of orders started after given start date but given end date null
-	 * @should return list of orders started before given end date but given start date null
-	 */
-	private List<RadiologyOrder> filterRadiologyOrdersByDateRange(List<RadiologyOrder> unfilteredRadiologyOrders,
-			Date startDate, Date endDate) {
-		
-		final List<RadiologyOrder> result = new Vector<RadiologyOrder>();
-		
-		if (startDate == null && endDate == null) {
-			return unfilteredRadiologyOrders;
-		} else if (startDate == null && endDate != null) {
-			for (RadiologyOrder order : unfilteredRadiologyOrders) {
-				if (order.getEffectiveStartDate() != null && order.getEffectiveStartDate()
-						.compareTo(endDate) <= 0) {
-					
-					result.add(order);
-				}
-			}
-			
-		} else if (startDate != null && endDate == null) {
-			for (final RadiologyOrder order : unfilteredRadiologyOrders) {
-				if (order.getEffectiveStartDate() != null && order.getEffectiveStartDate()
-						.compareTo(startDate) >= 0) {
-					result.add(order);
-				}
-			}
-		}
-		
-		else {
-			for (RadiologyOrder order : unfilteredRadiologyOrders) {
-				if (order.getEffectiveStartDate() != null && order.getEffectiveStartDate()
-						.compareTo(startDate) >= 0 && order.getEffectiveStartDate()
-						.compareTo(endDate) <= 0) {
-					result.add(order);
-				}
-			}
-		}
-		
-		return result;
-	}
-	
-	/**
-	 * Return true if end date is before start date
-	 * 
-	 * @param startDate start date of the date range
-	 * @param endDate end date of the date range
-	 * @return true if end date is before start date
-	 * @should return true if end date is after start date
-	 * @should return false if end date is not after start date
-	 * @should return false with given start date but end date null
-	 * @should return false with given end date but start date null
-	 * @should return false with given end date and end date null
-	 */
-	private boolean isEndDateBeforeStartDate(Date startDate, Date endDate) {
-		if (startDate != null && endDate != null && startDate.after(endDate)) {
-			return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Get orders of type radiology for patientQuery
-	 * 
-	 * @param patientQuery Patient string for which radiology orders and studies should be returned
-	 *        for
-	 * @return list of radiology orders associated with patientQuery
-	 * @should return list of all radiology orders given patientQuery empty
-	 * @should return list of all radiology orders given patientQuery null
-	 * @should return list of all radiology orders given patientQuery matching no patient
-	 * @should return empty list for patients without radiology orders
-	 * @should return list of all radiology orders for a patient given valid patientQuery
-	 */
-	private List<RadiologyOrder> getRadiologyOrdersForPatientQuery(String patientQuery) {
-		
-		final List<Patient> patientList = patientService.getPatients(patientQuery);
-		return radiologyOrderService.getRadiologyOrdersByPatients(patientList);
-	}
-	
-	/**
-	 * Handle all exceptions of type TypeMismatchException which occur in this class
-	 * 
-	 * @param TypeMismatchException the thrown TypeMismatchException
-	 * @return model and view with exception information
-	 * @should populate model with exception text from message properties and invalid value if date
-	 *         is expected but nut passed
-	 * @should should populate model with exception text
-	 */
-	@ExceptionHandler(TypeMismatchException.class)
-	public ModelAndView handleTypeMismatchException(TypeMismatchException typeMismatchException) {
-		
-		log.error(typeMismatchException.getMessage());
-		final ModelAndView mav = new ModelAndView();
-		
-		if (typeMismatchException.getRequiredType()
-				.equals(Date.class)) {
-			mav.addObject("invalidValue", typeMismatchException.getValue());
-			mav.addObject("exceptionText", "typeMismatch.java.util.Date");
-		} else {
-			mav.addObject("exceptionText", typeMismatchException.getMessage());
-		}
-		
-		return mav;
-	}
-	
+    
+    private static final Log log = LogFactory.getLog(PortletsController.class);
+    
+    @Autowired
+    private RadiologyOrderService radiologyOrderService;
+    
+    @Autowired
+    private PatientService patientService;
+    
+    /**
+     * Get URL to the patientOverview portlet
+     * 
+     * @return patient info route
+     * @should return string with patient info route
+     */
+    @RequestMapping("/module/radiology/portlets/patientOverview.portlet")
+    String getPatientInfoRoute() {
+        return "module/radiology/portlets/patientOverview";
+    }
+    
+    /**
+     * Get model and view containing radiology orders and studies for given patient string and date
+     * range
+     * 
+     * @param patientQuery Patient string for which radiology orders and studies should be returned
+     *        for
+     * @param startDate Date from which on the radiology orders and studies should be returned for
+     * @param endDate Date until which the radiology orders and studies should be returned for
+     * @return model and view containing radiology orders and studies corresponding to given
+     *         criteria
+     * @should populate model and view with radiology orders associated with given empty patient and
+     *         given date range null
+     * @should not populate model and view with radiology orders if start date is after end date
+     */
+    @RequestMapping(value = "/module/radiology/portlets/orderSearch.portlet")
+    ModelAndView getRadiologyOrdersByPatientQueryAndDateRange(
+            @RequestParam(value = "patientQuery", required = false) String patientQuery,
+            @RequestParam(value = "startDate", required = false) @DateTimeFormat(iso = ISO.DATE) Date startDate,
+            @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = ISO.DATE) Date endDate) {
+        final ModelAndView mav = new ModelAndView("module/radiology/portlets/orderSearch");
+        
+        if (isEndDateBeforeStartDate(startDate, endDate)) {
+            mav.addObject("exceptionText", "radiology.crossDate");
+            mav.addObject("radiologyOrders", new ArrayList<RadiologyOrder>());
+            return mav;
+        }
+        
+        List<RadiologyOrder> radiologyOrders = getRadiologyOrdersForPatientQuery(patientQuery);
+        radiologyOrders = filterRadiologyOrdersByDateRange(radiologyOrders, startDate, endDate);
+        mav.addObject("radiologyOrders", radiologyOrders);
+        
+        return mav;
+    }
+    
+    /**
+     * Get all orders for given date range
+     * 
+     * @param unfilteredRadiologyOrders list of orders which matches a patientQuery
+     * @param startDate Date from which on the radiology orders should be returned for
+     * @param endDate Date until which the radiology should be returned for
+     * @return list of radiology orders corresponding to given criteria
+     * @should return list of orders matching a given date range
+     * @should return list of all orders with start date if start date is null and end date is null
+     * @should return empty list of orders with given end date and start date before any order has
+     *         started
+     * @should return empty list of orders with given end date and start date after any order has
+     *         started
+     * @should return list of orders started after given start date but given end date null
+     * @should return list of orders started before given end date but given start date null
+     */
+    private List<RadiologyOrder> filterRadiologyOrdersByDateRange(List<RadiologyOrder> unfilteredRadiologyOrders,
+            Date startDate, Date endDate) {
+        
+        final List<RadiologyOrder> result = new Vector<RadiologyOrder>();
+        
+        if (startDate == null && endDate == null) {
+            return unfilteredRadiologyOrders;
+        } else if (startDate == null && endDate != null) {
+            for (RadiologyOrder order : unfilteredRadiologyOrders) {
+                if (order.getEffectiveStartDate() != null && order.getEffectiveStartDate()
+                        .compareTo(endDate) <= 0) {
+                    
+                    result.add(order);
+                }
+            }
+            
+        } else if (startDate != null && endDate == null) {
+            for (final RadiologyOrder order : unfilteredRadiologyOrders) {
+                if (order.getEffectiveStartDate() != null && order.getEffectiveStartDate()
+                        .compareTo(startDate) >= 0) {
+                    result.add(order);
+                }
+            }
+        }
+        
+        else {
+            for (RadiologyOrder order : unfilteredRadiologyOrders) {
+                if (order.getEffectiveStartDate() != null && order.getEffectiveStartDate()
+                        .compareTo(startDate) >= 0 && order.getEffectiveStartDate()
+                        .compareTo(endDate) <= 0) {
+                    result.add(order);
+                }
+            }
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Return true if end date is before start date
+     * 
+     * @param startDate start date of the date range
+     * @param endDate end date of the date range
+     * @return true if end date is before start date
+     * @should return true if end date is after start date
+     * @should return false if end date is not after start date
+     * @should return false with given start date but end date null
+     * @should return false with given end date but start date null
+     * @should return false with given end date and end date null
+     */
+    private boolean isEndDateBeforeStartDate(Date startDate, Date endDate) {
+        if (startDate != null && endDate != null && startDate.after(endDate)) {
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * Get orders of type radiology for patientQuery
+     * 
+     * @param patientQuery Patient string for which radiology orders and studies should be returned
+     *        for
+     * @return list of radiology orders associated with patientQuery
+     * @should return list of all radiology orders given patientQuery empty
+     * @should return list of all radiology orders given patientQuery null
+     * @should return list of all radiology orders given patientQuery matching no patient
+     * @should return empty list for patients without radiology orders
+     * @should return list of all radiology orders for a patient given valid patientQuery
+     */
+    private List<RadiologyOrder> getRadiologyOrdersForPatientQuery(String patientQuery) {
+        
+        final List<Patient> patientList = patientService.getPatients(patientQuery);
+        return radiologyOrderService.getRadiologyOrdersByPatients(patientList);
+    }
+    
+    /**
+     * Handle all exceptions of type TypeMismatchException which occur in this class
+     * 
+     * @param TypeMismatchException the thrown TypeMismatchException
+     * @return model and view with exception information
+     * @should populate model with exception text from message properties and invalid value if date
+     *         is expected but nut passed
+     * @should should populate model with exception text
+     */
+    @ExceptionHandler(TypeMismatchException.class)
+    public ModelAndView handleTypeMismatchException(TypeMismatchException typeMismatchException) {
+        
+        log.error(typeMismatchException.getMessage());
+        final ModelAndView mav = new ModelAndView();
+        
+        if (typeMismatchException.getRequiredType()
+                .equals(Date.class)) {
+            mav.addObject("invalidValue", typeMismatchException.getValue());
+            mav.addObject("exceptionText", "typeMismatch.java.util.Date");
+        } else {
+            mav.addObject("exceptionText", typeMismatchException.getMessage());
+        }
+        
+        return mav;
+    }
+    
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardFormController.java
@@ -17,13 +17,13 @@ import org.springframework.web.servlet.ModelAndView;
 @Controller
 @RequestMapping(RadiologyDashboardFormController.RADIOLOGY_DASHBOARD_FORM_REQUEST_MAPPING)
 public class RadiologyDashboardFormController {
-	
-	public static final String RADIOLOGY_DASHBOARD_FORM_REQUEST_MAPPING = "/module/radiology/radiologyDashboard.form";
-	
-	static final String RADIOLOGY_DASHBOARD_FORM_VIEW = "/module/radiology/radiologyDashboardForm";
-	
-	@RequestMapping(method = RequestMethod.GET)
-	protected ModelAndView get() {
-		return new ModelAndView(RADIOLOGY_DASHBOARD_FORM_VIEW);
-	}
+    
+    public static final String RADIOLOGY_DASHBOARD_FORM_REQUEST_MAPPING = "/module/radiology/radiologyDashboard.form";
+    
+    static final String RADIOLOGY_DASHBOARD_FORM_VIEW = "/module/radiology/radiologyDashboardForm";
+    
+    @RequestMapping(method = RequestMethod.GET)
+    protected ModelAndView get() {
+        return new ModelAndView(RADIOLOGY_DASHBOARD_FORM_VIEW);
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
@@ -50,306 +50,306 @@ import org.springframework.web.servlet.ModelAndView;
 @Controller
 @RequestMapping(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING)
 public class RadiologyOrderFormController {
-	
-	public static final String RADIOLOGY_ORDER_FORM_REQUEST_MAPPING = "/module/radiology/radiologyOrder.form";
-	
-	static final String RADIOLOGY_ORDER_FORM_VIEW = "/module/radiology/radiologyOrderForm";
-	
-	@Autowired
-	private RadiologyOrderService radiologyOrderService;
-	
-	@Autowired
-	private RadiologyReportService radiologyReportService;
-	
-	@Autowired
-	private RadiologyProperties radiologyProperties;
-	
-	@Autowired
-	private DicomWebViewer dicomWebViewer;
-	
-	/**
-	 * Handles GET requests for the radiologyOrderForm with new radiology order
-	 * 
-	 * @return model and view containing new radiology order
-	 * @should populate model and view with new radiology order
-	 */
-	@RequestMapping(method = RequestMethod.GET)
-	protected ModelAndView getRadiologyOrderFormWithNewRadiologyOrder() {
-		
-		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
-		
-		if (Context.isAuthenticated()) {
-			modelAndView.addObject("order", new Order());
-			modelAndView.addObject("radiologyReport", null);
-			final RadiologyOrder radiologyOrder = new RadiologyOrder();
-			radiologyOrder.setStudy(new RadiologyStudy());
-			modelAndView.addObject("radiologyOrder", radiologyOrder);
-		}
-		
-		return modelAndView;
-	}
-	
-	/**
-	 * Handles GET requests for the radiologyOrderForm with new radiology order with prefilled
-	 * patient
-	 * 
-	 * @param patient existing patient which should be associated with a new radiology order
-	 *        returned in the model and view
-	 * @return model and view containing new radiology order
-	 * @should populate model and view with new radiology order prefilled with given patient
-	 * @should populate model and view with new radiology order without prefilled patient if given
-	 *         patient is null
-	 */
-	@RequestMapping(method = RequestMethod.GET, params = "patientId")
-	protected ModelAndView getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(
-			@RequestParam(value = "patientId", required = true) Patient patient) {
-		
-		final ModelAndView modelAndView = getRadiologyOrderFormWithNewRadiologyOrder();
-		
-		if (Context.isAuthenticated() && patient != null) {
-			Order order = (Order) modelAndView.getModel()
-					.get("radiologyOrder");
-			order.setPatient(patient);
-			modelAndView.addObject("patientId", patient.getPatientId());
-		}
-		
-		return modelAndView;
-	}
-	
-	/**
-	 * Handles GET requests for the radiologyOrderForm with existing radiology order
-	 * 
-	 * @param order Order of an existing radiology order which should be put into the model and view
-	 * @return model and view containing radiology order
-	 * @should populate model and view with existing radiology order if given order id matches a
-	 *         radiology order and no dicomViewerUrl if order is not completed
-	 * @should populate model and view with existing radiology order if given order id matches a
-	 *         radiology order and dicomViewerUrl if order completed
-	 * @should populate model and view with existing order if given order id only matches an order
-	 *         and not a radiology order
-	 */
-	@RequestMapping(method = RequestMethod.GET, params = "orderId")
-	protected ModelAndView getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(
-			@RequestParam(value = "orderId", required = true) Order order) {
-		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
-		
-		if (Context.isAuthenticated()) {
-			modelAndView.addObject("order", order);
-			modelAndView.addObject("discontinuationOrder", new Order());
-			
-			if (order instanceof RadiologyOrder) {
-				final RadiologyOrder radiologyOrder = (RadiologyOrder) order;
-				modelAndView.addObject("radiologyOrder", radiologyOrder);
-				if (radiologyOrder.isCompleted()) {
-					modelAndView.addObject("dicomViewerUrl", dicomWebViewer.getDicomViewerUrl(radiologyOrder.getStudy()));
-				}
-			}
-			
-			if (Context.getAuthenticatedUser()
-					.hasPrivilege(ADD_RADIOLOGY_REPORTS)) {
-				radiologyReportNeedsToBeCreated(modelAndView, order);
-			}
-		}
-		
-		return modelAndView;
-	}
-	
-	/**
-	 * Handles POST requests for the radiologyOrderForm with request parameter attribute
-	 * saveRadiologyOrder
-	 *
-	 * @param patientId patient id of an existing patient which is used to redirect to the patient
-	 *        dashboard
-	 * @param radiologyOrder radiology order object
-	 * @param radiologyOrderErrors binding result containing order errors for a non valid order
-	 * @return model and view
-	 * @should set http session attribute openmrs message to order saved and redirect to to
-	 *         radiologyOrderForm when save study was successful
-	 * @should set http session attribute openmrs message to order saved and redirect to
-	 *         radiologyOrderForm when save study was successful and given patient id
-	 * @should set http session attribute openmrs message to study performed when study performed
-	 *         status is in progress and request was issued by radiology scheduler
-	 * @should not redirect if radiology order is not valid according to order validator
-	 */
-	@RequestMapping(method = RequestMethod.POST, params = "saveRadiologyOrder")
-	protected ModelAndView postSaveRadiologyOrder(HttpServletRequest request,
-			@RequestParam(value = "patient_id", required = false) Integer patientId, @ModelAttribute("order") Order order,
-			@ModelAttribute("radiologyOrder") RadiologyOrder radiologyOrder, BindingResult radiologyOrderErrors)
-			throws Exception {
-		
-		final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
-		
-		if (Context.getAuthenticatedUser()
-				.hasRole(SCHEDULER, true) && !radiologyOrder.getStudy()
-				.isScheduleable()) {
-			request.getSession()
-					.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "radiology.studyPerformed");
-		} else {
-			new RadiologyOrderValidator().validate(radiologyOrder, radiologyOrderErrors);
-			if (radiologyOrderErrors.hasErrors()) {
-				return modelAndView;
-			}
-			
-			try {
-				radiologyOrderService.placeRadiologyOrder(radiologyOrder);
-				
-				request.getSession()
-						.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "Order.saved");
-				modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "?orderId="
-						+ radiologyOrder.getOrderId());
-			}
-			catch (Exception ex) {
-				request.getSession()
-						.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, ex.getMessage());
-				ex.printStackTrace();
-			}
-		}
-		
-		return modelAndView;
-	}
-	
-	/**
-	 * Handles POST requests for the radiologyOrderForm with request parameter attribute
-	 * discontinueOrder
-	 *
-	 * @param radiologyOrderToDiscontinue order to discontinue
-	 * @param nonCodedDiscontinueReason non coded discontinue reason
-	 * @return model and view populated with discontinuation order
-	 * @throws Exception
-	 * @should discontinue non discontinued order and redirect to discontinuation order
-	 */
-	@RequestMapping(method = RequestMethod.POST, params = "discontinueOrder")
-	protected ModelAndView postDiscontinueRadiologyOrder(HttpServletRequest request, HttpServletResponse response,
-			@RequestParam("orderId") RadiologyOrder radiologyOrderToDiscontinue,
-			@ModelAttribute("discontinuationOrder") Order discontinuationOrder, BindingResult radiologyOrderErrors)
-			throws Exception {
-		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
-		
-		try {
-			new RadiologyDiscontinuedOrderValidator().validate(discontinuationOrder, radiologyOrderErrors);
-			if (radiologyOrderErrors.hasErrors()) {
-				modelAndView.addObject("order", radiologyOrderToDiscontinue);
-				modelAndView.addObject("radiologyOrder",
-					radiologyOrderService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
-				
-				return modelAndView;
-			}
-			discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrderToDiscontinue,
-				discontinuationOrder.getOrderer(), discontinuationOrder.getOrderReasonNonCoded());
-			
-			request.getSession()
-					.setAttribute(WebConstants.OPENMRS_MSG_ATTR, "Order.discontinuedSuccessfully");
-			modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "?orderId="
-					+ discontinuationOrder.getOrderId());
-		}
-		catch (APIException apiException) {
-			request.getSession()
-					.setAttribute(WebConstants.OPENMRS_ERROR_ATTR, apiException.getMessage());
-		}
-		
-		modelAndView.addObject("order", radiologyOrderToDiscontinue);
-		modelAndView.addObject("radiologyOrder",
-			radiologyOrderService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
-		modelAndView.addObject("discontinuationOrder", discontinuationOrder);
-		return modelAndView;
-	}
-	
-	/**
-	 * Convenient method to check if a radiologyReport needs to be created. Adds true to the
-	 * modelAndView, if a RadiologyReport needs to be created, otherwise false.
-	 *
-	 * @param modelAndView ModelAndView of the RadiologyOrderForm
-	 * @param order Order which should be verified if a RadiologyReport needs to be created
-	 * @return true if a RadiologyReport needs to be created, false otherwise
-	 * @should return false if order is not a radiology order
-	 * @should return false if radiology order is not completed
-	 * @should return false if radiology order is completed but has a claimed report
-	 * @should return false if radiology order is completed but has a completed report
-	 * @should return true if radiology order is completed and has no claimed report
-	 */
-	private boolean radiologyReportNeedsToBeCreated(ModelAndView modelAndView, Order order) {
-		
-		final RadiologyOrder radiologyOrder;
-		if (order instanceof RadiologyOrder) {
-			radiologyOrder = (RadiologyOrder) order;
-		} else {
-			modelAndView.addObject("radiologyReportNeedsToBeCreated", false);
-			return false;
-		}
-		
-		if (radiologyOrder.isNotCompleted()) {
-			modelAndView.addObject("radiologyReportNeedsToBeCreated", false);
-			return false;
-		}
-		
-		final RadiologyReport radiologyReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(radiologyOrder);
-		if (radiologyReport == null) {
-			modelAndView.addObject("radiologyReportNeedsToBeCreated", true);
-			return true;
-		} else {
-			modelAndView.addObject("radiologyReportNeedsToBeCreated", false);
-			modelAndView.addObject("radiologyReport", radiologyReport);
-			return false;
-		}
-	}
-	
-	@ModelAttribute("modalities")
-	private Map<String, String> getModalityList() {
-		
-		final Map<String, String> modalities = new HashMap<String, String>();
-		
-		for (final Modality modality : Modality.values()) {
-			modalities.put(modality.name(), modality.getFullName());
-		}
-		
-		return modalities;
-	}
-	
-	@ModelAttribute("urgencies")
-	private List<String> getUrgenciesList() {
-		
-		final List<String> urgencies = new LinkedList<String>();
-		
-		for (final Order.Urgency urgency : Order.Urgency.values()) {
-			urgencies.add(urgency.name());
-		}
-		
-		return urgencies;
-	}
-	
-	@ModelAttribute("scheduledProcedureStepStatuses")
-	private Map<String, String> getScheduledProcedureStepStatusList() {
-		
-		final Map<String, String> scheduledProcedureStepStatuses = new LinkedHashMap<String, String>();
-		scheduledProcedureStepStatuses.put("", "Select");
-		
-		for (final ScheduledProcedureStepStatus scheduledProcedureStepStatus : ScheduledProcedureStepStatus.values()) {
-			scheduledProcedureStepStatuses.put(scheduledProcedureStepStatus.name(), scheduledProcedureStepStatus.name());
-		}
-		
-		return scheduledProcedureStepStatuses;
-	}
-	
-	@ModelAttribute("performedStatuses")
-	private Map<String, String> getPerformedStatusList() {
-		
-		final Map<String, String> performedStatuses = new HashMap<String, String>();
-		performedStatuses.put("", "Select");
-		
-		for (final PerformedProcedureStepStatus performedStatus : PerformedProcedureStepStatus.values()) {
-			performedStatuses.put(performedStatus.name(), performedStatus.name());
-		}
-		
-		return performedStatuses;
-	}
-	
-	/**
-	 * Gets the Name of the ConceptClasses that should be filtered
-	 *
-	 * @return Name of ConceptClasses
-	 */
-	@ModelAttribute("radiologyConceptClassNames")
-	private String getRadiologyConceptClassNames() {
-		return radiologyProperties.getRadiologyConceptClassNames();
-	}
+    
+    public static final String RADIOLOGY_ORDER_FORM_REQUEST_MAPPING = "/module/radiology/radiologyOrder.form";
+    
+    static final String RADIOLOGY_ORDER_FORM_VIEW = "/module/radiology/radiologyOrderForm";
+    
+    @Autowired
+    private RadiologyOrderService radiologyOrderService;
+    
+    @Autowired
+    private RadiologyReportService radiologyReportService;
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    @Autowired
+    private DicomWebViewer dicomWebViewer;
+    
+    /**
+     * Handles GET requests for the radiologyOrderForm with new radiology order
+     * 
+     * @return model and view containing new radiology order
+     * @should populate model and view with new radiology order
+     */
+    @RequestMapping(method = RequestMethod.GET)
+    protected ModelAndView getRadiologyOrderFormWithNewRadiologyOrder() {
+        
+        ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
+        
+        if (Context.isAuthenticated()) {
+            modelAndView.addObject("order", new Order());
+            modelAndView.addObject("radiologyReport", null);
+            final RadiologyOrder radiologyOrder = new RadiologyOrder();
+            radiologyOrder.setStudy(new RadiologyStudy());
+            modelAndView.addObject("radiologyOrder", radiologyOrder);
+        }
+        
+        return modelAndView;
+    }
+    
+    /**
+     * Handles GET requests for the radiologyOrderForm with new radiology order with prefilled
+     * patient
+     * 
+     * @param patient existing patient which should be associated with a new radiology order
+     *        returned in the model and view
+     * @return model and view containing new radiology order
+     * @should populate model and view with new radiology order prefilled with given patient
+     * @should populate model and view with new radiology order without prefilled patient if given
+     *         patient is null
+     */
+    @RequestMapping(method = RequestMethod.GET, params = "patientId")
+    protected ModelAndView getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(
+            @RequestParam(value = "patientId", required = true) Patient patient) {
+        
+        final ModelAndView modelAndView = getRadiologyOrderFormWithNewRadiologyOrder();
+        
+        if (Context.isAuthenticated() && patient != null) {
+            Order order = (Order) modelAndView.getModel()
+                    .get("radiologyOrder");
+            order.setPatient(patient);
+            modelAndView.addObject("patientId", patient.getPatientId());
+        }
+        
+        return modelAndView;
+    }
+    
+    /**
+     * Handles GET requests for the radiologyOrderForm with existing radiology order
+     * 
+     * @param order Order of an existing radiology order which should be put into the model and view
+     * @return model and view containing radiology order
+     * @should populate model and view with existing radiology order if given order id matches a
+     *         radiology order and no dicomViewerUrl if order is not completed
+     * @should populate model and view with existing radiology order if given order id matches a
+     *         radiology order and dicomViewerUrl if order completed
+     * @should populate model and view with existing order if given order id only matches an order
+     *         and not a radiology order
+     */
+    @RequestMapping(method = RequestMethod.GET, params = "orderId")
+    protected ModelAndView getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(
+            @RequestParam(value = "orderId", required = true) Order order) {
+        ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
+        
+        if (Context.isAuthenticated()) {
+            modelAndView.addObject("order", order);
+            modelAndView.addObject("discontinuationOrder", new Order());
+            
+            if (order instanceof RadiologyOrder) {
+                final RadiologyOrder radiologyOrder = (RadiologyOrder) order;
+                modelAndView.addObject("radiologyOrder", radiologyOrder);
+                if (radiologyOrder.isCompleted()) {
+                    modelAndView.addObject("dicomViewerUrl", dicomWebViewer.getDicomViewerUrl(radiologyOrder.getStudy()));
+                }
+            }
+            
+            if (Context.getAuthenticatedUser()
+                    .hasPrivilege(ADD_RADIOLOGY_REPORTS)) {
+                radiologyReportNeedsToBeCreated(modelAndView, order);
+            }
+        }
+        
+        return modelAndView;
+    }
+    
+    /**
+     * Handles POST requests for the radiologyOrderForm with request parameter attribute
+     * saveRadiologyOrder
+     *
+     * @param patientId patient id of an existing patient which is used to redirect to the patient
+     *        dashboard
+     * @param radiologyOrder radiology order object
+     * @param radiologyOrderErrors binding result containing order errors for a non valid order
+     * @return model and view
+     * @should set http session attribute openmrs message to order saved and redirect to to
+     *         radiologyOrderForm when save study was successful
+     * @should set http session attribute openmrs message to order saved and redirect to
+     *         radiologyOrderForm when save study was successful and given patient id
+     * @should set http session attribute openmrs message to study performed when study performed
+     *         status is in progress and request was issued by radiology scheduler
+     * @should not redirect if radiology order is not valid according to order validator
+     */
+    @RequestMapping(method = RequestMethod.POST, params = "saveRadiologyOrder")
+    protected ModelAndView postSaveRadiologyOrder(HttpServletRequest request,
+            @RequestParam(value = "patient_id", required = false) Integer patientId, @ModelAttribute("order") Order order,
+            @ModelAttribute("radiologyOrder") RadiologyOrder radiologyOrder, BindingResult radiologyOrderErrors)
+            throws Exception {
+        
+        final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
+        
+        if (Context.getAuthenticatedUser()
+                .hasRole(SCHEDULER, true) && !radiologyOrder.getStudy()
+                .isScheduleable()) {
+            request.getSession()
+                    .setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "radiology.studyPerformed");
+        } else {
+            new RadiologyOrderValidator().validate(radiologyOrder, radiologyOrderErrors);
+            if (radiologyOrderErrors.hasErrors()) {
+                return modelAndView;
+            }
+            
+            try {
+                radiologyOrderService.placeRadiologyOrder(radiologyOrder);
+                
+                request.getSession()
+                        .setAttribute(WebConstants.OPENMRS_MSG_ATTR, "Order.saved");
+                modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "?orderId="
+                        + radiologyOrder.getOrderId());
+            }
+            catch (Exception ex) {
+                request.getSession()
+                        .setAttribute(WebConstants.OPENMRS_ERROR_ATTR, ex.getMessage());
+                ex.printStackTrace();
+            }
+        }
+        
+        return modelAndView;
+    }
+    
+    /**
+     * Handles POST requests for the radiologyOrderForm with request parameter attribute
+     * discontinueOrder
+     *
+     * @param radiologyOrderToDiscontinue order to discontinue
+     * @param nonCodedDiscontinueReason non coded discontinue reason
+     * @return model and view populated with discontinuation order
+     * @throws Exception
+     * @should discontinue non discontinued order and redirect to discontinuation order
+     */
+    @RequestMapping(method = RequestMethod.POST, params = "discontinueOrder")
+    protected ModelAndView postDiscontinueRadiologyOrder(HttpServletRequest request, HttpServletResponse response,
+            @RequestParam("orderId") RadiologyOrder radiologyOrderToDiscontinue,
+            @ModelAttribute("discontinuationOrder") Order discontinuationOrder, BindingResult radiologyOrderErrors)
+            throws Exception {
+        ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
+        
+        try {
+            new RadiologyDiscontinuedOrderValidator().validate(discontinuationOrder, radiologyOrderErrors);
+            if (radiologyOrderErrors.hasErrors()) {
+                modelAndView.addObject("order", radiologyOrderToDiscontinue);
+                modelAndView.addObject("radiologyOrder",
+                    radiologyOrderService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
+                
+                return modelAndView;
+            }
+            discontinuationOrder = radiologyOrderService.discontinueRadiologyOrder(radiologyOrderToDiscontinue,
+                discontinuationOrder.getOrderer(), discontinuationOrder.getOrderReasonNonCoded());
+            
+            request.getSession()
+                    .setAttribute(WebConstants.OPENMRS_MSG_ATTR, "Order.discontinuedSuccessfully");
+            modelAndView.setViewName("redirect:" + RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "?orderId="
+                    + discontinuationOrder.getOrderId());
+        }
+        catch (APIException apiException) {
+            request.getSession()
+                    .setAttribute(WebConstants.OPENMRS_ERROR_ATTR, apiException.getMessage());
+        }
+        
+        modelAndView.addObject("order", radiologyOrderToDiscontinue);
+        modelAndView.addObject("radiologyOrder",
+            radiologyOrderService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
+        modelAndView.addObject("discontinuationOrder", discontinuationOrder);
+        return modelAndView;
+    }
+    
+    /**
+     * Convenient method to check if a radiologyReport needs to be created. Adds true to the
+     * modelAndView, if a RadiologyReport needs to be created, otherwise false.
+     *
+     * @param modelAndView ModelAndView of the RadiologyOrderForm
+     * @param order Order which should be verified if a RadiologyReport needs to be created
+     * @return true if a RadiologyReport needs to be created, false otherwise
+     * @should return false if order is not a radiology order
+     * @should return false if radiology order is not completed
+     * @should return false if radiology order is completed but has a claimed report
+     * @should return false if radiology order is completed but has a completed report
+     * @should return true if radiology order is completed and has no claimed report
+     */
+    private boolean radiologyReportNeedsToBeCreated(ModelAndView modelAndView, Order order) {
+        
+        final RadiologyOrder radiologyOrder;
+        if (order instanceof RadiologyOrder) {
+            radiologyOrder = (RadiologyOrder) order;
+        } else {
+            modelAndView.addObject("radiologyReportNeedsToBeCreated", false);
+            return false;
+        }
+        
+        if (radiologyOrder.isNotCompleted()) {
+            modelAndView.addObject("radiologyReportNeedsToBeCreated", false);
+            return false;
+        }
+        
+        final RadiologyReport radiologyReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(radiologyOrder);
+        if (radiologyReport == null) {
+            modelAndView.addObject("radiologyReportNeedsToBeCreated", true);
+            return true;
+        } else {
+            modelAndView.addObject("radiologyReportNeedsToBeCreated", false);
+            modelAndView.addObject("radiologyReport", radiologyReport);
+            return false;
+        }
+    }
+    
+    @ModelAttribute("modalities")
+    private Map<String, String> getModalityList() {
+        
+        final Map<String, String> modalities = new HashMap<String, String>();
+        
+        for (final Modality modality : Modality.values()) {
+            modalities.put(modality.name(), modality.getFullName());
+        }
+        
+        return modalities;
+    }
+    
+    @ModelAttribute("urgencies")
+    private List<String> getUrgenciesList() {
+        
+        final List<String> urgencies = new LinkedList<String>();
+        
+        for (final Order.Urgency urgency : Order.Urgency.values()) {
+            urgencies.add(urgency.name());
+        }
+        
+        return urgencies;
+    }
+    
+    @ModelAttribute("scheduledProcedureStepStatuses")
+    private Map<String, String> getScheduledProcedureStepStatusList() {
+        
+        final Map<String, String> scheduledProcedureStepStatuses = new LinkedHashMap<String, String>();
+        scheduledProcedureStepStatuses.put("", "Select");
+        
+        for (final ScheduledProcedureStepStatus scheduledProcedureStepStatus : ScheduledProcedureStepStatus.values()) {
+            scheduledProcedureStepStatuses.put(scheduledProcedureStepStatus.name(), scheduledProcedureStepStatus.name());
+        }
+        
+        return scheduledProcedureStepStatuses;
+    }
+    
+    @ModelAttribute("performedStatuses")
+    private Map<String, String> getPerformedStatusList() {
+        
+        final Map<String, String> performedStatuses = new HashMap<String, String>();
+        performedStatuses.put("", "Select");
+        
+        for (final PerformedProcedureStepStatus performedStatus : PerformedProcedureStepStatus.values()) {
+            performedStatuses.put(performedStatus.name(), performedStatus.name());
+        }
+        
+        return performedStatuses;
+    }
+    
+    /**
+     * Gets the Name of the ConceptClasses that should be filtered
+     *
+     * @return Name of ConceptClasses
+     */
+    @ModelAttribute("radiologyConceptClassNames")
+    private String getRadiologyConceptClassNames() {
+        return radiologyProperties.getRadiologyConceptClassNames();
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderListController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderListController.java
@@ -17,14 +17,14 @@ import org.springframework.web.servlet.ModelAndView;
 @Controller
 @RequestMapping(RadiologyOrderListController.RADIOLOGY_ORDER_LIST_REQUEST_MAPPING)
 public class RadiologyOrderListController {
-	
-	public static final String RADIOLOGY_ORDER_LIST_REQUEST_MAPPING = "/module/radiology/radiologyOrder.list";
-	
-	private static final String RADIOLOGY_ORDER_LIST_VIEW = "/module/radiology/radiologyOrderList";
-	
-	@RequestMapping(method = RequestMethod.GET)
-	public ModelAndView handleRequest() {
-		final ModelAndView mav = new ModelAndView(RADIOLOGY_ORDER_LIST_VIEW);
-		return mav;
-	}
+    
+    public static final String RADIOLOGY_ORDER_LIST_REQUEST_MAPPING = "/module/radiology/radiologyOrder.list";
+    
+    private static final String RADIOLOGY_ORDER_LIST_VIEW = "/module/radiology/radiologyOrderList";
+    
+    @RequestMapping(method = RequestMethod.GET)
+    public ModelAndView handleRequest() {
+        final ModelAndView mav = new ModelAndView(RADIOLOGY_ORDER_LIST_VIEW);
+        return mav;
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
@@ -28,153 +28,153 @@ import org.springframework.web.servlet.ModelAndView;
 @Controller
 @RequestMapping(value = RadiologyReportFormController.RADIOLOGY_REPORT_FORM_REQUEST_MAPPING)
 public class RadiologyReportFormController {
-	
-	protected static final String RADIOLOGY_REPORT_FORM_REQUEST_MAPPING = "/module/radiology/radiologyReport.form";
-	
-	private static final String RADIOLOGY_REPORT_FORM_VIEW = "/module/radiology/radiologyReportForm";
-	
-	@Autowired
-	private RadiologyReportService radiologyReportService;
-	
-	@Autowired
-	private DicomWebViewer dicomWebViewer;
-	
-	/**
-	 * Handles GET requests for the radiologyReportForm creating a new radiology report for given
-	 * radiology order
-	 * 
-	 * @param radiologyOrder radiology order for which a radiology report will be created
-	 * @return model and view containing new radiology report for given radiology order
-	 * @should populate model and view with new radiology report for given radiology order
-	 */
-	@RequestMapping(method = RequestMethod.GET, params = "orderId")
-	protected ModelAndView getRadiologyReportFormWithNewRadiologyReport(
-			@RequestParam(value = "orderId", required = true) RadiologyOrder radiologyOrder) {
-		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
-		
-		final RadiologyReport radiologyReport = radiologyReportService.createAndClaimRadiologyReport(radiologyOrder);
-		modelAndView = new ModelAndView("redirect:" + RADIOLOGY_REPORT_FORM_REQUEST_MAPPING + "?radiologyReportId="
-				+ radiologyReport.getId());
-		
-		addObjectsToModelAndView(modelAndView, radiologyReport);
-		return modelAndView;
-	}
-	
-	/**
-	 * Handles GET requests for the radiologyReportForm when called for existing radiology reports
-	 * 
-	 * @param radiologyReportId radiology report id of the existing radiology report which should be
-	 *        put into the model and view
-	 * @return model and view containing radiology report for given radiology report id
-	 * @should populate model and view with existing radiology report matching given radiology
-	 *         report id
-	 */
-	@RequestMapping(method = RequestMethod.GET, params = "radiologyReportId")
-	protected ModelAndView getRadiologyReportFormWithExistingRadiologyReport(
-			@RequestParam(value = "radiologyReportId", required = true) Integer radiologyReportId) {
-		
-		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
-		
-		final RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(radiologyReportId);
-		addObjectsToModelAndView(modelAndView, radiologyReport);
-		
-		return modelAndView;
-	}
-	
-	/**
-	 * Handles POST request for the RadiologyReportForm to save a RadiologyReport
-	 *
-	 * @param radiologyReport radiology report to be saved
-	 * @return ModelAndView containing saved radiology report
-	 * @should save given radiology report and populate model and view with it
-	 */
-	@RequestMapping(method = RequestMethod.POST, params = "saveRadiologyReport")
-	protected ModelAndView saveRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport) {
-		ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
-		radiologyReportService.saveRadiologyReport(radiologyReport);
-		
-		addObjectsToModelAndView(modelAndView, radiologyReport);
-		return modelAndView;
-	}
-	
-	/**
-	 * Handles POST request for the RadiologyReportForm to unclaim given RadiologyReport
-	 *
-	 * @param radiologyReport radiology report to be unclaimed
-	 * @return ModelAndView with redirect to order form if unclaim was successful, otherwise stay on
-	 *         report form
-	 * @should redirect to radiology order form if unclaim was successful
-	 */
-	@RequestMapping(method = RequestMethod.POST, params = "unclaimRadiologyReport")
-	protected ModelAndView unclaimRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport) {
-		radiologyReportService.unclaimRadiologyReport(radiologyReport);
-		return new ModelAndView("redirect:" + RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING
-				+ "?orderId=" + radiologyReport.getRadiologyOrder()
-						.getOrderId());
-	}
-	
-	/**
-	 * Handles POST request for the RadiologyReportForm to complete given RadiologyReport
-	 *
-	 * @param radiologyReport radiology report to be completed
-	 * @param bindingResult BindingResult
-	 * @return ModelAndView RadiologyOrderForm if complete was successful, otherwise the
-	 *         ModelAndView with BindingResult errors
-	 * @should complete given radiology report and populate model and view with it
-	 * @should populate model and view radiology report form with BindingResult errors if provider
-	 *         is null
-	 */
-	@RequestMapping(method = RequestMethod.POST, params = "completeRadiologyReport")
-	protected ModelAndView completeRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport,
-			BindingResult bindingResult) {
-		
-		final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
-		
-		if (validateForm(modelAndView, radiologyReport, bindingResult)) {
-			return modelAndView;
-		}
-		
-		final RadiologyReport completedRadiologyReport = radiologyReportService.completeRadiologyReport(radiologyReport,
-			radiologyReport.getPrincipalResultsInterpreter());
-		addObjectsToModelAndView(modelAndView, completedRadiologyReport);
-		return modelAndView;
-	}
-	
-	/**
-	 * Convenience method to check, if RadiologyReportForm has BindingErrors (e.g. Provider is not
-	 * set)
-	 *
-	 * @param radiologyReport radiology report to be validated
-	 * @param bindingResult BindingResult
-	 * @param modelAndView model and view where radiology report is added
-	 * @return true, if RadiologyReportFrom has errors (e.g. Provider is missing), false if
-	 *         RadiologyReportForm has no errors
-	 */
-	private boolean validateForm(ModelAndView modelAndView, RadiologyReport radiologyReport, BindingResult bindingResult) {
-		if (radiologyReport.getPrincipalResultsInterpreter() == null) {
-			new RadiologyReportValidator().validate(radiologyReport, bindingResult);
-		}
-		if (bindingResult.hasErrors()) {
-			addObjectsToModelAndView(modelAndView, radiologyReport);
-			return true;
-		}
-		return false;
-	}
-	
-	/**
-	 * Convenience method to add objects (Order, RadiologyOrder, RadiologyReport) to given
-	 * ModelAndView
-	 *
-	 * @param modelAndView model and view to which objects should be added
-	 * @param radiologyReport radiology report from which objects should be added to the model and
-	 *        view
-	 */
-	private void addObjectsToModelAndView(ModelAndView modelAndView, RadiologyReport radiologyReport) {
-		
-		modelAndView.addObject("radiologyReport", radiologyReport);
-		modelAndView.addObject("order", (Order) radiologyReport.getRadiologyOrder());
-		modelAndView.addObject("dicomViewerUrl", dicomWebViewer.getDicomViewerUrl(radiologyReport.getRadiologyOrder()
-				.getStudy()));
-		modelAndView.addObject("radiologyOrder", radiologyReport.getRadiologyOrder());
-	}
+    
+    protected static final String RADIOLOGY_REPORT_FORM_REQUEST_MAPPING = "/module/radiology/radiologyReport.form";
+    
+    private static final String RADIOLOGY_REPORT_FORM_VIEW = "/module/radiology/radiologyReportForm";
+    
+    @Autowired
+    private RadiologyReportService radiologyReportService;
+    
+    @Autowired
+    private DicomWebViewer dicomWebViewer;
+    
+    /**
+     * Handles GET requests for the radiologyReportForm creating a new radiology report for given
+     * radiology order
+     * 
+     * @param radiologyOrder radiology order for which a radiology report will be created
+     * @return model and view containing new radiology report for given radiology order
+     * @should populate model and view with new radiology report for given radiology order
+     */
+    @RequestMapping(method = RequestMethod.GET, params = "orderId")
+    protected ModelAndView getRadiologyReportFormWithNewRadiologyReport(
+            @RequestParam(value = "orderId", required = true) RadiologyOrder radiologyOrder) {
+        ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
+        
+        final RadiologyReport radiologyReport = radiologyReportService.createAndClaimRadiologyReport(radiologyOrder);
+        modelAndView = new ModelAndView("redirect:" + RADIOLOGY_REPORT_FORM_REQUEST_MAPPING + "?radiologyReportId="
+                + radiologyReport.getId());
+        
+        addObjectsToModelAndView(modelAndView, radiologyReport);
+        return modelAndView;
+    }
+    
+    /**
+     * Handles GET requests for the radiologyReportForm when called for existing radiology reports
+     * 
+     * @param radiologyReportId radiology report id of the existing radiology report which should be
+     *        put into the model and view
+     * @return model and view containing radiology report for given radiology report id
+     * @should populate model and view with existing radiology report matching given radiology
+     *         report id
+     */
+    @RequestMapping(method = RequestMethod.GET, params = "radiologyReportId")
+    protected ModelAndView getRadiologyReportFormWithExistingRadiologyReport(
+            @RequestParam(value = "radiologyReportId", required = true) Integer radiologyReportId) {
+        
+        ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
+        
+        final RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByRadiologyReportId(radiologyReportId);
+        addObjectsToModelAndView(modelAndView, radiologyReport);
+        
+        return modelAndView;
+    }
+    
+    /**
+     * Handles POST request for the RadiologyReportForm to save a RadiologyReport
+     *
+     * @param radiologyReport radiology report to be saved
+     * @return ModelAndView containing saved radiology report
+     * @should save given radiology report and populate model and view with it
+     */
+    @RequestMapping(method = RequestMethod.POST, params = "saveRadiologyReport")
+    protected ModelAndView saveRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport) {
+        ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
+        radiologyReportService.saveRadiologyReport(radiologyReport);
+        
+        addObjectsToModelAndView(modelAndView, radiologyReport);
+        return modelAndView;
+    }
+    
+    /**
+     * Handles POST request for the RadiologyReportForm to unclaim given RadiologyReport
+     *
+     * @param radiologyReport radiology report to be unclaimed
+     * @return ModelAndView with redirect to order form if unclaim was successful, otherwise stay on
+     *         report form
+     * @should redirect to radiology order form if unclaim was successful
+     */
+    @RequestMapping(method = RequestMethod.POST, params = "unclaimRadiologyReport")
+    protected ModelAndView unclaimRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport) {
+        radiologyReportService.unclaimRadiologyReport(radiologyReport);
+        return new ModelAndView("redirect:" + RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING
+                + "?orderId=" + radiologyReport.getRadiologyOrder()
+                        .getOrderId());
+    }
+    
+    /**
+     * Handles POST request for the RadiologyReportForm to complete given RadiologyReport
+     *
+     * @param radiologyReport radiology report to be completed
+     * @param bindingResult BindingResult
+     * @return ModelAndView RadiologyOrderForm if complete was successful, otherwise the
+     *         ModelAndView with BindingResult errors
+     * @should complete given radiology report and populate model and view with it
+     * @should populate model and view radiology report form with BindingResult errors if provider
+     *         is null
+     */
+    @RequestMapping(method = RequestMethod.POST, params = "completeRadiologyReport")
+    protected ModelAndView completeRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport,
+            BindingResult bindingResult) {
+        
+        final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
+        
+        if (validateForm(modelAndView, radiologyReport, bindingResult)) {
+            return modelAndView;
+        }
+        
+        final RadiologyReport completedRadiologyReport = radiologyReportService.completeRadiologyReport(radiologyReport,
+            radiologyReport.getPrincipalResultsInterpreter());
+        addObjectsToModelAndView(modelAndView, completedRadiologyReport);
+        return modelAndView;
+    }
+    
+    /**
+     * Convenience method to check, if RadiologyReportForm has BindingErrors (e.g. Provider is not
+     * set)
+     *
+     * @param radiologyReport radiology report to be validated
+     * @param bindingResult BindingResult
+     * @param modelAndView model and view where radiology report is added
+     * @return true, if RadiologyReportFrom has errors (e.g. Provider is missing), false if
+     *         RadiologyReportForm has no errors
+     */
+    private boolean validateForm(ModelAndView modelAndView, RadiologyReport radiologyReport, BindingResult bindingResult) {
+        if (radiologyReport.getPrincipalResultsInterpreter() == null) {
+            new RadiologyReportValidator().validate(radiologyReport, bindingResult);
+        }
+        if (bindingResult.hasErrors()) {
+            addObjectsToModelAndView(modelAndView, radiologyReport);
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * Convenience method to add objects (Order, RadiologyOrder, RadiologyReport) to given
+     * ModelAndView
+     *
+     * @param modelAndView model and view to which objects should be added
+     * @param radiologyReport radiology report from which objects should be added to the model and
+     *        view
+     */
+    private void addObjectsToModelAndView(ModelAndView modelAndView, RadiologyReport radiologyReport) {
+        
+        modelAndView.addObject("radiologyReport", radiologyReport);
+        modelAndView.addObject("order", (Order) radiologyReport.getRadiologyOrder());
+        modelAndView.addObject("dicomViewerUrl", dicomWebViewer.getDicomViewerUrl(radiologyReport.getRadiologyOrder()
+                .getStudy()));
+        modelAndView.addObject("radiologyOrder", radiologyReport.getRadiologyOrder());
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/AdminList.java
@@ -16,25 +16,25 @@ import org.openmrs.module.Extension;
 import org.openmrs.module.web.extension.AdministrationSectionExt;
 
 public class AdminList extends AdministrationSectionExt {
-	
-	@Override
-	public Extension.MEDIA_TYPE getMediaType() {
-		return Extension.MEDIA_TYPE.html;
-	}
-	
-	@Override
-	public String getTitle() {
-		return "radiology.title";
-	}
-	
-	@Override
-	public Map<String, String> getLinks() {
-		
-		final Map<String, String> map = new HashMap<String, String>();
-		
-		map.put("module/radiology/radiologyOrder.list", "radiology.manageOrders");
-		
-		return map;
-	}
-	
+    
+    @Override
+    public Extension.MEDIA_TYPE getMediaType() {
+        return Extension.MEDIA_TYPE.html;
+    }
+    
+    @Override
+    public String getTitle() {
+        return "radiology.title";
+    }
+    
+    @Override
+    public Map<String, String> getLinks() {
+        
+        final Map<String, String> map = new HashMap<String, String>();
+        
+        map.put("module/radiology/radiologyOrder.list", "radiology.manageOrders");
+        
+        return map;
+    }
+    
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
@@ -14,19 +14,19 @@ import org.openmrs.module.radiology.order.web.RadiologyDashboardFormController;
 import org.openmrs.module.web.extension.LinkExt;
 
 public class GutterListExt extends LinkExt {
-	
-	@Override
-	public String getLabel() {
-		return "radiology.home.title";
-	}
-	
-	@Override
-	public String getRequiredPrivilege() {
-		return RadiologyPrivileges.VIEW_RADIOLOGY_SECTION;
-	}
-	
-	@Override
-	public String getUrl() {
-		return RadiologyDashboardFormController.RADIOLOGY_DASHBOARD_FORM_REQUEST_MAPPING;
-	}
+    
+    @Override
+    public String getLabel() {
+        return "radiology.home.title";
+    }
+    
+    @Override
+    public String getRequiredPrivilege() {
+        return RadiologyPrivileges.VIEW_RADIOLOGY_SECTION;
+    }
+    
+    @Override
+    public String getUrl() {
+        return RadiologyDashboardFormController.RADIOLOGY_DASHBOARD_FORM_REQUEST_MAPPING;
+    }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
@@ -15,24 +15,24 @@ import static org.openmrs.module.radiology.order.web.PatientDashboardRadiologyTa
 import org.openmrs.module.web.extension.PatientDashboardTabExt;
 
 public class PatientDashboardRadiologyTabExt extends PatientDashboardTabExt {
-	
-	@Override
-	public String getTabName() {
-		return "radiology.home.title";
-	}
-	
-	@Override
-	public String getTabId() {
-		return "patientDashboardRadiologyTab";
-	}
-	
-	@Override
-	public String getRequiredPrivilege() {
-		return VIEW_RADIOLOGY_SECTION;
-	}
-	
-	@Override
-	public String getPortletUrl() {
-		return PATIENT_DASHBOARD_RADIOLOGY_TAB;
-	}
+    
+    @Override
+    public String getTabName() {
+        return "radiology.home.title";
+    }
+    
+    @Override
+    public String getTabId() {
+        return "patientDashboardRadiologyTab";
+    }
+    
+    @Override
+    public String getRequiredPrivilege() {
+        return VIEW_RADIOLOGY_SECTION;
+    }
+    
+    @Override
+    public String getPortletUrl() {
+        return PATIENT_DASHBOARD_RADIOLOGY_TAB;
+    }
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -34,7 +34,8 @@
 
 	<extension>
 		<point>org.openmrs.patientDashboardTab</point>
-		<class>@MODULE_PACKAGE@.web.extension.html.PatientDashboardRadiologyTabExt</class>
+		<class>@MODULE_PACKAGE@.web.extension.html.PatientDashboardRadiologyTabExt
+		</class>
 	</extension>
 	<extension>
 		<point>org.openmrs.gutter.tools</point>

--- a/omod/src/main/webapp/localHeader.jsp
+++ b/omod/src/main/webapp/localHeader.jsp
@@ -9,20 +9,23 @@
 				code="admin.title.short" /></a></li>
 	<openmrs:hasPrivilege privilege="View Orders">
 		<li
-			<c:if test='<%=request.getRequestURI().contains("radiologyOrderList")%>'>class="active"</c:if>>
+			<c:if test='<%=request.getRequestURI()
+                            .contains("radiologyOrderList")%>'>class="active"</c:if>>
 			<a
 			href="${pageContext.request.contextPath}/module/radiology/radiologyOrder.list">
 				<spring:message code="radiology.manageOrders" />
 		</a>
 		</li>
 		<c:if
-			test='<%=request.getRequestURI().contains("radiologyOrderForm")%>'>
+			test='<%=request.getRequestURI()
+                            .contains("radiologyOrderForm")%>'>
 			<li class="active"><a
 				href="${pageContext.request.contextPath}/module/radiology/radiologyOrder.form?orderId=${radiologyOrder.orderId}">
 					Radiology Order </a></li>
 		</c:if>
 		<c:if
-			test='<%=request.getRequestURI().contains("radiology/radiologyReport")%>'>
+			test='<%=request.getRequestURI()
+                            .contains("radiology/radiologyReport")%>'>
 			<li><a
 				href="${pageContext.request.contextPath}/module/radiology/radiologyOrder.form?orderId=${radiologyOrder.orderId}">
 					Radiology Order </a></li>

--- a/omod/src/main/webapp/portlets/orderSearch.jsp
+++ b/omod/src/main/webapp/portlets/orderSearch.jsp
@@ -31,26 +31,27 @@
 								text="${radiologyOrder.study.scheduledStatus}" />"
 						data-child-instructions="${radiologyOrder.instructions}">
 						<td class="details-control"></td>
-					<td><a
-						href="radiologyOrder.form?orderId=${radiologyOrder.orderId}">${radiologyOrder.orderId}</a></td>
-					<td style="text-align: center"><a
-						href="/openmrs/patientDashboard.form?patientId=${radiologyOrder.patient.patientId}">${radiologyOrder.patient.patientIdentifier}</a></td>
-					<td><a
-						href="/openmrs/patientDashboard.form?patientId=${radiologyOrder.patient.patientId}">${radiologyOrder.patient.personName}</a></td>
-					<td><spring:message code="radiology.${radiologyOrder.urgency}"
-							text="${radiologyOrder.urgency}" /></td>
-					<td>${radiologyOrder.effectiveStartDate}</td>
-					<td><spring:message
-							code="radiology.${radiologyOrder.study.modality}"
-							text="${radiologyOrder.study.modality}" /></td>
-					<td><spring:message
-							code="radiology.${radiologyOrder.study.performedStatus}"
-							text="${radiologyOrder.study.performedStatus}" /></td>
-					<td>${radiologyOrder.orderer.name}</td>
-					<td><spring:message
-							code="radiology.${radiologyOrder.study.scheduledStatus}"
-							text="${radiologyOrder.study.scheduledStatus}" /></td>
-					<td>${radiologyOrder.instructions}</td>
+						<td><a
+							href="radiologyOrder.form?orderId=${radiologyOrder.orderId}">${radiologyOrder.orderId}</a></td>
+						<td style="text-align: center"><a
+							href="/openmrs/patientDashboard.form?patientId=${radiologyOrder.patient.patientId}">${radiologyOrder.patient.patientIdentifier}</a></td>
+						<td><a
+							href="/openmrs/patientDashboard.form?patientId=${radiologyOrder.patient.patientId}">${radiologyOrder.patient.personName}</a></td>
+						<td><spring:message
+								code="radiology.${radiologyOrder.urgency}"
+								text="${radiologyOrder.urgency}" /></td>
+						<td>${radiologyOrder.effectiveStartDate}</td>
+						<td><spring:message
+								code="radiology.${radiologyOrder.study.modality}"
+								text="${radiologyOrder.study.modality}" /></td>
+						<td><spring:message
+								code="radiology.${radiologyOrder.study.performedStatus}"
+								text="${radiologyOrder.study.performedStatus}" /></td>
+						<td>${radiologyOrder.orderer.name}</td>
+						<td><spring:message
+								code="radiology.${radiologyOrder.study.scheduledStatus}"
+								text="${radiologyOrder.study.scheduledStatus}" /></td>
+						<td>${radiologyOrder.instructions}</td>
 					</tr>
 				</c:forEach>
 			</tbody>

--- a/omod/src/main/webapp/portlets/radiologyOrderDiscontinuationPortlet.jsp
+++ b/omod/src/main/webapp/portlets/radiologyOrderDiscontinuationPortlet.jsp
@@ -29,4 +29,3 @@
 	<input type="submit" name="discontinueOrder"
 		value='<spring:message code="Order.discontinueOrder"/>' />
 </form:form>
- 

--- a/omod/src/main/webapp/portlets/radiologyOrdersTab.jsp
+++ b/omod/src/main/webapp/portlets/radiologyOrdersTab.jsp
@@ -18,7 +18,7 @@
 	<spring:message code="general.loading" />
 </div>
 <openmrs:hasPrivilege privilege="Add Radiology Orders">
-<br>
+	<br>
 	<a href="radiologyOrder.form"><spring:message
 			code="radiology.addOrder" /></a>
 	<br>

--- a/omod/src/main/webapp/radiologyDashboardForm.jsp
+++ b/omod/src/main/webapp/radiologyDashboardForm.jsp
@@ -12,44 +12,52 @@
 <script type="text/javascript">
 	var timeOut = null;
 
-	<openmrs:authentication>var userId = "${authenticatedUser.userId}";</openmrs:authentication>
+	<openmrs:authentication>var
+	userId = "${authenticatedUser.userId}";
+	</openmrs:authentication>
 
 	//initTabs
-	$j(document).ready(function() {
-		var c = getTabCookie();
-		if (c == null || (!document.getElementById(c))) {
-			var tabs = document.getElementById("radiologyTabs").getElementsByTagName("a");
-			if (tabs.length && tabs[0].id)
-				c = tabs[0].id;
-		}
-		changeTab(c);
-	});
-	
+	$j(document).ready(
+			function() {
+				var c = getTabCookie();
+				if (c == null || (!document.getElementById(c))) {
+					var tabs = document.getElementById("radiologyTabs")
+							.getElementsByTagName("a");
+					if (tabs.length && tabs[0].id)
+						c = tabs[0].id;
+				}
+				changeTab(c);
+			});
+
 	function setTabCookie(tabType) {
-		document.cookie = "dashboardTab-" + userId + "="+escape(tabType);
+		document.cookie = "dashboardTab-" + userId + "=" + escape(tabType);
 	}
-	
+
 	function getTabCookie() {
-		var cookies = document.cookie.match('dashboardTab-' + userId + '=(.*?)(;|$)');
+		var cookies = document.cookie.match('dashboardTab-' + userId
+				+ '=(.*?)(;|$)');
 		if (cookies) {
 			return unescape(cookies[1]);
 		}
 		return null;
 	}
-	
+
 	function changeTab(tabObj) {
-		if (!document.getElementById || !document.createTextNode) {return;}
+		if (!document.getElementById || !document.createTextNode) {
+			return;
+		}
 		if (typeof tabObj == "string")
 			tabObj = document.getElementById(tabObj);
-		
+
 		if (tabObj) {
 			console.log("ChangeTab is called on every click, and id=" + tabObj);
 			var tabs = tabObj.parentNode.parentNode.getElementsByTagName('a');
-			for (var i=0; i<tabs.length; i++) {
+			for (var i = 0; i < tabs.length; i++) {
 				if (tabs[i].className.indexOf('current') != -1) {
 					manipulateClass('remove', tabs[i], 'current');
 				}
-				var divId = tabs[i].id.substring(0, tabs[i].id.lastIndexOf("Tab"));
+				var divId = tabs[i].id.substring(0, tabs[i].id
+						.lastIndexOf("Tab"));
 				var divObj = document.getElementById(divId);
 				if (divObj) {
 					if (tabs[i].id == tabObj.id)
@@ -59,27 +67,30 @@
 				}
 			}
 			addClass(tabObj, 'current');
-			
+
 			setTabCookie(tabObj.id);
 		}
 		return false;
-    }
+	}
 </script>
 
 <div id="radiologyTabs">
 	<ul>
 		<openmrs:hasPrivilege privilege="View Orders">
-			<li><a id="radiologyOrdersTab" href="#" onclick="return changeTab(this);" hidefocus="hidefocus"><openmrs:message code="radiology.radiologyTabs.orders"/></a></li>
+			<li><a id="radiologyOrdersTab" href="#"
+				onclick="return changeTab(this);" hidefocus="hidefocus"><openmrs:message
+						code="radiology.radiologyTabs.orders" /></a></li>
 		</openmrs:hasPrivilege>
 	</ul>
 </div>
 
 <div id="radiologySections">
 	<openmrs:hasPrivilege privilege="View Orders">
-		<div id="radiologyOrders" style="display:none;">
-			
-			<openmrs:portlet url="radiologyOrdersTab" id="ordersTab" moduleId="radiology"/>	
-			
+		<div id="radiologyOrders" style="display: none;">
+
+			<openmrs:portlet url="radiologyOrdersTab" id="ordersTab"
+				moduleId="radiology" />
+
 		</div>
 	</openmrs:hasPrivilege>
 </div>

--- a/omod/src/main/webapp/radiologyReportForm.jsp
+++ b/omod/src/main/webapp/radiologyReportForm.jsp
@@ -8,26 +8,24 @@
 <spring:hasBindErrors name="radiologyReport">
 	<spring:message code="fix.error" />
 </spring:hasBindErrors>
-<openmrs:htmlInclude file="/moduleResources/radiology/js/tinymce/tinymce.min.js" />
+<openmrs:htmlInclude
+	file="/moduleResources/radiology/js/tinymce/tinymce.min.js" />
 <script type="text/javascript">
 	onload = initEverything();
-	function initEverything()
-	{
-		tinymce.init(
-				{
-					selector:'#reportText',
-					setup:function(ed){
-						if(document.getElementById("reportText").getAttribute("disabled")!=null)
-						{
-							ed.settings.readonly=true;
-							ed.settings.toolbar=false;
-							ed.settings.menubar=false;
-						}
-					},
-					menubar: "edit,format",
-					elementpath:false
+	function initEverything() {
+		tinymce.init({
+			selector : '#reportText',
+			setup : function(ed) {
+				if (document.getElementById("reportText").getAttribute(
+						"disabled") != null) {
+					ed.settings.readonly = true;
+					ed.settings.toolbar = false;
+					ed.settings.menubar = false;
 				}
-		);
+			},
+			menubar : "edit,format",
+			elementpath : false
+		});
 	}
 </script>
 <br>

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletControllerTest.java
@@ -37,68 +37,68 @@ import org.openmrs.test.BaseContextMockTest;
  * Tests {@link PatientDashboardRadiologyTabPortletController}
  */
 public class PatientDashboardRadiologyTabPortletControllerTest extends BaseContextMockTest {
-	
-	private List<RadiologyOrder> mockOrders;
-	
-	private Patient mockPatient1;
-	
-	private Patient invalidPatient;
-	
-	private HttpServletRequest request;
-	
-	private Map<String, Object> model;
-	
-	@Mock
-	private RadiologyOrderService radiologyOrderService;
-	
-	@InjectMocks
-	private PatientDashboardRadiologyTabPortletController patientDashboardRadiologyTabPortletController = new PatientDashboardRadiologyTabPortletController();
-	
-	@Before
-	public void setUp() {
-		
-		request = mock(HttpServletRequest.class);
-		model = new HashMap<String, Object>();
-		
-		mockPatient1 = RadiologyTestData.getMockPatient1();
-		mockOrders = new ArrayList<RadiologyOrder>();
-		mockOrders.add(RadiologyTestData.getMockRadiologyOrder1());
-		when((radiologyOrderService.getRadiologyOrdersByPatient(mockPatient1))).thenReturn(mockOrders);
-		
-		invalidPatient = new Patient();
-		ArrayList<RadiologyOrder> emptyOrdersList = new ArrayList<RadiologyOrder>();
-		when((radiologyOrderService.getRadiologyOrdersByPatient(invalidPatient))).thenReturn(emptyOrdersList);
-	}
-	
-	/**
-	 * @see PatientDashboardRadiologyTabPortletController#populateModel(HttpServletRequest, Map)
-	 * @verifies model is populated with all radiology orders for given patient
-	 */
-	@Test
-	public void populateModel_shouldPopulateModelWithAllRadiologyOrdersForGivenPatient() {
-		
-		model.put("patient", mockPatient1);
-		patientDashboardRadiologyTabPortletController.populateModel(request, model);
-		
-		verify(radiologyOrderService).getRadiologyOrdersByPatient(mockPatient1);
-		
-		List<RadiologyOrder> radiologyOrders = (ArrayList<RadiologyOrder>) model.get("radiologyOrders");
-		assertThat(radiologyOrders, is(mockOrders));
-	}
-	
-	/**
-	 * @see PatientDashboardRadiologyTabPortletController#populateModel(HttpServletRequest, Map)
-	 * @verifies model is populated with an empty list of radiology orders if given patient is unknown
-	 */
-	@Test
-	public void populateModel_shouldPopulateModelWithEmptyRadiologyOrderListWhenInvalidPatientIsGiven() {
-		
-		model.put("patient", invalidPatient);
-		patientDashboardRadiologyTabPortletController.populateModel(request, model);
-		
-		verify(radiologyOrderService).getRadiologyOrdersByPatient(invalidPatient);
-		
-		List<RadiologyOrder> radiologyOrders = (ArrayList<RadiologyOrder>) model.get("radiologyOrders");
-		assertThat(radiologyOrders, is(empty()));
-	}
+    
+    private List<RadiologyOrder> mockOrders;
+    
+    private Patient mockPatient1;
+    
+    private Patient invalidPatient;
+    
+    private HttpServletRequest request;
+    
+    private Map<String, Object> model;
+    
+    @Mock
+    private RadiologyOrderService radiologyOrderService;
+    
+    @InjectMocks
+    private PatientDashboardRadiologyTabPortletController patientDashboardRadiologyTabPortletController = new PatientDashboardRadiologyTabPortletController();
+    
+    @Before
+    public void setUp() {
+        
+        request = mock(HttpServletRequest.class);
+        model = new HashMap<String, Object>();
+        
+        mockPatient1 = RadiologyTestData.getMockPatient1();
+        mockOrders = new ArrayList<RadiologyOrder>();
+        mockOrders.add(RadiologyTestData.getMockRadiologyOrder1());
+        when((radiologyOrderService.getRadiologyOrdersByPatient(mockPatient1))).thenReturn(mockOrders);
+        
+        invalidPatient = new Patient();
+        ArrayList<RadiologyOrder> emptyOrdersList = new ArrayList<RadiologyOrder>();
+        when((radiologyOrderService.getRadiologyOrdersByPatient(invalidPatient))).thenReturn(emptyOrdersList);
+    }
+    
+    /**
+     * @see PatientDashboardRadiologyTabPortletController#populateModel(HttpServletRequest, Map)
+     * @verifies model is populated with all radiology orders for given patient
+     */
+    @Test
+    public void populateModel_shouldPopulateModelWithAllRadiologyOrdersForGivenPatient() {
+        
+        model.put("patient", mockPatient1);
+        patientDashboardRadiologyTabPortletController.populateModel(request, model);
+        
+        verify(radiologyOrderService).getRadiologyOrdersByPatient(mockPatient1);
+        
+        List<RadiologyOrder> radiologyOrders = (ArrayList<RadiologyOrder>) model.get("radiologyOrders");
+        assertThat(radiologyOrders, is(mockOrders));
+    }
+    
+    /**
+     * @see PatientDashboardRadiologyTabPortletController#populateModel(HttpServletRequest, Map)
+     * @verifies model is populated with an empty list of radiology orders if given patient is unknown
+     */
+    @Test
+    public void populateModel_shouldPopulateModelWithEmptyRadiologyOrderListWhenInvalidPatientIsGiven() {
+        
+        model.put("patient", invalidPatient);
+        patientDashboardRadiologyTabPortletController.populateModel(request, model);
+        
+        verify(radiologyOrderService).getRadiologyOrdersByPatient(invalidPatient);
+        
+        List<RadiologyOrder> radiologyOrders = (ArrayList<RadiologyOrder>) model.get("radiologyOrders");
+        assertThat(radiologyOrders, is(empty()));
+    }
 }

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/PortletsControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/PortletsControllerTest.java
@@ -46,533 +46,533 @@ import org.springframework.web.servlet.ModelAndView;
  * Tests {@link PortletsController}
  */
 public class PortletsControllerTest extends BaseContextMockTest {
-	
-	private List<RadiologyStudy> mockStudies;
-	
-	private List<RadiologyOrder> mockRadiologyOrders;
-	
-	private RadiologyOrder mockRadiologyOrder1;
-	
-	private RadiologyOrder mockRadiologyOrder2;
-	
-	private Patient mockPatient1;
-	
-	private Patient mockPatient3;
-	
-	@Mock
-	private PatientService patientService;
-	
-	@Mock
-	private RadiologyStudyService radiologyStudyService;
-	
-	@Mock
-	private RadiologyOrderService radiologyOrderService;
-	
-	@Mock
-	private AdministrationService administrationService;
-	
-	@InjectMocks
-	private PortletsController portletsController = new PortletsController();
-	
-	@Before
-	public void setUp() {
-		
-		mockRadiologyOrders = new ArrayList<RadiologyOrder>();
-		mockRadiologyOrder1 = RadiologyTestData.getMockRadiologyOrder1();
-		mockRadiologyOrder2 = RadiologyTestData.getMockRadiologyOrder2();
-		mockRadiologyOrders.add(mockRadiologyOrder1);
-		mockRadiologyOrders.add(mockRadiologyOrder2);
-		
-		mockStudies = new ArrayList<RadiologyStudy>();
-		mockStudies.add(RadiologyTestData.getMockStudy1PostSave());
-		mockStudies.add(RadiologyTestData.getMockStudy2PostSave());
-		
-		mockPatient1 = RadiologyTestData.getMockPatient1();
-		mockPatient3 = RadiologyTestData.getMockPatient3();
-		
-		when(Context.getAuthenticatedUser()).thenReturn(RadiologyTestData.getMockRadiologyReferringPhysician());
-		when(radiologyStudyService.getStudiesByRadiologyOrders(mockRadiologyOrders)).thenReturn(mockStudies);
-		when(radiologyOrderService.getRadiologyOrdersByPatients(patientService.getPatients(""))).thenReturn(
-			mockRadiologyOrders);
-		when(radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(mockPatient1))).thenReturn(
-			Arrays.asList(mockRadiologyOrder1));
-		when(radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(mockPatient3))).thenReturn(
-			new ArrayList<RadiologyOrder>());
-		when(patientService.getPatients("Johnny")).thenReturn(new ArrayList<Patient>());
-		when(patientService.getPatients("Joh")).thenReturn(Arrays.asList(mockPatient1));
-		when(patientService.getPatients(mockPatient3.getFamilyName())).thenReturn(Arrays.asList(mockPatient3));
-		
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersByPatientQueryAndDateRange(String, Date, Date)
-	 * @verifies populate model and view with radiology orders associated with given date range null
-	 */
-	@Test
-	public void getRadiologyOrdersByPatientQueryAndDateRange_shouldPopulateModelAndViewWithRadiologyOrdersAssociatedWithGivenDateRangeNull()
-			throws Exception {
-		
-		// given
-		String patientQuery = "";
-		Date startDate = null;
-		Date endDate = null;
-		
-		ModelAndView mav = portletsController.getRadiologyOrdersByPatientQueryAndDateRange(patientQuery, startDate, endDate);
-		assertThat(mav, is(notNullValue()));
-		
-		assertThat(mav.getModelMap(), hasKey("radiologyOrders"));
-		List<RadiologyOrder> radiologyOrders = (List<RadiologyOrder>) mav.getModelMap()
-				.get("radiologyOrders");
-		assertThat(radiologyOrders, is(notNullValue()));
-		assertThat(radiologyOrders, is(mockRadiologyOrders));
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersByPatientQueryAndDateRange(String, Date, Date)
-	 * @verifies not populate model and view with radiology orders if start date is after end date
-	 */
-	@Test
-	public void getRadiologyOrdersByPatientQueryAndDateRange_shouldNotPopulateModelAndViewWithRadiologyOrdersIfStartDateIsAfterEndDate()
-			throws Exception {
-		
-		// given
-		String patientQuery = "";
-		Date startDate = new GregorianCalendar(2010, Calendar.OCTOBER, 10).getTime();
-		Date endDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
-		
-		ModelAndView mav = portletsController.getRadiologyOrdersByPatientQueryAndDateRange(patientQuery, startDate, endDate);
-		assertThat(mav, is(notNullValue()));
-		
-		assertThat(mav.getModelMap(), hasKey("radiologyOrders"));
-		List<RadiologyOrder> radiologyOrders = (List<RadiologyOrder>) mav.getModelMap()
-				.get("radiologyOrders");
-		assertThat(radiologyOrders, is(notNullValue()));
-		assertThat(radiologyOrders, is(empty()));
-		
-		assertThat(mav.getModelMap(), hasKey("exceptionText"));
-		String exception = (String) mav.getModelMap()
-				.get("exceptionText");
-		assertThat(exception, is(notNullValue()));
-		assertThat(exception, is("radiology.crossDate"));
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersByPatientQueryAndDateRange(String, Date, Date)
-	 * @verifies populate model and view with radiology orders
-	 */
-	@Test
-	public void getRadiologyOrdersByPatientQueryAndDateRange_shouldPopulateModelAndViewWithRadiologyOrders()
-			throws Exception {
-		
-		// given
-		String patientQuery = "";
-		Date startDate = null;
-		Date endDate = new GregorianCalendar(2015, Calendar.MARCH, 01).getTime();
-		
-		when(Context.getAuthenticatedUser()).thenReturn(RadiologyTestData.getMockRadiologyReadingPhysician());
-		
-		ModelAndView mav = portletsController.getRadiologyOrdersByPatientQueryAndDateRange(patientQuery, startDate, endDate);
-		assertThat(mav, is(notNullValue()));
-		
-		assertThat(mav.getModelMap(), hasKey("radiologyOrders"));
-		List<RadiologyOrder> radiologyOrders = (List<RadiologyOrder>) mav.getModelMap()
-				.get("radiologyOrders");
-		assertThat(radiologyOrders, is(notNullValue()));
-		assertThat(radiologyOrders, is(Arrays.asList(mockRadiologyOrder1)));
-	}
-	
-	/**
-	 * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
-	 * @verifies return list of orders matching a given date range
-	 */
-	@Test
-	public void filterRadiologyOrdersByDateRange_shouldPopulateModelAndViewWithTableOfOrdersAssociatedWithGivenDateRange()
-			throws Exception {
-		
-		// given
-		Date startDate = new GregorianCalendar(2000, Calendar.MARCH, 01).getTime();
-		Date endDate = new GregorianCalendar(2020, Calendar.MAY, 01).getTime();
-		
-		Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
-				.getDeclaredMethod("filterRadiologyOrdersByDateRange",
-					new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
-		filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
-		
-		List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
-			portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
-		
-		assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
-		assertThat(filteredRadiologyOrdersByDateRange, is(mockRadiologyOrders));
-	}
-	
-	/**
-	 * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
-	 * @verifies return list of all orders with start date if start date is null and end date is null
-	 */
-	@Test
-	public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenDateRangeNull() throws Exception {
-		
-		// given
-		Date startDate = null;
-		Date endDate = null;
-		
-		Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
-				.getDeclaredMethod("filterRadiologyOrdersByDateRange",
-					new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
-		filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
-		
-		List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
-			portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
-		
-		assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
-		assertThat(filteredRadiologyOrdersByDateRange, is(mockRadiologyOrders));
-	}
-	
-	/**
-	 * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
-	 * @verifies return empty list of orders with given end date and start date before any order has started
-	 */
-	@Test
-	public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenEndDateAndStartDateBeforeAnyOrderHasStarted()
-			throws Exception {
-		
-		// given
-		Date startDate = new GregorianCalendar(2014, Calendar.MARCH, 01).getTime();
-		Date endDate = new GregorianCalendar(2014, Calendar.MAY, 01).getTime();
-		
-		Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
-				.getDeclaredMethod("filterRadiologyOrdersByDateRange",
-					new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
-		filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
-		
-		List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
-			portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
-		
-		assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
-		assertThat(filteredRadiologyOrdersByDateRange, is(empty()));
-	}
-	
-	/**
-	 * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
-	 * @verifies return empty list of orders with given end date and start date after any order has started
-	 */
-	@Test
-	public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenEndDateAndStartDateAfterAnyOrderHasStarted()
-			throws Exception {
-		
-		// given
-		Date startDate = new GregorianCalendar(2016, Calendar.MARCH, 01).getTime();
-		Date endDate = new GregorianCalendar(2016, Calendar.MAY, 01).getTime();
-		
-		Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
-				.getDeclaredMethod("filterRadiologyOrdersByDateRange",
-					new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
-		filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
-		
-		List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
-			portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
-		
-		assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
-		assertThat(filteredRadiologyOrdersByDateRange, is(empty()));
-	}
-	
-	/**
-	 * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
-	 * @verifies return list of orders started after given start date but given end date null
-	 */
-	@Test
-	public void filterRadiologyOrdersByDateRange_shouldPopulateModelAndViewWithTableOfOrdersAssociatedWithGivenStartDateButGivenEndDateNull()
-			throws Exception {
-		
-		// given
-		Date startDate = new GregorianCalendar(2015, Calendar.MARCH, 01).getTime();
-		Date endDate = null;
-		
-		Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
-				.getDeclaredMethod("filterRadiologyOrdersByDateRange",
-					new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
-		filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
-		
-		List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
-			portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
-		
-		assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
-		assertThat(filteredRadiologyOrdersByDateRange, is(Arrays.asList(mockRadiologyOrder2)));
-	}
-	
-	/**
-	 * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
-	 * @verifies return list of orders started before given end date but given start date null
-	 */
-	@Test
-	public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenEndDateButGivenStartDateNull()
-			throws Exception {
-		
-		// given
-		Date startDate = null;
-		Date endDate = new GregorianCalendar(2015, Calendar.MARCH, 01).getTime();
-		
-		Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
-				.getDeclaredMethod("filterRadiologyOrdersByDateRange",
-					new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
-		filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
-		
-		List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
-			portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
-		
-		assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
-		assertThat(filteredRadiologyOrdersByDateRange, is(Arrays.asList(mockRadiologyOrder1)));
-	}
-	
-	/**
-	 * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
-	 * @verifies return true if end date is after start date
-	 */
-	@Test
-	public void isEndDateBeforeStartDate_shouldReturnTrueIfEndDateIsAfterStartDate() throws Exception {
-		
-		Method isEndDateBeforeStartDateMethod = portletsController.getClass()
-				.getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
-		isEndDateBeforeStartDateMethod.setAccessible(true);
-		
-		Date startDate = new GregorianCalendar(2010, Calendar.OCTOBER, 10).getTime();
-		Date endDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
-		
-		Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
-				startDate, endDate });
-		assertThat(isEndDateBeforeStartDate, is(true));
-	}
-	
-	/**
-	 * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
-	 * @verifies return false if end date is not after start date
-	 */
-	@Test
-	public void isEndDateBeforeStartDate_shouldReturnFalseIfEndDateIsNotAfterStartDate() throws Exception {
-		
-		Method isEndDateBeforeStartDateMethod = portletsController.getClass()
-				.getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
-		isEndDateBeforeStartDateMethod.setAccessible(true);
-		
-		Date startDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
-		Date endDate = new GregorianCalendar(2010, Calendar.OCTOBER, 10).getTime();
-		
-		Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
-				startDate, endDate });
-		assertThat(isEndDateBeforeStartDate, is(false));
-	}
-	
-	/**
-	 * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
-	 * @verifies return false with given start date but end date null
-	 */
-	@Test
-	public void isEndDateBeforeStartDate_shouldReturnFalsewithGivenStartDateButEndDateNull() throws Exception {
-		
-		Method isEndDateBeforeStartDateMethod = portletsController.getClass()
-				.getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
-		isEndDateBeforeStartDateMethod.setAccessible(true);
-		
-		Date startDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
-		Date endDate = null;
-		
-		Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
-				startDate, endDate });
-		assertThat(isEndDateBeforeStartDate, is(false));
-	}
-	
-	/**
-	 * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
-	 * @verifies return false with given end date but start date null
-	 */
-	@Test
-	public void isEndDateBeforeStartDate_shouldReturnFalsewithGivenEndDateButStartDateNull() throws Exception {
-		
-		Method isEndDateBeforeStartDateMethod = portletsController.getClass()
-				.getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
-		isEndDateBeforeStartDateMethod.setAccessible(true);
-		
-		Date startDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
-		Date endDate = null;
-		
-		Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
-				startDate, endDate });
-		assertThat(isEndDateBeforeStartDate, is(false));
-	}
-	
-	/**
-	 * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
-	 * @verifies return false with given start date and end date null
-	 */
-	@Test
-	public void isEndDateBeforeStartDate_shouldReturnFalsewithGivenStartDateAndEndDateNull() throws Exception {
-		
-		Method isEndDateBeforeStartDateMethod = portletsController.getClass()
-				.getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
-		isEndDateBeforeStartDateMethod.setAccessible(true);
-		
-		Date startDate = null;
-		Date endDate = null;
-		
-		Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
-				startDate, endDate });
-		assertThat(isEndDateBeforeStartDate, is(false));
-	}
-	
-	/**
-	 * @see PortletsController#handleTypeMismatchException(TypeMismatchException)
-	 * @verifies populate model with exception text and invalid value
-	 */
-	@Test
-	public void handleTypeMismatchException_shouldPopulateModelWithExceptionTextAndInvalidValue() throws Exception {
-		
-		// given
-		TypeMismatchException typeMismatchException = new TypeMismatchException("13", Date.class);
-		
-		ModelAndView mav = portletsController.handleTypeMismatchException(typeMismatchException);
-		assertThat(mav, is(notNullValue()));
-		
-		assertThat(mav.getModelMap(), hasKey("invalidValue"));
-		String invalidValue = (String) mav.getModelMap()
-				.get("invalidValue");
-		assertThat(invalidValue, is(notNullValue()));
-		assertThat(invalidValue, is("13"));
-		
-		assertThat(mav.getModelMap(), hasKey("exceptionText"));
-		String exceptionText = (String) mav.getModelMap()
-				.get("exceptionText");
-		assertThat(exceptionText, is(notNullValue()));
-		assertThat(exceptionText, is("typeMismatch.java.util.Date"));
-	}
-	
-	/**
-	 * @see PortletsController#handleTypeMismatchException(TypeMismatchException)
-	 * @verifies populate model with exception text
-	 */
-	@Test
-	public void handleTypeMismatchException_shouldPopulateModelWithExceptionText() throws Exception {
-		
-		// given
-		TypeMismatchException typeMismatchException = new TypeMismatchException("13", Object.class);
-		
-		ModelAndView mav = portletsController.handleTypeMismatchException(typeMismatchException);
-		assertThat(mav, is(notNullValue()));
-		
-		assertThat(mav.getModelMap(), not(hasKey("invalidValue")));
-		
-		assertThat(mav.getModelMap(), hasKey("exceptionText"));
-		String exceptionText = (String) mav.getModelMap()
-				.get("exceptionText");
-		assertThat(exceptionText, is(notNullValue()));
-	}
-	
-	/**
-	 * @see PortletsController#getPatientInfoRoute()
-	 * @verifies return string with patient info route
-	 */
-	@Test
-	public void getPatientInfoRoute_ShouldReturnStringWithPatientInfoRoute() throws Exception {
-		
-		// given
-		String patientInfoRoute = portletsController.getPatientInfoRoute();
-		
-		assertThat(patientInfoRoute, is(notNullValue()));
-		assertThat(patientInfoRoute, is("module/radiology/portlets/patientOverview"));
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
-	 * @verifies return list of all radiology orders given patientQuery empty
-	 */
-	@Test
-	public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersGivenPatientQueryEmpty()
-			throws Exception {
-		
-		Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
-				.getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
-		getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
-		
-		String patientQuery = "";
-		
-		List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
-			portletsController, new Object[] { patientQuery });
-		assertThat(RadiologyOrdersForPatientQuery, is(mockRadiologyOrders));
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
-	 * @verifies return list of all radiology orders given patientQuery null
-	 */
-	@Test
-	public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersGivenPatientQueryNull()
-			throws Exception {
-		
-		Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
-				.getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
-		getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
-		
-		String patientQuery = null;
-		
-		List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
-			portletsController, new Object[] { patientQuery });
-		assertThat(RadiologyOrdersForPatientQuery, is(mockRadiologyOrders));
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
-	 * @verifies return list of all radiology orders given patientQuery matching no patient
-	 */
-	@Test
-	public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersGivenPatientQueryMatchingNoPatient()
-			throws Exception {
-		
-		Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
-				.getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
-		getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
-		
-		String patientQuery = "Johnny";
-		
-		List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
-			portletsController, new Object[] { patientQuery });
-		assertThat(RadiologyOrdersForPatientQuery, is(mockRadiologyOrders));
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
-	 * @verifies return empty list for patients without radiology orders
-	 */
-	@Test
-	public void getRadiologyOrdersForPatientQuery_shouldReturnEmptyListForPatientsWithoutRadiologyOrders() throws Exception {
-		
-		Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
-				.getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
-		getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
-		
-		String patientQuery = RadiologyTestData.getMockPatient3()
-				.getFamilyName();
-		
-		List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
-			portletsController, new Object[] { patientQuery });
-		assertThat(RadiologyOrdersForPatientQuery, is(empty()));
-	}
-	
-	/**
-	 * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
-	 * @verifies return list of all radiology orders for a patient given valid patientQuery
-	 */
-	@Test
-	public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersForGivenPatientQuery()
-			throws Exception {
-		
-		Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
-				.getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
-		getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
-		
-		String patientQuery = "Joh";
-		
-		List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
-			portletsController, new Object[] { patientQuery });
-		assertThat(RadiologyOrdersForPatientQuery, is(Arrays.asList(mockRadiologyOrder1)));
-	}
-	
+    
+    private List<RadiologyStudy> mockStudies;
+    
+    private List<RadiologyOrder> mockRadiologyOrders;
+    
+    private RadiologyOrder mockRadiologyOrder1;
+    
+    private RadiologyOrder mockRadiologyOrder2;
+    
+    private Patient mockPatient1;
+    
+    private Patient mockPatient3;
+    
+    @Mock
+    private PatientService patientService;
+    
+    @Mock
+    private RadiologyStudyService radiologyStudyService;
+    
+    @Mock
+    private RadiologyOrderService radiologyOrderService;
+    
+    @Mock
+    private AdministrationService administrationService;
+    
+    @InjectMocks
+    private PortletsController portletsController = new PortletsController();
+    
+    @Before
+    public void setUp() {
+        
+        mockRadiologyOrders = new ArrayList<RadiologyOrder>();
+        mockRadiologyOrder1 = RadiologyTestData.getMockRadiologyOrder1();
+        mockRadiologyOrder2 = RadiologyTestData.getMockRadiologyOrder2();
+        mockRadiologyOrders.add(mockRadiologyOrder1);
+        mockRadiologyOrders.add(mockRadiologyOrder2);
+        
+        mockStudies = new ArrayList<RadiologyStudy>();
+        mockStudies.add(RadiologyTestData.getMockStudy1PostSave());
+        mockStudies.add(RadiologyTestData.getMockStudy2PostSave());
+        
+        mockPatient1 = RadiologyTestData.getMockPatient1();
+        mockPatient3 = RadiologyTestData.getMockPatient3();
+        
+        when(Context.getAuthenticatedUser()).thenReturn(RadiologyTestData.getMockRadiologyReferringPhysician());
+        when(radiologyStudyService.getStudiesByRadiologyOrders(mockRadiologyOrders)).thenReturn(mockStudies);
+        when(radiologyOrderService.getRadiologyOrdersByPatients(patientService.getPatients(""))).thenReturn(
+            mockRadiologyOrders);
+        when(radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(mockPatient1))).thenReturn(
+            Arrays.asList(mockRadiologyOrder1));
+        when(radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(mockPatient3))).thenReturn(
+            new ArrayList<RadiologyOrder>());
+        when(patientService.getPatients("Johnny")).thenReturn(new ArrayList<Patient>());
+        when(patientService.getPatients("Joh")).thenReturn(Arrays.asList(mockPatient1));
+        when(patientService.getPatients(mockPatient3.getFamilyName())).thenReturn(Arrays.asList(mockPatient3));
+        
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersByPatientQueryAndDateRange(String, Date, Date)
+     * @verifies populate model and view with radiology orders associated with given date range null
+     */
+    @Test
+    public void getRadiologyOrdersByPatientQueryAndDateRange_shouldPopulateModelAndViewWithRadiologyOrdersAssociatedWithGivenDateRangeNull()
+            throws Exception {
+        
+        // given
+        String patientQuery = "";
+        Date startDate = null;
+        Date endDate = null;
+        
+        ModelAndView mav = portletsController.getRadiologyOrdersByPatientQueryAndDateRange(patientQuery, startDate, endDate);
+        assertThat(mav, is(notNullValue()));
+        
+        assertThat(mav.getModelMap(), hasKey("radiologyOrders"));
+        List<RadiologyOrder> radiologyOrders = (List<RadiologyOrder>) mav.getModelMap()
+                .get("radiologyOrders");
+        assertThat(radiologyOrders, is(notNullValue()));
+        assertThat(radiologyOrders, is(mockRadiologyOrders));
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersByPatientQueryAndDateRange(String, Date, Date)
+     * @verifies not populate model and view with radiology orders if start date is after end date
+     */
+    @Test
+    public void getRadiologyOrdersByPatientQueryAndDateRange_shouldNotPopulateModelAndViewWithRadiologyOrdersIfStartDateIsAfterEndDate()
+            throws Exception {
+        
+        // given
+        String patientQuery = "";
+        Date startDate = new GregorianCalendar(2010, Calendar.OCTOBER, 10).getTime();
+        Date endDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
+        
+        ModelAndView mav = portletsController.getRadiologyOrdersByPatientQueryAndDateRange(patientQuery, startDate, endDate);
+        assertThat(mav, is(notNullValue()));
+        
+        assertThat(mav.getModelMap(), hasKey("radiologyOrders"));
+        List<RadiologyOrder> radiologyOrders = (List<RadiologyOrder>) mav.getModelMap()
+                .get("radiologyOrders");
+        assertThat(radiologyOrders, is(notNullValue()));
+        assertThat(radiologyOrders, is(empty()));
+        
+        assertThat(mav.getModelMap(), hasKey("exceptionText"));
+        String exception = (String) mav.getModelMap()
+                .get("exceptionText");
+        assertThat(exception, is(notNullValue()));
+        assertThat(exception, is("radiology.crossDate"));
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersByPatientQueryAndDateRange(String, Date, Date)
+     * @verifies populate model and view with radiology orders
+     */
+    @Test
+    public void getRadiologyOrdersByPatientQueryAndDateRange_shouldPopulateModelAndViewWithRadiologyOrders()
+            throws Exception {
+        
+        // given
+        String patientQuery = "";
+        Date startDate = null;
+        Date endDate = new GregorianCalendar(2015, Calendar.MARCH, 01).getTime();
+        
+        when(Context.getAuthenticatedUser()).thenReturn(RadiologyTestData.getMockRadiologyReadingPhysician());
+        
+        ModelAndView mav = portletsController.getRadiologyOrdersByPatientQueryAndDateRange(patientQuery, startDate, endDate);
+        assertThat(mav, is(notNullValue()));
+        
+        assertThat(mav.getModelMap(), hasKey("radiologyOrders"));
+        List<RadiologyOrder> radiologyOrders = (List<RadiologyOrder>) mav.getModelMap()
+                .get("radiologyOrders");
+        assertThat(radiologyOrders, is(notNullValue()));
+        assertThat(radiologyOrders, is(Arrays.asList(mockRadiologyOrder1)));
+    }
+    
+    /**
+     * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
+     * @verifies return list of orders matching a given date range
+     */
+    @Test
+    public void filterRadiologyOrdersByDateRange_shouldPopulateModelAndViewWithTableOfOrdersAssociatedWithGivenDateRange()
+            throws Exception {
+        
+        // given
+        Date startDate = new GregorianCalendar(2000, Calendar.MARCH, 01).getTime();
+        Date endDate = new GregorianCalendar(2020, Calendar.MAY, 01).getTime();
+        
+        Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
+                .getDeclaredMethod("filterRadiologyOrdersByDateRange",
+                    new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
+        filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
+        
+        List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
+            portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
+        
+        assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
+        assertThat(filteredRadiologyOrdersByDateRange, is(mockRadiologyOrders));
+    }
+    
+    /**
+     * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
+     * @verifies return list of all orders with start date if start date is null and end date is null
+     */
+    @Test
+    public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenDateRangeNull() throws Exception {
+        
+        // given
+        Date startDate = null;
+        Date endDate = null;
+        
+        Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
+                .getDeclaredMethod("filterRadiologyOrdersByDateRange",
+                    new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
+        filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
+        
+        List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
+            portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
+        
+        assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
+        assertThat(filteredRadiologyOrdersByDateRange, is(mockRadiologyOrders));
+    }
+    
+    /**
+     * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
+     * @verifies return empty list of orders with given end date and start date before any order has started
+     */
+    @Test
+    public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenEndDateAndStartDateBeforeAnyOrderHasStarted()
+            throws Exception {
+        
+        // given
+        Date startDate = new GregorianCalendar(2014, Calendar.MARCH, 01).getTime();
+        Date endDate = new GregorianCalendar(2014, Calendar.MAY, 01).getTime();
+        
+        Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
+                .getDeclaredMethod("filterRadiologyOrdersByDateRange",
+                    new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
+        filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
+        
+        List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
+            portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
+        
+        assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
+        assertThat(filteredRadiologyOrdersByDateRange, is(empty()));
+    }
+    
+    /**
+     * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
+     * @verifies return empty list of orders with given end date and start date after any order has started
+     */
+    @Test
+    public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenEndDateAndStartDateAfterAnyOrderHasStarted()
+            throws Exception {
+        
+        // given
+        Date startDate = new GregorianCalendar(2016, Calendar.MARCH, 01).getTime();
+        Date endDate = new GregorianCalendar(2016, Calendar.MAY, 01).getTime();
+        
+        Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
+                .getDeclaredMethod("filterRadiologyOrdersByDateRange",
+                    new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
+        filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
+        
+        List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
+            portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
+        
+        assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
+        assertThat(filteredRadiologyOrdersByDateRange, is(empty()));
+    }
+    
+    /**
+     * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
+     * @verifies return list of orders started after given start date but given end date null
+     */
+    @Test
+    public void filterRadiologyOrdersByDateRange_shouldPopulateModelAndViewWithTableOfOrdersAssociatedWithGivenStartDateButGivenEndDateNull()
+            throws Exception {
+        
+        // given
+        Date startDate = new GregorianCalendar(2015, Calendar.MARCH, 01).getTime();
+        Date endDate = null;
+        
+        Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
+                .getDeclaredMethod("filterRadiologyOrdersByDateRange",
+                    new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
+        filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
+        
+        List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
+            portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
+        
+        assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
+        assertThat(filteredRadiologyOrdersByDateRange, is(Arrays.asList(mockRadiologyOrder2)));
+    }
+    
+    /**
+     * @see PortletsController#filterRadiologyOrdersByDateRange(List<RadiologyOrder>, Date, Date)
+     * @verifies return list of orders started before given end date but given start date null
+     */
+    @Test
+    public void filterRadiologyOrdersByDateRange_shouldReturnListOfOrdersAssociatedWithGivenEndDateButGivenStartDateNull()
+            throws Exception {
+        
+        // given
+        Date startDate = null;
+        Date endDate = new GregorianCalendar(2015, Calendar.MARCH, 01).getTime();
+        
+        Method filterRadiologyOrdersByDateRangeMethod = portletsController.getClass()
+                .getDeclaredMethod("filterRadiologyOrdersByDateRange",
+                    new Class[] { java.util.List.class, java.util.Date.class, java.util.Date.class });
+        filterRadiologyOrdersByDateRangeMethod.setAccessible(true);
+        
+        List<RadiologyOrder> filteredRadiologyOrdersByDateRange = (List<RadiologyOrder>) filterRadiologyOrdersByDateRangeMethod.invoke(
+            portletsController, new Object[] { mockRadiologyOrders, startDate, endDate });
+        
+        assertThat(filteredRadiologyOrdersByDateRange, is(notNullValue()));
+        assertThat(filteredRadiologyOrdersByDateRange, is(Arrays.asList(mockRadiologyOrder1)));
+    }
+    
+    /**
+     * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
+     * @verifies return true if end date is after start date
+     */
+    @Test
+    public void isEndDateBeforeStartDate_shouldReturnTrueIfEndDateIsAfterStartDate() throws Exception {
+        
+        Method isEndDateBeforeStartDateMethod = portletsController.getClass()
+                .getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
+        isEndDateBeforeStartDateMethod.setAccessible(true);
+        
+        Date startDate = new GregorianCalendar(2010, Calendar.OCTOBER, 10).getTime();
+        Date endDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
+        
+        Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
+                startDate, endDate });
+        assertThat(isEndDateBeforeStartDate, is(true));
+    }
+    
+    /**
+     * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
+     * @verifies return false if end date is not after start date
+     */
+    @Test
+    public void isEndDateBeforeStartDate_shouldReturnFalseIfEndDateIsNotAfterStartDate() throws Exception {
+        
+        Method isEndDateBeforeStartDateMethod = portletsController.getClass()
+                .getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
+        isEndDateBeforeStartDateMethod.setAccessible(true);
+        
+        Date startDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
+        Date endDate = new GregorianCalendar(2010, Calendar.OCTOBER, 10).getTime();
+        
+        Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
+                startDate, endDate });
+        assertThat(isEndDateBeforeStartDate, is(false));
+    }
+    
+    /**
+     * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
+     * @verifies return false with given start date but end date null
+     */
+    @Test
+    public void isEndDateBeforeStartDate_shouldReturnFalsewithGivenStartDateButEndDateNull() throws Exception {
+        
+        Method isEndDateBeforeStartDateMethod = portletsController.getClass()
+                .getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
+        isEndDateBeforeStartDateMethod.setAccessible(true);
+        
+        Date startDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
+        Date endDate = null;
+        
+        Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
+                startDate, endDate });
+        assertThat(isEndDateBeforeStartDate, is(false));
+    }
+    
+    /**
+     * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
+     * @verifies return false with given end date but start date null
+     */
+    @Test
+    public void isEndDateBeforeStartDate_shouldReturnFalsewithGivenEndDateButStartDateNull() throws Exception {
+        
+        Method isEndDateBeforeStartDateMethod = portletsController.getClass()
+                .getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
+        isEndDateBeforeStartDateMethod.setAccessible(true);
+        
+        Date startDate = new GregorianCalendar(2001, Calendar.JANUARY, 01).getTime();
+        Date endDate = null;
+        
+        Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
+                startDate, endDate });
+        assertThat(isEndDateBeforeStartDate, is(false));
+    }
+    
+    /**
+     * @see PortletsController#isEndDateBeforeStartDate(Date, Date)
+     * @verifies return false with given start date and end date null
+     */
+    @Test
+    public void isEndDateBeforeStartDate_shouldReturnFalsewithGivenStartDateAndEndDateNull() throws Exception {
+        
+        Method isEndDateBeforeStartDateMethod = portletsController.getClass()
+                .getDeclaredMethod("isEndDateBeforeStartDate", new Class[] { java.util.Date.class, java.util.Date.class });
+        isEndDateBeforeStartDateMethod.setAccessible(true);
+        
+        Date startDate = null;
+        Date endDate = null;
+        
+        Boolean isEndDateBeforeStartDate = (Boolean) isEndDateBeforeStartDateMethod.invoke(portletsController, new Object[] {
+                startDate, endDate });
+        assertThat(isEndDateBeforeStartDate, is(false));
+    }
+    
+    /**
+     * @see PortletsController#handleTypeMismatchException(TypeMismatchException)
+     * @verifies populate model with exception text and invalid value
+     */
+    @Test
+    public void handleTypeMismatchException_shouldPopulateModelWithExceptionTextAndInvalidValue() throws Exception {
+        
+        // given
+        TypeMismatchException typeMismatchException = new TypeMismatchException("13", Date.class);
+        
+        ModelAndView mav = portletsController.handleTypeMismatchException(typeMismatchException);
+        assertThat(mav, is(notNullValue()));
+        
+        assertThat(mav.getModelMap(), hasKey("invalidValue"));
+        String invalidValue = (String) mav.getModelMap()
+                .get("invalidValue");
+        assertThat(invalidValue, is(notNullValue()));
+        assertThat(invalidValue, is("13"));
+        
+        assertThat(mav.getModelMap(), hasKey("exceptionText"));
+        String exceptionText = (String) mav.getModelMap()
+                .get("exceptionText");
+        assertThat(exceptionText, is(notNullValue()));
+        assertThat(exceptionText, is("typeMismatch.java.util.Date"));
+    }
+    
+    /**
+     * @see PortletsController#handleTypeMismatchException(TypeMismatchException)
+     * @verifies populate model with exception text
+     */
+    @Test
+    public void handleTypeMismatchException_shouldPopulateModelWithExceptionText() throws Exception {
+        
+        // given
+        TypeMismatchException typeMismatchException = new TypeMismatchException("13", Object.class);
+        
+        ModelAndView mav = portletsController.handleTypeMismatchException(typeMismatchException);
+        assertThat(mav, is(notNullValue()));
+        
+        assertThat(mav.getModelMap(), not(hasKey("invalidValue")));
+        
+        assertThat(mav.getModelMap(), hasKey("exceptionText"));
+        String exceptionText = (String) mav.getModelMap()
+                .get("exceptionText");
+        assertThat(exceptionText, is(notNullValue()));
+    }
+    
+    /**
+     * @see PortletsController#getPatientInfoRoute()
+     * @verifies return string with patient info route
+     */
+    @Test
+    public void getPatientInfoRoute_ShouldReturnStringWithPatientInfoRoute() throws Exception {
+        
+        // given
+        String patientInfoRoute = portletsController.getPatientInfoRoute();
+        
+        assertThat(patientInfoRoute, is(notNullValue()));
+        assertThat(patientInfoRoute, is("module/radiology/portlets/patientOverview"));
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
+     * @verifies return list of all radiology orders given patientQuery empty
+     */
+    @Test
+    public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersGivenPatientQueryEmpty()
+            throws Exception {
+        
+        Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
+                .getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
+        getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
+        
+        String patientQuery = "";
+        
+        List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
+            portletsController, new Object[] { patientQuery });
+        assertThat(RadiologyOrdersForPatientQuery, is(mockRadiologyOrders));
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
+     * @verifies return list of all radiology orders given patientQuery null
+     */
+    @Test
+    public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersGivenPatientQueryNull()
+            throws Exception {
+        
+        Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
+                .getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
+        getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
+        
+        String patientQuery = null;
+        
+        List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
+            portletsController, new Object[] { patientQuery });
+        assertThat(RadiologyOrdersForPatientQuery, is(mockRadiologyOrders));
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
+     * @verifies return list of all radiology orders given patientQuery matching no patient
+     */
+    @Test
+    public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersGivenPatientQueryMatchingNoPatient()
+            throws Exception {
+        
+        Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
+                .getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
+        getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
+        
+        String patientQuery = "Johnny";
+        
+        List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
+            portletsController, new Object[] { patientQuery });
+        assertThat(RadiologyOrdersForPatientQuery, is(mockRadiologyOrders));
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
+     * @verifies return empty list for patients without radiology orders
+     */
+    @Test
+    public void getRadiologyOrdersForPatientQuery_shouldReturnEmptyListForPatientsWithoutRadiologyOrders() throws Exception {
+        
+        Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
+                .getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
+        getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
+        
+        String patientQuery = RadiologyTestData.getMockPatient3()
+                .getFamilyName();
+        
+        List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
+            portletsController, new Object[] { patientQuery });
+        assertThat(RadiologyOrdersForPatientQuery, is(empty()));
+    }
+    
+    /**
+     * @see PortletsController#getRadiologyOrdersForPatientQuery(String)
+     * @verifies return list of all radiology orders for a patient given valid patientQuery
+     */
+    @Test
+    public void getRadiologyOrdersForPatientQuery_shouldReturnListOfAllRadiologyOrdersForGivenPatientQuery()
+            throws Exception {
+        
+        Method getRadiologyOrdersForPatientQueryMethod = portletsController.getClass()
+                .getDeclaredMethod("getRadiologyOrdersForPatientQuery", new Class[] { String.class });
+        getRadiologyOrdersForPatientQueryMethod.setAccessible(true);
+        
+        String patientQuery = "Joh";
+        
+        List<RadiologyOrder> RadiologyOrdersForPatientQuery = (List<RadiologyOrder>) getRadiologyOrdersForPatientQueryMethod.invoke(
+            portletsController, new Object[] { patientQuery });
+        assertThat(RadiologyOrdersForPatientQuery, is(Arrays.asList(mockRadiologyOrder1)));
+    }
+    
 }

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
@@ -55,534 +55,534 @@ import org.springframework.web.servlet.ModelAndView;
  * Tests {@link RadiologyOrderFormController}
  */
 public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
-	
-	@Mock
-	private OrderService orderService;
-	
-	@Mock
-	private RadiologyOrderService radiologyOrderService;
-	
-	@Mock
-	private RadiologyReportService radiologyReportService;
-	
-	@Mock
-	private RadiologyProperties radiologyProperties;
-	
-	@Mock
-	private DicomWebViewer dicomWebViewer;
-	
-	@InjectMocks
-	private RadiologyOrderFormController radiologyOrderFormController = new RadiologyOrderFormController();
-	
-	private Method radiologyReportNeedsToBeCreatedMethod = null;
-	
-	@Before
-	public void setUp() throws Exception {
-		when(radiologyProperties.getRadiologyTestOrderType()).thenReturn(RadiologyTestData.getMockRadiologyOrderType());
-		
-		radiologyReportNeedsToBeCreatedMethod = RadiologyOrderFormController.class.getDeclaredMethod(
-			"radiologyReportNeedsToBeCreated", new Class[] { org.springframework.web.servlet.ModelAndView.class,
-					org.openmrs.Order.class });
-		radiologyReportNeedsToBeCreatedMethod.setAccessible(true);
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#getRadiologyOrderFormWithNewRadiologyOrder()
-	 */
-	@Test
-	@Verifies(value = "should populate model and view with new radiology order", method = "getRadiologyOrderFormWithNewRadiologyOrder()")
-	public void getRadiologyOrderFormWithNewRadiologyOrder_shouldPopulateModelAndViewWithNewRadiologyOrder()
-			throws Exception {
-		
-		ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrder();
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertNull(order.getOrderId());
-		
-		assertNotNull(order.getStudy());
-		assertNull(order.getStudy()
-				.getStudyId());
-		
-		assertNull(order.getOrderer());
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)
-	 */
-	@Test
-	@Verifies(value = "should populate model and view with new radiology order prefilled with given patient", method = "getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)")
-	public void getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient_shouldPopulateModelAndViewWithNewRadiologyOrderPrefilledWithGivenPatient()
-	
-	throws Exception {
-		
-		// given
-		Patient mockPatient = RadiologyTestData.getMockPatient1();
-		
-		ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(mockPatient);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertNull(order.getOrderId());
-		
-		assertNotNull(order.getStudy());
-		assertNull(order.getStudy()
-				.getStudyId());
-		
-		assertNotNull(order.getPatient());
-		assertThat(order.getPatient(), is(mockPatient));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("patientId"));
-		Integer patientId = (Integer) modelAndView.getModelMap()
-				.get("patientId");
-		assertThat(patientId, is(mockPatient.getPatientId()));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)
-	 */
-	@Test
-	@Verifies(value = "should populate model and view with new radiology order without prefilled patient if given patient is null", method = "getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)")
-	public void getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient_shouldPopulateModelAndViewWithNewRadiologyOrderWithoutPrefilledPatientIfGivenPatientIsNull()
-			throws Exception {
-		
-		ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(null);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertNull(order.getOrderId());
-		
-		assertNotNull(order.getStudy());
-		assertNull(order.getStudy()
-				.getStudyId());
-		
-		assertNull(order.getPatient());
-		
-		assertThat(modelAndView.getModelMap(), not(hasKey("patientId")));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(Order)
-	 * @verifies populate model and view with existing radiology order if given order id matches a
-	 *           radiology order and no dicomViewerUrl if order is not completed
-	 */
-	@Test
-	public void getRadiologyOrderFormWithExistingRadiologyOrderByOrderId_shouldPopulateModelAndViewWithExistingRadiologyOrderIfGivenOrderIdMatchesARadiologyOrderAndNoDicomViewerUrlIfOrderIsNotCompleted()
-			throws Exception {
-		
-		// given
-		RadiologyOrder mockRadiologyOrderInProgress = RadiologyTestData.getMockRadiologyOrder1();
-		mockRadiologyOrderInProgress.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		
-		ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(mockRadiologyOrderInProgress);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
-				.get("order");
-		assertThat(order, is(mockRadiologyOrderInProgress));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertThat(radiologyOrder, is(mockRadiologyOrderInProgress));
-		
-		assertThat(modelAndView.getModelMap(), not(hasKey("dicomViewerUrl")));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(Order)
-	 * @verifies populate model and view with existing radiology order if given order id matches a
-	 *           radiology order and dicomViewerUrl if order completed
-	 */
-	@Test
-	public void getRadiologyOrderFormWithExistingRadiologyOrderByOrderId_shouldPopulateModelAndViewWithExistingRadiologyOrderIfGivenOrderIdMatchesARadiologyOrderAndDicomViewerUrlIfOrderCompleted()
-			throws Exception {
-		
-		// given
-		RadiologyOrder mockCompletedRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		mockCompletedRadiologyOrder.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		
-		when(dicomWebViewer.getDicomViewerUrl(mockCompletedRadiologyOrder.getStudy())).thenReturn(
-			"http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1");
-		
-		ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(mockCompletedRadiologyOrder);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
-				.get("order");
-		assertThat(order, is(mockCompletedRadiologyOrder));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertThat(radiologyOrder, is(mockCompletedRadiologyOrder));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("dicomViewerUrl"));
-		String dicomViewerUrl = (String) modelAndView.getModelMap()
-				.get("dicomViewerUrl");
-		assertThat(dicomViewerUrl,
-			is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(Order)
-	 * @verifies populate model and view with existing order if given order id only matches an order
-	 *           and not a radiology order
-	 */
-	@Test
-	public void getRadiologyOrderFormWithExistingRadiologyOrderByOrderId_shouldPopulateModelAndViewWithExistingOrderIfGivenOrderIdOnlyMatchesAnOrderAndNotARadiologyOrder()
-			throws Exception {
-		
-		// given
-		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
-		String discontinueReason = "Wrong Procedure";
-		
-		Order mockDiscontinuationOrder = new Order();
-		mockDiscontinuationOrder.setOrderId(2);
-		mockDiscontinuationOrder.setAction(Order.Action.DISCONTINUE);
-		mockDiscontinuationOrder.setOrderer(mockRadiologyOrderToDiscontinue.getOrderer());
-		mockDiscontinuationOrder.setOrderReasonNonCoded(discontinueReason);
-		mockDiscontinuationOrder.setPreviousOrder(mockRadiologyOrderToDiscontinue);
-		
-		ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(mockDiscontinuationOrder);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		Order order = (Order) modelAndView.getModelMap()
-				.get("order");
-		assertThat(order, is(mockDiscontinuationOrder));
-		
-		assertThat(modelAndView.getModelMap(), not(hasKey("radiologyOrder")));
-		
-		assertThat(modelAndView.getModelMap(), not(hasKey("dicomViewerUrl")));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
-	 */
-	@Test
-	@Verifies(value = "should set http session attribute openmrs message to order saved and redirect to radiologyOrderForm when save study was successful", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
-	public void postSaveRadiologyOrder_shouldSetHttpSessionAttributeOpenmrsMessageToOrderSavedAndRedirectToRadiologyOrderFormWhenSaveStudyWasSuccessful()
-			throws Exception {
-		
-		// given
-		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		
-		when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		mockRequest.addParameter("saveOrder", "saveOrder");
-		MockHttpSession mockSession = new MockHttpSession();
-		mockRequest.setSession(mockSession);
-		
-		BindingResult orderErrors = mock(BindingResult.class);
-		when(orderErrors.hasErrors()).thenReturn(false);
-		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest, null,
-			mockRadiologyOrder, mockRadiologyOrder, orderErrors);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockRadiologyOrder.getOrderId()));
-		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
-	 */
-	@Test
-	@Verifies(value = "should set http session attribute openmrs message to order saved and redirect to radiologyOrderForm when save study was successful and given patient id", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
-	public void postSaveRadiologyOrder_shouldSetHttpSessionAttributeOpenmrsMessageToOrderSavedAndRedirectToRadiologyOrderFormWhenSaveStudyWasSuccessfulAndGivenPatientId()
-			throws Exception {
-		
-		// given
-		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		
-		when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		mockRequest.addParameter("saveOrder", "saveOrder");
-		MockHttpSession mockSession = new MockHttpSession();
-		mockRequest.setSession(mockSession);
-		
-		BindingResult orderErrors = mock(BindingResult.class);
-		when(orderErrors.hasErrors()).thenReturn(false);
-		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest,
-			mockRadiologyOrder.getPatient()
-					.getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockRadiologyOrder.getOrderId()));
-		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
-	 */
-	@Test
-	@Verifies(value = "should set http session attribute openmrs message to study performed when study performed status is in progress and request was issued by radiology scheduler", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
-	public void postSaveRadiologyOrder_shouldSetHttpSessionAttributeOpenmrsMessageToStudyPerformedWhenStudyPerformedStatusIsInProgressAndRequestWasIssuedByRadiologyScheduler()
-			throws Exception {
-		
-		// given
-		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		mockRadiologyOrder.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
-		
-		when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
-		when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		mockRequest.addParameter("saveOrder", "saveOrder");
-		MockHttpSession mockSession = new MockHttpSession();
-		mockRequest.setSession(mockSession);
-		
-		BindingResult orderErrors = mock(BindingResult.class);
-		when(orderErrors.hasErrors()).thenReturn(false);
-		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest,
-			mockRadiologyOrder.getPatient()
-					.getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR), is("radiology.studyPerformed"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
-	 */
-	@Test
-	@Verifies(value = "should not redirect if radiology order is not valid according to order validator", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
-	public void postSaveRadiologyOrder_shouldNotRedirectIfRadiologyOrderIsNotValidAccordingToOrderValidator()
-			throws Exception {
-		
-		// given
-		RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
-		
-		when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
-		when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
-		
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		mockRequest.addParameter("saveOrder", "saveOrder");
-		MockHttpSession mockSession = new MockHttpSession();
-		mockRequest.setSession(mockSession);
-		
-		BindingResult orderErrors = mock(BindingResult.class);
-		when(orderErrors.hasErrors()).thenReturn(true);
-		
-		ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest,
-			mockRadiologyOrder.getPatient()
-					.getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#postDiscontinueRadiologyOrder(HttpServletRequest, HttpServletResponse, Order,
-	 *      String, Date)
-	 */
-	@Test
-	@Verifies(value = "should discontinue non discontinued order and redirect to discontinuation order", method = "postDiscontinueRadiologyOrder(HttpServletRequest, HttpServletResponse, Order, String, Date)")
-	public void postDiscontinueRadiologyOrder_shouldDiscontinueNonDiscontinuedOrderAndRedirectToDiscontinuationOrder()
-			throws Exception {
-		// given
-		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
-		String discontinueReason = "Wrong Procedure";
-		
-		Order mockDiscontinuationOrder = new Order();
-		mockDiscontinuationOrder.setOrderId(2);
-		mockDiscontinuationOrder.setAction(Order.Action.DISCONTINUE);
-		mockDiscontinuationOrder.setOrderer(mockRadiologyOrderToDiscontinue.getOrderer());
-		mockDiscontinuationOrder.setOrderReasonNonCoded(discontinueReason);
-		mockDiscontinuationOrder.setPreviousOrder(mockRadiologyOrderToDiscontinue);
-		
-		MockHttpServletRequest mockRequest = new MockHttpServletRequest();
-		mockRequest.addParameter("discontinueOrder", "discontinueOrder");
-		MockHttpSession mockSession = new MockHttpSession();
-		mockRequest.setSession(mockSession);
-		
-		when(radiologyOrderService.getRadiologyOrderByOrderId(mockRadiologyOrderToDiscontinue.getOrderId())).thenReturn(
-			mockRadiologyOrderToDiscontinue);
-		when(
-			radiologyOrderService.discontinueRadiologyOrder(mockRadiologyOrderToDiscontinue,
-				mockDiscontinuationOrder.getOrderer(), mockDiscontinuationOrder.getOrderReasonNonCoded())).thenReturn(
-			mockDiscontinuationOrder);
-		
-		BindingResult orderErrors = mock(BindingResult.class);
-		assertThat(mockRadiologyOrderToDiscontinue.getAction(), is(Order.Action.NEW));
-		ModelAndView modelAndView = radiologyOrderFormController.postDiscontinueRadiologyOrder(mockRequest, null,
-			mockRadiologyOrderToDiscontinue, mockDiscontinuationOrder, orderErrors);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockDiscontinuationOrder.getOrderId()));
-		assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.discontinuedSuccessfully"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
-	 * @verifies return false if order is not a radiology order
-	 */
-	@Test
-	public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfOrderIsNotARadiologyOrder() throws Exception {
-		
-		// given
-		ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
-		
-		RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
-		String discontinueReason = "Wrong Procedure";
-		
-		Order mockDiscontinuationOrder = new Order();
-		mockDiscontinuationOrder.setOrderId(2);
-		mockDiscontinuationOrder.setAction(Order.Action.DISCONTINUE);
-		mockDiscontinuationOrder.setOrderer(mockRadiologyOrderToDiscontinue.getOrderer());
-		mockDiscontinuationOrder.setOrderReasonNonCoded(discontinueReason);
-		mockDiscontinuationOrder.setPreviousOrder(mockRadiologyOrderToDiscontinue);
-		
-		final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
-			new Object[] { modelAndView, mockDiscontinuationOrder });
-		assertFalse(result);
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
-		assertFalse((Boolean) modelAndView.getModelMap()
-				.get("radiologyReportNeedsToBeCreated"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
-	 * @verifies return false if radiology order is not completed
-	 */
-	@Test
-	public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfRadiologyOrderIsNotCompleted() throws Exception {
-		
-		// given
-		ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
-		
-		RadiologyOrder incompleteRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
-		incompleteRadiologyOrder.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
-		
-		final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
-			new Object[] { modelAndView, incompleteRadiologyOrder });
-		assertFalse(result);
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
-		assertFalse((Boolean) modelAndView.getModelMap()
-				.get("radiologyReportNeedsToBeCreated"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
-	 * @verifies return false if radiology order is completed but has a claimed report
-	 */
-	@Test
-	public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfRadiologyOrderIsCompletedButHasAClaimedReport()
-			throws Exception {
-		
-		// given
-		ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
-		
-		RadiologyReport claimedReport = RadiologyTestData.getMockRadiologyReport1();
-		claimedReport.setReportStatus(RadiologyReportStatus.CLAIMED);
-		
-		RadiologyOrder completedRadiologyOrderWithClaimedReport = claimedReport.getRadiologyOrder();
-		completedRadiologyOrderWithClaimedReport.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		
-		when(radiologyReportService.getActiveRadiologyReportByRadiologyOrder(completedRadiologyOrderWithClaimedReport)).thenReturn(
-			claimedReport);
-		
-		final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
-			new Object[] { modelAndView, completedRadiologyOrderWithClaimedReport });
-		assertFalse(result);
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
-		assertFalse((Boolean) modelAndView.getModelMap()
-				.get("radiologyReportNeedsToBeCreated"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
-	 * @verifies return false if radiology order is completed but has a completed report
-	 */
-	@Test
-	public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfRadiologyOrderIsCompletedButHasACompletedReport()
-			throws Exception {
-		
-		// given
-		ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
-		
-		RadiologyReport completedReport = RadiologyTestData.getMockRadiologyReport1();
-		completedReport.setReportStatus(RadiologyReportStatus.COMPLETED);
-		
-		RadiologyOrder completedRadiologyOrderWithCompletedReport = completedReport.getRadiologyOrder();
-		completedRadiologyOrderWithCompletedReport.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		
-		when(radiologyReportService.getActiveRadiologyReportByRadiologyOrder(completedRadiologyOrderWithCompletedReport)).thenReturn(
-			completedReport);
-		
-		final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
-			new Object[] { modelAndView, completedRadiologyOrderWithCompletedReport });
-		assertFalse(result);
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
-		assertFalse((Boolean) modelAndView.getModelMap()
-				.get("radiologyReportNeedsToBeCreated"));
-	}
-	
-	/**
-	 * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
-	 * @verifies return true if radiology order is completed and has no claimed report
-	 */
-	@Test
-	public void radiologyReportNeedsToBeCreated_shouldReturnTrueIfRadiologyOrderIsCompletedAndHasNoClaimedReport()
-			throws Exception {
-		
-		// given
-		ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
-		
-		RadiologyOrder completedRadiologyOrderWithNoClaimedReport = RadiologyTestData.getMockRadiologyOrder1();
-		completedRadiologyOrderWithNoClaimedReport.getStudy()
-				.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		
-		when(radiologyReportService.getActiveRadiologyReportByRadiologyOrder(completedRadiologyOrderWithNoClaimedReport)).thenReturn(
-			null);
-		
-		final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
-			new Object[] { modelAndView, completedRadiologyOrderWithNoClaimedReport });
-		assertTrue(result);
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
-		assertTrue((Boolean) modelAndView.getModelMap()
-				.get("radiologyReportNeedsToBeCreated"));
-	}
+    
+    @Mock
+    private OrderService orderService;
+    
+    @Mock
+    private RadiologyOrderService radiologyOrderService;
+    
+    @Mock
+    private RadiologyReportService radiologyReportService;
+    
+    @Mock
+    private RadiologyProperties radiologyProperties;
+    
+    @Mock
+    private DicomWebViewer dicomWebViewer;
+    
+    @InjectMocks
+    private RadiologyOrderFormController radiologyOrderFormController = new RadiologyOrderFormController();
+    
+    private Method radiologyReportNeedsToBeCreatedMethod = null;
+    
+    @Before
+    public void setUp() throws Exception {
+        when(radiologyProperties.getRadiologyTestOrderType()).thenReturn(RadiologyTestData.getMockRadiologyOrderType());
+        
+        radiologyReportNeedsToBeCreatedMethod = RadiologyOrderFormController.class.getDeclaredMethod(
+            "radiologyReportNeedsToBeCreated", new Class[] { org.springframework.web.servlet.ModelAndView.class,
+                    org.openmrs.Order.class });
+        radiologyReportNeedsToBeCreatedMethod.setAccessible(true);
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#getRadiologyOrderFormWithNewRadiologyOrder()
+     */
+    @Test
+    @Verifies(value = "should populate model and view with new radiology order", method = "getRadiologyOrderFormWithNewRadiologyOrder()")
+    public void getRadiologyOrderFormWithNewRadiologyOrder_shouldPopulateModelAndViewWithNewRadiologyOrder()
+            throws Exception {
+        
+        ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrder();
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertNull(order.getOrderId());
+        
+        assertNotNull(order.getStudy());
+        assertNull(order.getStudy()
+                .getStudyId());
+        
+        assertNull(order.getOrderer());
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)
+     */
+    @Test
+    @Verifies(value = "should populate model and view with new radiology order prefilled with given patient", method = "getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)")
+    public void getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient_shouldPopulateModelAndViewWithNewRadiologyOrderPrefilledWithGivenPatient()
+    
+    throws Exception {
+        
+        // given
+        Patient mockPatient = RadiologyTestData.getMockPatient1();
+        
+        ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(mockPatient);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertNull(order.getOrderId());
+        
+        assertNotNull(order.getStudy());
+        assertNull(order.getStudy()
+                .getStudyId());
+        
+        assertNotNull(order.getPatient());
+        assertThat(order.getPatient(), is(mockPatient));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("patientId"));
+        Integer patientId = (Integer) modelAndView.getModelMap()
+                .get("patientId");
+        assertThat(patientId, is(mockPatient.getPatientId()));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)
+     */
+    @Test
+    @Verifies(value = "should populate model and view with new radiology order without prefilled patient if given patient is null", method = "getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(Integer)")
+    public void getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient_shouldPopulateModelAndViewWithNewRadiologyOrderWithoutPrefilledPatientIfGivenPatientIsNull()
+            throws Exception {
+        
+        ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(null);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertNull(order.getOrderId());
+        
+        assertNotNull(order.getStudy());
+        assertNull(order.getStudy()
+                .getStudyId());
+        
+        assertNull(order.getPatient());
+        
+        assertThat(modelAndView.getModelMap(), not(hasKey("patientId")));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(Order)
+     * @verifies populate model and view with existing radiology order if given order id matches a
+     *           radiology order and no dicomViewerUrl if order is not completed
+     */
+    @Test
+    public void getRadiologyOrderFormWithExistingRadiologyOrderByOrderId_shouldPopulateModelAndViewWithExistingRadiologyOrderIfGivenOrderIdMatchesARadiologyOrderAndNoDicomViewerUrlIfOrderIsNotCompleted()
+            throws Exception {
+        
+        // given
+        RadiologyOrder mockRadiologyOrderInProgress = RadiologyTestData.getMockRadiologyOrder1();
+        mockRadiologyOrderInProgress.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        
+        ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(mockRadiologyOrderInProgress);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
+                .get("order");
+        assertThat(order, is(mockRadiologyOrderInProgress));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertThat(radiologyOrder, is(mockRadiologyOrderInProgress));
+        
+        assertThat(modelAndView.getModelMap(), not(hasKey("dicomViewerUrl")));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(Order)
+     * @verifies populate model and view with existing radiology order if given order id matches a
+     *           radiology order and dicomViewerUrl if order completed
+     */
+    @Test
+    public void getRadiologyOrderFormWithExistingRadiologyOrderByOrderId_shouldPopulateModelAndViewWithExistingRadiologyOrderIfGivenOrderIdMatchesARadiologyOrderAndDicomViewerUrlIfOrderCompleted()
+            throws Exception {
+        
+        // given
+        RadiologyOrder mockCompletedRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
+        mockCompletedRadiologyOrder.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        
+        when(dicomWebViewer.getDicomViewerUrl(mockCompletedRadiologyOrder.getStudy())).thenReturn(
+            "http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1");
+        
+        ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(mockCompletedRadiologyOrder);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
+                .get("order");
+        assertThat(order, is(mockCompletedRadiologyOrder));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertThat(radiologyOrder, is(mockCompletedRadiologyOrder));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("dicomViewerUrl"));
+        String dicomViewerUrl = (String) modelAndView.getModelMap()
+                .get("dicomViewerUrl");
+        assertThat(dicomViewerUrl,
+            is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(Order)
+     * @verifies populate model and view with existing order if given order id only matches an order
+     *           and not a radiology order
+     */
+    @Test
+    public void getRadiologyOrderFormWithExistingRadiologyOrderByOrderId_shouldPopulateModelAndViewWithExistingOrderIfGivenOrderIdOnlyMatchesAnOrderAndNotARadiologyOrder()
+            throws Exception {
+        
+        // given
+        RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
+        String discontinueReason = "Wrong Procedure";
+        
+        Order mockDiscontinuationOrder = new Order();
+        mockDiscontinuationOrder.setOrderId(2);
+        mockDiscontinuationOrder.setAction(Order.Action.DISCONTINUE);
+        mockDiscontinuationOrder.setOrderer(mockRadiologyOrderToDiscontinue.getOrderer());
+        mockDiscontinuationOrder.setOrderReasonNonCoded(discontinueReason);
+        mockDiscontinuationOrder.setPreviousOrder(mockRadiologyOrderToDiscontinue);
+        
+        ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithExistingRadiologyOrderByOrderId(mockDiscontinuationOrder);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        Order order = (Order) modelAndView.getModelMap()
+                .get("order");
+        assertThat(order, is(mockDiscontinuationOrder));
+        
+        assertThat(modelAndView.getModelMap(), not(hasKey("radiologyOrder")));
+        
+        assertThat(modelAndView.getModelMap(), not(hasKey("dicomViewerUrl")));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
+     */
+    @Test
+    @Verifies(value = "should set http session attribute openmrs message to order saved and redirect to radiologyOrderForm when save study was successful", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
+    public void postSaveRadiologyOrder_shouldSetHttpSessionAttributeOpenmrsMessageToOrderSavedAndRedirectToRadiologyOrderFormWhenSaveStudyWasSuccessful()
+            throws Exception {
+        
+        // given
+        RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
+        
+        when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
+        
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.addParameter("saveOrder", "saveOrder");
+        MockHttpSession mockSession = new MockHttpSession();
+        mockRequest.setSession(mockSession);
+        
+        BindingResult orderErrors = mock(BindingResult.class);
+        when(orderErrors.hasErrors()).thenReturn(false);
+        
+        ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest, null,
+            mockRadiologyOrder, mockRadiologyOrder, orderErrors);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
+                + mockRadiologyOrder.getOrderId()));
+        assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
+     */
+    @Test
+    @Verifies(value = "should set http session attribute openmrs message to order saved and redirect to radiologyOrderForm when save study was successful and given patient id", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
+    public void postSaveRadiologyOrder_shouldSetHttpSessionAttributeOpenmrsMessageToOrderSavedAndRedirectToRadiologyOrderFormWhenSaveStudyWasSuccessfulAndGivenPatientId()
+            throws Exception {
+        
+        // given
+        RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
+        
+        when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
+        
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.addParameter("saveOrder", "saveOrder");
+        MockHttpSession mockSession = new MockHttpSession();
+        mockRequest.setSession(mockSession);
+        
+        BindingResult orderErrors = mock(BindingResult.class);
+        when(orderErrors.hasErrors()).thenReturn(false);
+        
+        ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest,
+            mockRadiologyOrder.getPatient()
+                    .getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
+                + mockRadiologyOrder.getOrderId()));
+        assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.saved"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
+     */
+    @Test
+    @Verifies(value = "should set http session attribute openmrs message to study performed when study performed status is in progress and request was issued by radiology scheduler", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
+    public void postSaveRadiologyOrder_shouldSetHttpSessionAttributeOpenmrsMessageToStudyPerformedWhenStudyPerformedStatusIsInProgressAndRequestWasIssuedByRadiologyScheduler()
+            throws Exception {
+        
+        // given
+        RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
+        mockRadiologyOrder.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
+        
+        when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
+        when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
+        
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.addParameter("saveOrder", "saveOrder");
+        MockHttpSession mockSession = new MockHttpSession();
+        mockRequest.setSession(mockSession);
+        
+        BindingResult orderErrors = mock(BindingResult.class);
+        when(orderErrors.hasErrors()).thenReturn(false);
+        
+        ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest,
+            mockRadiologyOrder.getPatient()
+                    .getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+        assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_ERROR_ATTR), is("radiology.studyPerformed"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#postSaveRadiologyOrder(HttpServletRequest, Integer, Order, BindingResult)
+     */
+    @Test
+    @Verifies(value = "should not redirect if radiology order is not valid according to order validator", method = "postSaveRadiologyOrder(HttpServletRequest, Integer, RadiologyOrder, BindingResult)")
+    public void postSaveRadiologyOrder_shouldNotRedirectIfRadiologyOrderIsNotValidAccordingToOrderValidator()
+            throws Exception {
+        
+        // given
+        RadiologyOrder mockRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
+        User mockRadiologyScheduler = RadiologyTestData.getMockRadiologyScheduler();
+        
+        when(userContext.getAuthenticatedUser()).thenReturn(mockRadiologyScheduler);
+        when(radiologyOrderService.placeRadiologyOrder(mockRadiologyOrder)).thenReturn(mockRadiologyOrder);
+        
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.addParameter("saveOrder", "saveOrder");
+        MockHttpSession mockSession = new MockHttpSession();
+        mockRequest.setSession(mockSession);
+        
+        BindingResult orderErrors = mock(BindingResult.class);
+        when(orderErrors.hasErrors()).thenReturn(true);
+        
+        ModelAndView modelAndView = radiologyOrderFormController.postSaveRadiologyOrder(mockRequest,
+            mockRadiologyOrder.getPatient()
+                    .getPatientId(), mockRadiologyOrder, mockRadiologyOrder, orderErrors);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyOrderForm"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#postDiscontinueRadiologyOrder(HttpServletRequest, HttpServletResponse, Order,
+     *      String, Date)
+     */
+    @Test
+    @Verifies(value = "should discontinue non discontinued order and redirect to discontinuation order", method = "postDiscontinueRadiologyOrder(HttpServletRequest, HttpServletResponse, Order, String, Date)")
+    public void postDiscontinueRadiologyOrder_shouldDiscontinueNonDiscontinuedOrderAndRedirectToDiscontinuationOrder()
+            throws Exception {
+        // given
+        RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
+        String discontinueReason = "Wrong Procedure";
+        
+        Order mockDiscontinuationOrder = new Order();
+        mockDiscontinuationOrder.setOrderId(2);
+        mockDiscontinuationOrder.setAction(Order.Action.DISCONTINUE);
+        mockDiscontinuationOrder.setOrderer(mockRadiologyOrderToDiscontinue.getOrderer());
+        mockDiscontinuationOrder.setOrderReasonNonCoded(discontinueReason);
+        mockDiscontinuationOrder.setPreviousOrder(mockRadiologyOrderToDiscontinue);
+        
+        MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+        mockRequest.addParameter("discontinueOrder", "discontinueOrder");
+        MockHttpSession mockSession = new MockHttpSession();
+        mockRequest.setSession(mockSession);
+        
+        when(radiologyOrderService.getRadiologyOrderByOrderId(mockRadiologyOrderToDiscontinue.getOrderId())).thenReturn(
+            mockRadiologyOrderToDiscontinue);
+        when(
+            radiologyOrderService.discontinueRadiologyOrder(mockRadiologyOrderToDiscontinue,
+                mockDiscontinuationOrder.getOrderer(), mockDiscontinuationOrder.getOrderReasonNonCoded())).thenReturn(
+            mockDiscontinuationOrder);
+        
+        BindingResult orderErrors = mock(BindingResult.class);
+        assertThat(mockRadiologyOrderToDiscontinue.getAction(), is(Order.Action.NEW));
+        ModelAndView modelAndView = radiologyOrderFormController.postDiscontinueRadiologyOrder(mockRequest, null,
+            mockRadiologyOrderToDiscontinue, mockDiscontinuationOrder, orderErrors);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
+                + mockDiscontinuationOrder.getOrderId()));
+        assertThat((String) mockSession.getAttribute(WebConstants.OPENMRS_MSG_ATTR), is("Order.discontinuedSuccessfully"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
+     * @verifies return false if order is not a radiology order
+     */
+    @Test
+    public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfOrderIsNotARadiologyOrder() throws Exception {
+        
+        // given
+        ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
+        
+        RadiologyOrder mockRadiologyOrderToDiscontinue = RadiologyTestData.getMockRadiologyOrder1();
+        String discontinueReason = "Wrong Procedure";
+        
+        Order mockDiscontinuationOrder = new Order();
+        mockDiscontinuationOrder.setOrderId(2);
+        mockDiscontinuationOrder.setAction(Order.Action.DISCONTINUE);
+        mockDiscontinuationOrder.setOrderer(mockRadiologyOrderToDiscontinue.getOrderer());
+        mockDiscontinuationOrder.setOrderReasonNonCoded(discontinueReason);
+        mockDiscontinuationOrder.setPreviousOrder(mockRadiologyOrderToDiscontinue);
+        
+        final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
+            new Object[] { modelAndView, mockDiscontinuationOrder });
+        assertFalse(result);
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
+        assertFalse((Boolean) modelAndView.getModelMap()
+                .get("radiologyReportNeedsToBeCreated"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
+     * @verifies return false if radiology order is not completed
+     */
+    @Test
+    public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfRadiologyOrderIsNotCompleted() throws Exception {
+        
+        // given
+        ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
+        
+        RadiologyOrder incompleteRadiologyOrder = RadiologyTestData.getMockRadiologyOrder1();
+        incompleteRadiologyOrder.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
+        
+        final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
+            new Object[] { modelAndView, incompleteRadiologyOrder });
+        assertFalse(result);
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
+        assertFalse((Boolean) modelAndView.getModelMap()
+                .get("radiologyReportNeedsToBeCreated"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
+     * @verifies return false if radiology order is completed but has a claimed report
+     */
+    @Test
+    public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfRadiologyOrderIsCompletedButHasAClaimedReport()
+            throws Exception {
+        
+        // given
+        ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
+        
+        RadiologyReport claimedReport = RadiologyTestData.getMockRadiologyReport1();
+        claimedReport.setReportStatus(RadiologyReportStatus.CLAIMED);
+        
+        RadiologyOrder completedRadiologyOrderWithClaimedReport = claimedReport.getRadiologyOrder();
+        completedRadiologyOrderWithClaimedReport.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        
+        when(radiologyReportService.getActiveRadiologyReportByRadiologyOrder(completedRadiologyOrderWithClaimedReport)).thenReturn(
+            claimedReport);
+        
+        final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
+            new Object[] { modelAndView, completedRadiologyOrderWithClaimedReport });
+        assertFalse(result);
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
+        assertFalse((Boolean) modelAndView.getModelMap()
+                .get("radiologyReportNeedsToBeCreated"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
+     * @verifies return false if radiology order is completed but has a completed report
+     */
+    @Test
+    public void radiologyReportNeedsToBeCreated_shouldReturnFalseIfRadiologyOrderIsCompletedButHasACompletedReport()
+            throws Exception {
+        
+        // given
+        ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
+        
+        RadiologyReport completedReport = RadiologyTestData.getMockRadiologyReport1();
+        completedReport.setReportStatus(RadiologyReportStatus.COMPLETED);
+        
+        RadiologyOrder completedRadiologyOrderWithCompletedReport = completedReport.getRadiologyOrder();
+        completedRadiologyOrderWithCompletedReport.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        
+        when(radiologyReportService.getActiveRadiologyReportByRadiologyOrder(completedRadiologyOrderWithCompletedReport)).thenReturn(
+            completedReport);
+        
+        final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
+            new Object[] { modelAndView, completedRadiologyOrderWithCompletedReport });
+        assertFalse(result);
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
+        assertFalse((Boolean) modelAndView.getModelMap()
+                .get("radiologyReportNeedsToBeCreated"));
+    }
+    
+    /**
+     * @see RadiologyOrderFormController#radiologyReportNeedsToBeCreated(ModelAndView,Order)
+     * @verifies return true if radiology order is completed and has no claimed report
+     */
+    @Test
+    public void radiologyReportNeedsToBeCreated_shouldReturnTrueIfRadiologyOrderIsCompletedAndHasNoClaimedReport()
+            throws Exception {
+        
+        // given
+        ModelAndView modelAndView = new ModelAndView(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW);
+        
+        RadiologyOrder completedRadiologyOrderWithNoClaimedReport = RadiologyTestData.getMockRadiologyOrder1();
+        completedRadiologyOrderWithNoClaimedReport.getStudy()
+                .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        
+        when(radiologyReportService.getActiveRadiologyReportByRadiologyOrder(completedRadiologyOrderWithNoClaimedReport)).thenReturn(
+            null);
+        
+        final boolean result = (Boolean) radiologyReportNeedsToBeCreatedMethod.invoke(radiologyOrderFormController,
+            new Object[] { modelAndView, completedRadiologyOrderWithNoClaimedReport });
+        assertTrue(result);
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyReportNeedsToBeCreated"));
+        assertTrue((Boolean) modelAndView.getModelMap()
+                .get("radiologyReportNeedsToBeCreated"));
+    }
 }

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
@@ -22,234 +22,234 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.servlet.ModelAndView;
 
 public class RadiologyReportFormControllerTest extends BaseContextMockTest {
-	
-	@Mock
-	private RadiologyReportService radiologyReportService;
-	
-	@Mock
-	private DicomWebViewer dicomWebViewer;
-	
-	@InjectMocks
-	private RadiologyReportFormController radiologyReportFormController = new RadiologyReportFormController();
-	
-	/**
-	 * @verifies populate model and view with new radiology report for given radiology order
-	 * @see RadiologyReportFormController#getRadiologyReportFormWithNewRadiologyReport(RadiologyOrder)
-	 */
-	@Test
-	public void getRadiologyReportFormWithNewRadiologyReport_shouldPopulateModelAndViewWithNewRadiologyReportForGivenRadiologyOrder() {
-		
-		// given
-		RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
-		RadiologyOrder mockRadiologyOrder = mockRadiologyReport.getRadiologyOrder();
-		
-		when(radiologyReportService.createAndClaimRadiologyReport(mockRadiologyOrder)).thenReturn(mockRadiologyReport);
-		when(dicomWebViewer.getDicomViewerUrl(mockRadiologyOrder.getStudy())).thenReturn(
-			"http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1");
-		
-		ModelAndView modelAndView = radiologyReportFormController.getRadiologyReportFormWithNewRadiologyReport(mockRadiologyOrder);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyReport.form?radiologyReportId="
-				+ mockRadiologyReport.getId()));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		Order order = (Order) modelAndView.getModelMap()
-				.get("order");
-		assertNotNull(order);
-		assertThat(order, is((Order) mockRadiologyOrder));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertThat(radiologyOrder, is(mockRadiologyOrder));
-		
-		RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
-				.get("radiologyReport");
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport, is(mockRadiologyReport));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("dicomViewerUrl"));
-		String dicomViewerUrl = (String) modelAndView.getModelMap()
-				.get("dicomViewerUrl");
-		assertThat(dicomViewerUrl,
-			is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1"));
-	}
-	
-	/**
-	 * @verifies populate model and view with existing radiology report matching given radiology
-	 *           report id
-	 * @see RadiologyReportFormController#getRadiologyReportFormWithExistingRadiologyReport(Integer)
-	 */
-	@Test
-	public void getRadiologyReportFormWithExistingRadiologyReport_shouldPopulateModelAndViewWithExistingRadiologyReportMatchingGivenRadiologyReportId() {
-		
-		// given
-		RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
-		
-		when(radiologyReportService.getRadiologyReportByRadiologyReportId(mockRadiologyReport.getId())).thenReturn(
-			mockRadiologyReport);
-		when(dicomWebViewer.getDicomViewerUrl(mockRadiologyReport.getRadiologyOrder()
-				.getStudy())).thenReturn(
-			"http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1");
-		
-		ModelAndView modelAndView = radiologyReportFormController.getRadiologyReportFormWithExistingRadiologyReport(mockRadiologyReport.getId());
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		Order order = (Order) modelAndView.getModelMap()
-				.get("order");
-		assertNotNull(order);
-		assertThat(order, is((Order) mockRadiologyReport.getRadiologyOrder()));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertThat(radiologyOrder, is(mockRadiologyReport.getRadiologyOrder()));
-		
-		RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
-				.get("radiologyReport");
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport, is(mockRadiologyReport));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("dicomViewerUrl"));
-		String dicomViewerUrl = (String) modelAndView.getModelMap()
-				.get("dicomViewerUrl");
-		assertThat(dicomViewerUrl,
-			is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1"));
-	}
-	
-	/**
-	 * @verifies save given radiology report and populate model and view with it
-	 * @see RadiologyReportFormController#saveRadiologyReport(RadiologyReport)
-	 */
-	@Test
-	public void saveRadiologyReport_shouldSaveGivenRadiologyReportAndPopulateModelAndViewWithIt() {
-		
-		// given
-		RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
-		
-		ModelAndView modelAndView = radiologyReportFormController.saveRadiologyReport(mockRadiologyReport);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		Order order = (Order) modelAndView.getModelMap()
-				.get("order");
-		assertNotNull(order);
-		assertThat(order, is((Order) mockRadiologyReport.getRadiologyOrder()));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertThat(radiologyOrder, is(mockRadiologyReport.getRadiologyOrder()));
-		
-		RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
-				.get("radiologyReport");
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport, is(mockRadiologyReport));
-	}
-	
-	/**
-	 * @verifies redirect to radiology order form if unclaim was successful
-	 * @see RadiologyReportFormController#unclaimRadiologyReport(RadiologyReport)
-	 */
-	@Test
-	public void unclaimRadiologyReport_shouldRedirectToRadiologyOrderFormIfUnclaimWasSuccessful() {
-		
-		// given
-		RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
-		
-		ModelAndView modelAndView = radiologyReportFormController.unclaimRadiologyReport(mockRadiologyReport);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
-				+ mockRadiologyReport.getRadiologyOrder()
-						.getOrderId()));
-	}
-	
-	/**
-	 * @verifies complete given radiology report and populate model and view with it
-	 * @see RadiologyReportFormController#completeRadiologyReport(RadiologyReport,
-	 *      org.springframework.validation.BindingResult)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldCompleteGivenRadiologyReportAndPopulateModelAndViewWithIt() {
-		
-		// given
-		RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
-		mockRadiologyReport.setPrincipalResultsInterpreter(RadiologyTestData.getMockProvider1());
-		RadiologyReport mockCompletedRadiologyReport = mockRadiologyReport;
-		mockCompletedRadiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
-		BindingResult reportErrors = mock(BindingResult.class);
-		
-		when(
-			radiologyReportService.completeRadiologyReport(mockRadiologyReport,
-				mockRadiologyReport.getPrincipalResultsInterpreter())).thenReturn(mockCompletedRadiologyReport);
-		
-		ModelAndView modelAndView = radiologyReportFormController.completeRadiologyReport(mockRadiologyReport, reportErrors);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		Order order = (Order) modelAndView.getModelMap()
-				.get("order");
-		assertNotNull(order);
-		assertThat(order, is((Order) mockRadiologyReport.getRadiologyOrder()));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertNotNull(radiologyOrder);
-		assertThat(radiologyOrder, is(mockRadiologyReport.getRadiologyOrder()));
-		
-		RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
-				.get("radiologyReport");
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport, is(mockRadiologyReport));
-	}
-	
-	/**
-	 * @verifies populate model and view radiology report form with BindingResult errors if provider
-	 *           is null
-	 * @see RadiologyReportFormController#completeRadiologyReport(RadiologyReport,
-	 *      org.springframework.validation.BindingResult)
-	 */
-	@Test
-	public void completeRadiologyReport_shouldPopulateModelAndViewRadiologyReportFormWithBindingResultErrorsIfProviderIsNull() {
-		
-		// given
-		RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
-		mockRadiologyReport.setPrincipalResultsInterpreter(null);
-		
-		BindingResult reportErrors = mock(BindingResult.class);
-		
-		when(reportErrors.hasErrors()).thenReturn(true);
-		
-		ModelAndView modelAndView = radiologyReportFormController.completeRadiologyReport(mockRadiologyReport, reportErrors);
-		
-		assertNotNull(modelAndView);
-		assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
-		
-		assertThat(modelAndView.getModelMap(), hasKey("order"));
-		Order order = (Order) modelAndView.getModelMap()
-				.get("order");
-		assertNotNull(order);
-		
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
-		RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
-				.get("radiologyOrder");
-		assertNotNull(radiologyOrder);
-		
-		assertThat(mockRadiologyReport.getRadiologyOrder(), is(radiologyOrder));
-		assertThat(modelAndView.getModelMap(), hasKey("radiologyReport"));
-		RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
-				.get("radiologyReport");
-		assertNotNull(radiologyReport);
-		assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.CLAIMED));
-	}
+    
+    @Mock
+    private RadiologyReportService radiologyReportService;
+    
+    @Mock
+    private DicomWebViewer dicomWebViewer;
+    
+    @InjectMocks
+    private RadiologyReportFormController radiologyReportFormController = new RadiologyReportFormController();
+    
+    /**
+     * @verifies populate model and view with new radiology report for given radiology order
+     * @see RadiologyReportFormController#getRadiologyReportFormWithNewRadiologyReport(RadiologyOrder)
+     */
+    @Test
+    public void getRadiologyReportFormWithNewRadiologyReport_shouldPopulateModelAndViewWithNewRadiologyReportForGivenRadiologyOrder() {
+        
+        // given
+        RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
+        RadiologyOrder mockRadiologyOrder = mockRadiologyReport.getRadiologyOrder();
+        
+        when(radiologyReportService.createAndClaimRadiologyReport(mockRadiologyOrder)).thenReturn(mockRadiologyReport);
+        when(dicomWebViewer.getDicomViewerUrl(mockRadiologyOrder.getStudy())).thenReturn(
+            "http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1");
+        
+        ModelAndView modelAndView = radiologyReportFormController.getRadiologyReportFormWithNewRadiologyReport(mockRadiologyOrder);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyReport.form?radiologyReportId="
+                + mockRadiologyReport.getId()));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        Order order = (Order) modelAndView.getModelMap()
+                .get("order");
+        assertNotNull(order);
+        assertThat(order, is((Order) mockRadiologyOrder));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertThat(radiologyOrder, is(mockRadiologyOrder));
+        
+        RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
+                .get("radiologyReport");
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport, is(mockRadiologyReport));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("dicomViewerUrl"));
+        String dicomViewerUrl = (String) modelAndView.getModelMap()
+                .get("dicomViewerUrl");
+        assertThat(dicomViewerUrl,
+            is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1"));
+    }
+    
+    /**
+     * @verifies populate model and view with existing radiology report matching given radiology
+     *           report id
+     * @see RadiologyReportFormController#getRadiologyReportFormWithExistingRadiologyReport(Integer)
+     */
+    @Test
+    public void getRadiologyReportFormWithExistingRadiologyReport_shouldPopulateModelAndViewWithExistingRadiologyReportMatchingGivenRadiologyReportId() {
+        
+        // given
+        RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
+        
+        when(radiologyReportService.getRadiologyReportByRadiologyReportId(mockRadiologyReport.getId())).thenReturn(
+            mockRadiologyReport);
+        when(dicomWebViewer.getDicomViewerUrl(mockRadiologyReport.getRadiologyOrder()
+                .getStudy())).thenReturn(
+            "http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1");
+        
+        ModelAndView modelAndView = radiologyReportFormController.getRadiologyReportFormWithExistingRadiologyReport(mockRadiologyReport.getId());
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        Order order = (Order) modelAndView.getModelMap()
+                .get("order");
+        assertNotNull(order);
+        assertThat(order, is((Order) mockRadiologyReport.getRadiologyOrder()));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertThat(radiologyOrder, is(mockRadiologyReport.getRadiologyOrder()));
+        
+        RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
+                .get("radiologyReport");
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport, is(mockRadiologyReport));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("dicomViewerUrl"));
+        String dicomViewerUrl = (String) modelAndView.getModelMap()
+                .get("dicomViewerUrl");
+        assertThat(dicomViewerUrl,
+            is("http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1"));
+    }
+    
+    /**
+     * @verifies save given radiology report and populate model and view with it
+     * @see RadiologyReportFormController#saveRadiologyReport(RadiologyReport)
+     */
+    @Test
+    public void saveRadiologyReport_shouldSaveGivenRadiologyReportAndPopulateModelAndViewWithIt() {
+        
+        // given
+        RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
+        
+        ModelAndView modelAndView = radiologyReportFormController.saveRadiologyReport(mockRadiologyReport);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        Order order = (Order) modelAndView.getModelMap()
+                .get("order");
+        assertNotNull(order);
+        assertThat(order, is((Order) mockRadiologyReport.getRadiologyOrder()));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertThat(radiologyOrder, is(mockRadiologyReport.getRadiologyOrder()));
+        
+        RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
+                .get("radiologyReport");
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport, is(mockRadiologyReport));
+    }
+    
+    /**
+     * @verifies redirect to radiology order form if unclaim was successful
+     * @see RadiologyReportFormController#unclaimRadiologyReport(RadiologyReport)
+     */
+    @Test
+    public void unclaimRadiologyReport_shouldRedirectToRadiologyOrderFormIfUnclaimWasSuccessful() {
+        
+        // given
+        RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
+        
+        ModelAndView modelAndView = radiologyReportFormController.unclaimRadiologyReport(mockRadiologyReport);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("redirect:/module/radiology/radiologyOrder.form?orderId="
+                + mockRadiologyReport.getRadiologyOrder()
+                        .getOrderId()));
+    }
+    
+    /**
+     * @verifies complete given radiology report and populate model and view with it
+     * @see RadiologyReportFormController#completeRadiologyReport(RadiologyReport,
+     *      org.springframework.validation.BindingResult)
+     */
+    @Test
+    public void completeRadiologyReport_shouldCompleteGivenRadiologyReportAndPopulateModelAndViewWithIt() {
+        
+        // given
+        RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
+        mockRadiologyReport.setPrincipalResultsInterpreter(RadiologyTestData.getMockProvider1());
+        RadiologyReport mockCompletedRadiologyReport = mockRadiologyReport;
+        mockCompletedRadiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
+        BindingResult reportErrors = mock(BindingResult.class);
+        
+        when(
+            radiologyReportService.completeRadiologyReport(mockRadiologyReport,
+                mockRadiologyReport.getPrincipalResultsInterpreter())).thenReturn(mockCompletedRadiologyReport);
+        
+        ModelAndView modelAndView = radiologyReportFormController.completeRadiologyReport(mockRadiologyReport, reportErrors);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        Order order = (Order) modelAndView.getModelMap()
+                .get("order");
+        assertNotNull(order);
+        assertThat(order, is((Order) mockRadiologyReport.getRadiologyOrder()));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertNotNull(radiologyOrder);
+        assertThat(radiologyOrder, is(mockRadiologyReport.getRadiologyOrder()));
+        
+        RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
+                .get("radiologyReport");
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport, is(mockRadiologyReport));
+    }
+    
+    /**
+     * @verifies populate model and view radiology report form with BindingResult errors if provider
+     *           is null
+     * @see RadiologyReportFormController#completeRadiologyReport(RadiologyReport,
+     *      org.springframework.validation.BindingResult)
+     */
+    @Test
+    public void completeRadiologyReport_shouldPopulateModelAndViewRadiologyReportFormWithBindingResultErrorsIfProviderIsNull() {
+        
+        // given
+        RadiologyReport mockRadiologyReport = RadiologyTestData.getMockRadiologyReport1();
+        mockRadiologyReport.setPrincipalResultsInterpreter(null);
+        
+        BindingResult reportErrors = mock(BindingResult.class);
+        
+        when(reportErrors.hasErrors()).thenReturn(true);
+        
+        ModelAndView modelAndView = radiologyReportFormController.completeRadiologyReport(mockRadiologyReport, reportErrors);
+        
+        assertNotNull(modelAndView);
+        assertThat(modelAndView.getViewName(), is("/module/radiology/radiologyReportForm"));
+        
+        assertThat(modelAndView.getModelMap(), hasKey("order"));
+        Order order = (Order) modelAndView.getModelMap()
+                .get("order");
+        assertNotNull(order);
+        
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
+        RadiologyOrder radiologyOrder = (RadiologyOrder) modelAndView.getModelMap()
+                .get("radiologyOrder");
+        assertNotNull(radiologyOrder);
+        
+        assertThat(mockRadiologyReport.getRadiologyOrder(), is(radiologyOrder));
+        assertThat(modelAndView.getModelMap(), hasKey("radiologyReport"));
+        RadiologyReport radiologyReport = (RadiologyReport) modelAndView.getModelMap()
+                .get("radiologyReport");
+        assertNotNull(radiologyReport);
+        assertThat(radiologyReport.getReportStatus(), is(RadiologyReportStatus.CLAIMED));
+    }
 }

--- a/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
@@ -43,416 +43,416 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
 
 public class RadiologyTestData {
-	
-	static OrderType radiologyOrderType = new OrderType("Radiology Order", "Order type for radiology exams",
-			"org.openmrs.module.radiology.order.RadiologyOrder");
-	
-	/**
-	 * Convenience method constructing a study order for the tests
-	 */
-	public static RadiologyStudy getMockStudy1PreSave() {
-		
-		RadiologyStudy mockStudy = new RadiologyStudy();
-		mockStudy.setModality(Modality.CT);
-		
-		return mockStudy;
-	}
-	
-	/**
-	 * Convenience method constructing a study order for the tests
-	 */
-	public static RadiologyStudy getMockStudy1PostSave() {
-		
-		RadiologyStudy mockStudy = getMockStudy1PreSave();
-		
-		int studyId = 1;
-		mockStudy.setStudyId(studyId);
-		mockStudy.setStudyInstanceUid(getStudyPrefix() + studyId);
-		
-		return mockStudy;
-	}
-	
-	/**
-	 * Convenience method constructing a study order for the tests
-	 */
-	public static RadiologyStudy getMockStudy2PreSave() {
-		
-		RadiologyStudy mockStudy = new RadiologyStudy();
-		mockStudy.setModality(Modality.CT);
-		
-		return mockStudy;
-	}
-	
-	/**
-	 * Convenience method constructing a study order for the tests
-	 */
-	public static RadiologyStudy getMockStudy2PostSave() {
-		
-		RadiologyStudy mockStudy = getMockStudy2PreSave();
-		
-		int studyId = 2;
-		mockStudy.setStudyId(studyId);
-		mockStudy.setStudyInstanceUid(getStudyPrefix() + studyId);
-		
-		return mockStudy;
-	}
-	
-	/**
-	 * Convenience method to get the StudyPrefix needed for StudyInstanceUid construction in the
-	 * tests
-	 */
-	public static String getStudyPrefix() {
-		
-		return "1.2.826.0.1.3680043.8.2186.1.";
-	}
-	
-	/**
-	 * Convenience method constructing an encounter for the tests
-	 */
-	public static Encounter getMockEncounter1() {
-		
-		Encounter mockEncounter = new Encounter();
-		mockEncounter.setId(1);
-		mockEncounter.setEncounterType(new EncounterType(1));
-		mockEncounter.setEncounterDatetime(new GregorianCalendar(2015, 0, 01).getTime());
-		mockEncounter.setLocation(new Location(1));
-		
-		EncounterProvider encounterProvider = new EncounterProvider();
-		encounterProvider.setId(1);
-		Set<EncounterProvider> providerSet = new HashSet<EncounterProvider>();
-		providerSet.add(encounterProvider);
-		mockEncounter.setEncounterProviders(providerSet);
-		
-		return mockEncounter;
-	}
-	
-	/**
-	 * Convenience method constructing an encounter for the tests
-	 */
-	public static Encounter getMockEncounter2() {
-		
-		Encounter mockEncounter = new Encounter();
-		mockEncounter.setId(2);
-		mockEncounter.setEncounterType(new EncounterType(1));
-		mockEncounter.setEncounterDatetime(new GregorianCalendar(2015, 1, 02).getTime());
-		mockEncounter.setLocation(new Location(1));
-		
-		EncounterProvider encounterProvider = new EncounterProvider();
-		encounterProvider.setId(1);
-		Set<EncounterProvider> providerSet = new HashSet<EncounterProvider>();
-		providerSet.add(encounterProvider);
-		mockEncounter.setEncounterProviders(providerSet);
-		
-		return mockEncounter;
-	}
-	
-	/**
-	 * Convenience method constructing an order for the tests
-	 */
-	public static Order getMockOrder1() {
-		
-		Order mockOrder = new Order();
-		mockOrder.setOrderId(1);
-		mockOrder.setPatient(getMockPatient1());
-		Calendar calendar = Calendar.getInstance();
-		calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
-		mockOrder.setScheduledDate(calendar.getTime());
-		mockOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
-		mockOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
-		mockOrder.setVoided(false);
-		return mockOrder;
-	}
-	
-	/**
-	 * Convenience method constructing a mock RadiologyOrder for the tests
-	 */
-	public static RadiologyOrder getMockRadiologyOrder1() {
-		
-		RadiologyOrder mockRadiologyOrder = new RadiologyOrder();
-		mockRadiologyOrder.setOrderId(1);
-		mockRadiologyOrder.setOrderType(getMockRadiologyOrderType());
-		mockRadiologyOrder.setPatient(getMockPatient1());
-		Calendar calendar = Calendar.getInstance();
-		calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
-		mockRadiologyOrder.setScheduledDate(calendar.getTime());
-		mockRadiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
-		mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
-		mockRadiologyOrder.setVoided(false);
-		RadiologyStudy radiologyStudy = getMockStudy1PostSave();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		mockRadiologyOrder.setStudy(radiologyStudy);
-		
-		return mockRadiologyOrder;
-	}
-	
-	/**
-	 * Convenience method constructing a mock RadiologyOrder for the tests
-	 */
-	public static RadiologyOrder getMockRadiologyOrder2() {
-		
-		RadiologyOrder mockRadiologyOrder = new RadiologyOrder();
-		mockRadiologyOrder.setOrderId(2);
-		mockRadiologyOrder.setOrderType(getMockRadiologyOrderType());
-		mockRadiologyOrder.setPatient(getMockPatient2());
-		Calendar calendar = Calendar.getInstance();
-		calendar.set(2015, Calendar.MARCH, 4, 14, 35, 0);
-		mockRadiologyOrder.setScheduledDate(calendar.getTime());
-		mockRadiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
-		mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITHOUT IV CONTRAST");
-		mockRadiologyOrder.setVoided(false);
-		RadiologyStudy radiologyStudy = getMockStudy2PostSave();
-		radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-		mockRadiologyOrder.setStudy(radiologyStudy);
-		
-		return mockRadiologyOrder;
-	}
-	
-	/**
-	 * Convenience method constructing a multipart http servlet request for the tests
-	 */
-	public static MockMultipartHttpServletRequest getMockMultipartHttpServletRequestForMockObsWithComplexConcept() {
-		MockMultipartHttpServletRequest mockRequest = new MockMultipartHttpServletRequest();
-		mockRequest.addFile(getMockMultipartFileForMockObsWithComplexConcept());
-		
-		return mockRequest;
-	}
-	
-	/**
-	 * Convenience method constructing a multipart file for the tests
-	 */
-	public static MockMultipartFile getMockMultipartFileForMockObsWithComplexConcept() {
-		final String fileName = "test.jpg";
-		final byte[] content = "FFD8FFE000104A46".getBytes();
-		return new MockMultipartFile("complexDataFile", fileName, "image/jpeg", content);
-	}
-	
-	/**
-	 * Convenience method constructing an empty multipart file for the tests
-	 */
-	public static MockMultipartFile getEmptyMockMultipartFileForMockObsWithComplexConcept() {
-		final String fileName = "test.jpg";
-		final byte[] content = "".getBytes();
-		return new MockMultipartFile("complexDataFile", fileName, "image/jpeg", content);
-	}
-	
-	/**
-	 * Convenience method constructing a mock radiology order type for the tests
-	 */
-	public static OrderType getMockRadiologyOrderType() {
-		
-		return radiologyOrderType;
-	}
-	
-	/**
-	 * Convenience method constructing a mock patient for the tests
-	 */
-	public static Patient getMockPatient1() {
-		
-		Patient mockPatient = new Patient();
-		mockPatient.setPatientId(1);
-		mockPatient.addIdentifiers(getPatientIdentifiers("100"));
-		mockPatient.setGender("M");
-		
-		Set<PersonName> personNames = new HashSet<PersonName>();
-		PersonName personName = new PersonName();
-		personName.setFamilyName("Doe");
-		personName.setGivenName("John");
-		personName.setMiddleName("Francis");
-		personNames.add(personName);
-		mockPatient.setNames(personNames);
-		
-		Calendar cal = Calendar.getInstance();
-		cal.set(1950, Calendar.APRIL, 1, 0, 0, 0);
-		mockPatient.setBirthdate(cal.getTime());
-		
-		return mockPatient;
-	}
-	
-	/**
-	 * Convenience method constructing a mock patient for the tests
-	 */
-	public static Patient getMockPatient2() {
-		
-		Patient mockPatient = new Patient();
-		mockPatient.setPatientId(2);
-		mockPatient.addIdentifiers(getPatientIdentifiers("101"));
-		mockPatient.setGender("F");
-		
-		Set<PersonName> personNames = new HashSet<PersonName>();
-		PersonName personName = new PersonName();
-		personName.setFamilyName("Doe");
-		personName.setGivenName("Jane");
-		personName.setMiddleName("Francine");
-		personNames.add(personName);
-		mockPatient.setNames(personNames);
-		
-		Calendar cal = Calendar.getInstance();
-		cal.set(1955, Calendar.FEBRUARY, 1, 0, 0, 0);
-		mockPatient.setBirthdate(cal.getTime());
-		
-		return mockPatient;
-	}
-	
-	/**
-	 * Convenience method constructing a mock patient for the tests
-	 */
-	public static Patient getMockPatient3() {
-		
-		Patient mockPatient = new Patient();
-		mockPatient.setPatientId(3);
-		mockPatient.addIdentifiers(getPatientIdentifiers("102"));
-		mockPatient.setGender("F");
-		
-		Set<PersonName> personNames = new HashSet<PersonName>();
-		PersonName personName = new PersonName();
-		personName.setFamilyName("Diaz");
-		personName.setGivenName("Maria");
-		personName.setMiddleName("Sophia");
-		personNames.add(personName);
-		mockPatient.setNames(personNames);
-		
-		Calendar cal = Calendar.getInstance();
-		cal.set(1980, Calendar.FEBRUARY, 1, 0, 0, 0);
-		mockPatient.setBirthdate(cal.getTime());
-		
-		return mockPatient;
-	}
-	
-	/**
-	 * Convenience method constructing PatientIdentifiers
-	 */
-	public static Set<PatientIdentifier> getPatientIdentifiers(String id) {
-		PatientIdentifier patientIdentifier = new PatientIdentifier();
-		patientIdentifier.setIdentifierType(getPatientIdentifierType());
-		patientIdentifier.setIdentifier(id);
-		patientIdentifier.setPreferred(true);
-		Set<PatientIdentifier> patientIdentifiers = new HashSet<PatientIdentifier>();
-		patientIdentifiers.add(patientIdentifier);
-		return patientIdentifiers;
-	}
-	
-	/**
-	 * Convenience method constructing a PatientIdentifierType
-	 */
-	public static PatientIdentifierType getPatientIdentifierType() {
-		PatientIdentifierType patientIdentifierType = new PatientIdentifierType();
-		patientIdentifierType.setPatientIdentifierTypeId(1);
-		patientIdentifierType.setName("Test Identifier Type");
-		patientIdentifierType.setDescription("Test description");
-		
-		return patientIdentifierType;
-	}
-	
-	/**
-	 * Convenience method constructing a mock user with role RADIOLOGY_REFERRING_PHYSICIAN for the
-	 * tests
-	 */
-	public static User getMockRadiologyReferringPhysician() {
-		
-		Role role = new Role(REFERRING_PHYSICIAN);
-		Set<Role> roles = new HashSet<Role>();
-		roles.add(role);
-		
-		User radiologyReferringPhysician = new User();
-		radiologyReferringPhysician.setRoles(roles);
-		radiologyReferringPhysician.setPerson(getMockUserPerson());
-		
-		return radiologyReferringPhysician;
-	}
-	
-	/**
-	 * Convenience method constructing a mock user with role RADIOLOGY_PERFORMING_PHYSICIAN for the
-	 * tests
-	 */
-	public static User getMockRadiologyPerformingPhysician() {
-		
-		Role role = new Role(PERFORMING_PHYSICIAN);
-		Set<Role> roles = new HashSet<Role>();
-		roles.add(role);
-		
-		User radiologyPerformingPhysician = new User();
-		radiologyPerformingPhysician.setRoles(roles);
-		radiologyPerformingPhysician.setPerson(getMockUserPerson());
-		
-		return radiologyPerformingPhysician;
-	}
-	
-	/**
-	 * Convenience method constructing a mock user with role RADIOLOGY_READING_PHYSICIAN for the
-	 * tests
-	 */
-	public static User getMockRadiologyReadingPhysician() {
-		Role role = new Role(READING_PHYSICIAN);
-		Set<Role> roles = new HashSet<Role>();
-		roles.add(role);
-		
-		User radiologyReadingPhysician = new User();
-		radiologyReadingPhysician.setRoles(roles);
-		radiologyReadingPhysician.setPerson(getMockUserPerson());
-		
-		return radiologyReadingPhysician;
-	}
-	
-	/**
-	 * Convenience method constructing a mock user with role RADIOLOGY_SCHEDULER for the tests
-	 */
-	public static User getMockRadiologyScheduler() {
-		
-		Role role = new Role(SCHEDULER);
-		Set<Role> roles = new HashSet<Role>();
-		roles.add(role);
-		
-		User radiologyScheduler = new User();
-		radiologyScheduler.setRoles(roles);
-		radiologyScheduler.setPerson(getMockUserPerson());
-		
-		return radiologyScheduler;
-	}
-	
-	/**
-	 * Convenience method constructing a mock user with role RADIOLOGY_SCHEDULER for the tests
-	 */
-	public static User getMockRadiologySuperUser() {
-		
-		Role role = new Role(RoleConstants.SUPERUSER);
-		Set<Role> roles = new HashSet<Role>();
-		roles.add(role);
-		
-		User radiologySuperUser = new User();
-		radiologySuperUser.setRoles(roles);
-		radiologySuperUser.setPerson(getMockUserPerson());
-		
-		return radiologySuperUser;
-	}
-	
-	/**
-	 * Convenience method constructing a mock person for the tests
-	 */
-	public static Person getMockUserPerson() {
-		
-		PersonName name = new PersonName();
-		name.setFamilyName("Karlsson");
-		name.setGivenName("Karl");
-		Set<PersonName> names = new HashSet<PersonName>();
-		names.add(name);
-		
-		Person person = new Person();
-		person.setNames(names);
-		
-		return person;
-	}
-	
-	public static Provider getMockProvider1() {
-		Provider provider = new Provider();
-		provider.setId(1);
-		provider.setName("doctor");
-		return provider;
-	}
-	
-	public static RadiologyReport getMockRadiologyReport1() {
-		
-		RadiologyReport radiologyReport = new RadiologyReport(getMockRadiologyOrder1());
-		radiologyReport.setId(1);
-		return radiologyReport;
-	}
+    
+    static OrderType radiologyOrderType = new OrderType("Radiology Order", "Order type for radiology exams",
+            "org.openmrs.module.radiology.order.RadiologyOrder");
+    
+    /**
+     * Convenience method constructing a study order for the tests
+     */
+    public static RadiologyStudy getMockStudy1PreSave() {
+        
+        RadiologyStudy mockStudy = new RadiologyStudy();
+        mockStudy.setModality(Modality.CT);
+        
+        return mockStudy;
+    }
+    
+    /**
+     * Convenience method constructing a study order for the tests
+     */
+    public static RadiologyStudy getMockStudy1PostSave() {
+        
+        RadiologyStudy mockStudy = getMockStudy1PreSave();
+        
+        int studyId = 1;
+        mockStudy.setStudyId(studyId);
+        mockStudy.setStudyInstanceUid(getStudyPrefix() + studyId);
+        
+        return mockStudy;
+    }
+    
+    /**
+     * Convenience method constructing a study order for the tests
+     */
+    public static RadiologyStudy getMockStudy2PreSave() {
+        
+        RadiologyStudy mockStudy = new RadiologyStudy();
+        mockStudy.setModality(Modality.CT);
+        
+        return mockStudy;
+    }
+    
+    /**
+     * Convenience method constructing a study order for the tests
+     */
+    public static RadiologyStudy getMockStudy2PostSave() {
+        
+        RadiologyStudy mockStudy = getMockStudy2PreSave();
+        
+        int studyId = 2;
+        mockStudy.setStudyId(studyId);
+        mockStudy.setStudyInstanceUid(getStudyPrefix() + studyId);
+        
+        return mockStudy;
+    }
+    
+    /**
+     * Convenience method to get the StudyPrefix needed for StudyInstanceUid construction in the
+     * tests
+     */
+    public static String getStudyPrefix() {
+        
+        return "1.2.826.0.1.3680043.8.2186.1.";
+    }
+    
+    /**
+     * Convenience method constructing an encounter for the tests
+     */
+    public static Encounter getMockEncounter1() {
+        
+        Encounter mockEncounter = new Encounter();
+        mockEncounter.setId(1);
+        mockEncounter.setEncounterType(new EncounterType(1));
+        mockEncounter.setEncounterDatetime(new GregorianCalendar(2015, 0, 01).getTime());
+        mockEncounter.setLocation(new Location(1));
+        
+        EncounterProvider encounterProvider = new EncounterProvider();
+        encounterProvider.setId(1);
+        Set<EncounterProvider> providerSet = new HashSet<EncounterProvider>();
+        providerSet.add(encounterProvider);
+        mockEncounter.setEncounterProviders(providerSet);
+        
+        return mockEncounter;
+    }
+    
+    /**
+     * Convenience method constructing an encounter for the tests
+     */
+    public static Encounter getMockEncounter2() {
+        
+        Encounter mockEncounter = new Encounter();
+        mockEncounter.setId(2);
+        mockEncounter.setEncounterType(new EncounterType(1));
+        mockEncounter.setEncounterDatetime(new GregorianCalendar(2015, 1, 02).getTime());
+        mockEncounter.setLocation(new Location(1));
+        
+        EncounterProvider encounterProvider = new EncounterProvider();
+        encounterProvider.setId(1);
+        Set<EncounterProvider> providerSet = new HashSet<EncounterProvider>();
+        providerSet.add(encounterProvider);
+        mockEncounter.setEncounterProviders(providerSet);
+        
+        return mockEncounter;
+    }
+    
+    /**
+     * Convenience method constructing an order for the tests
+     */
+    public static Order getMockOrder1() {
+        
+        Order mockOrder = new Order();
+        mockOrder.setOrderId(1);
+        mockOrder.setPatient(getMockPatient1());
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
+        mockOrder.setScheduledDate(calendar.getTime());
+        mockOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
+        mockOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
+        mockOrder.setVoided(false);
+        return mockOrder;
+    }
+    
+    /**
+     * Convenience method constructing a mock RadiologyOrder for the tests
+     */
+    public static RadiologyOrder getMockRadiologyOrder1() {
+        
+        RadiologyOrder mockRadiologyOrder = new RadiologyOrder();
+        mockRadiologyOrder.setOrderId(1);
+        mockRadiologyOrder.setOrderType(getMockRadiologyOrderType());
+        mockRadiologyOrder.setPatient(getMockPatient1());
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2015, Calendar.FEBRUARY, 4, 14, 35, 0);
+        mockRadiologyOrder.setScheduledDate(calendar.getTime());
+        mockRadiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
+        mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITH IV CONTRAST");
+        mockRadiologyOrder.setVoided(false);
+        RadiologyStudy radiologyStudy = getMockStudy1PostSave();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        mockRadiologyOrder.setStudy(radiologyStudy);
+        
+        return mockRadiologyOrder;
+    }
+    
+    /**
+     * Convenience method constructing a mock RadiologyOrder for the tests
+     */
+    public static RadiologyOrder getMockRadiologyOrder2() {
+        
+        RadiologyOrder mockRadiologyOrder = new RadiologyOrder();
+        mockRadiologyOrder.setOrderId(2);
+        mockRadiologyOrder.setOrderType(getMockRadiologyOrderType());
+        mockRadiologyOrder.setPatient(getMockPatient2());
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2015, Calendar.MARCH, 4, 14, 35, 0);
+        mockRadiologyOrder.setScheduledDate(calendar.getTime());
+        mockRadiologyOrder.setUrgency(Order.Urgency.ON_SCHEDULED_DATE);
+        mockRadiologyOrder.setInstructions("CT ABDOMEN PANCREAS WITHOUT IV CONTRAST");
+        mockRadiologyOrder.setVoided(false);
+        RadiologyStudy radiologyStudy = getMockStudy2PostSave();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        mockRadiologyOrder.setStudy(radiologyStudy);
+        
+        return mockRadiologyOrder;
+    }
+    
+    /**
+     * Convenience method constructing a multipart http servlet request for the tests
+     */
+    public static MockMultipartHttpServletRequest getMockMultipartHttpServletRequestForMockObsWithComplexConcept() {
+        MockMultipartHttpServletRequest mockRequest = new MockMultipartHttpServletRequest();
+        mockRequest.addFile(getMockMultipartFileForMockObsWithComplexConcept());
+        
+        return mockRequest;
+    }
+    
+    /**
+     * Convenience method constructing a multipart file for the tests
+     */
+    public static MockMultipartFile getMockMultipartFileForMockObsWithComplexConcept() {
+        final String fileName = "test.jpg";
+        final byte[] content = "FFD8FFE000104A46".getBytes();
+        return new MockMultipartFile("complexDataFile", fileName, "image/jpeg", content);
+    }
+    
+    /**
+     * Convenience method constructing an empty multipart file for the tests
+     */
+    public static MockMultipartFile getEmptyMockMultipartFileForMockObsWithComplexConcept() {
+        final String fileName = "test.jpg";
+        final byte[] content = "".getBytes();
+        return new MockMultipartFile("complexDataFile", fileName, "image/jpeg", content);
+    }
+    
+    /**
+     * Convenience method constructing a mock radiology order type for the tests
+     */
+    public static OrderType getMockRadiologyOrderType() {
+        
+        return radiologyOrderType;
+    }
+    
+    /**
+     * Convenience method constructing a mock patient for the tests
+     */
+    public static Patient getMockPatient1() {
+        
+        Patient mockPatient = new Patient();
+        mockPatient.setPatientId(1);
+        mockPatient.addIdentifiers(getPatientIdentifiers("100"));
+        mockPatient.setGender("M");
+        
+        Set<PersonName> personNames = new HashSet<PersonName>();
+        PersonName personName = new PersonName();
+        personName.setFamilyName("Doe");
+        personName.setGivenName("John");
+        personName.setMiddleName("Francis");
+        personNames.add(personName);
+        mockPatient.setNames(personNames);
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(1950, Calendar.APRIL, 1, 0, 0, 0);
+        mockPatient.setBirthdate(cal.getTime());
+        
+        return mockPatient;
+    }
+    
+    /**
+     * Convenience method constructing a mock patient for the tests
+     */
+    public static Patient getMockPatient2() {
+        
+        Patient mockPatient = new Patient();
+        mockPatient.setPatientId(2);
+        mockPatient.addIdentifiers(getPatientIdentifiers("101"));
+        mockPatient.setGender("F");
+        
+        Set<PersonName> personNames = new HashSet<PersonName>();
+        PersonName personName = new PersonName();
+        personName.setFamilyName("Doe");
+        personName.setGivenName("Jane");
+        personName.setMiddleName("Francine");
+        personNames.add(personName);
+        mockPatient.setNames(personNames);
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(1955, Calendar.FEBRUARY, 1, 0, 0, 0);
+        mockPatient.setBirthdate(cal.getTime());
+        
+        return mockPatient;
+    }
+    
+    /**
+     * Convenience method constructing a mock patient for the tests
+     */
+    public static Patient getMockPatient3() {
+        
+        Patient mockPatient = new Patient();
+        mockPatient.setPatientId(3);
+        mockPatient.addIdentifiers(getPatientIdentifiers("102"));
+        mockPatient.setGender("F");
+        
+        Set<PersonName> personNames = new HashSet<PersonName>();
+        PersonName personName = new PersonName();
+        personName.setFamilyName("Diaz");
+        personName.setGivenName("Maria");
+        personName.setMiddleName("Sophia");
+        personNames.add(personName);
+        mockPatient.setNames(personNames);
+        
+        Calendar cal = Calendar.getInstance();
+        cal.set(1980, Calendar.FEBRUARY, 1, 0, 0, 0);
+        mockPatient.setBirthdate(cal.getTime());
+        
+        return mockPatient;
+    }
+    
+    /**
+     * Convenience method constructing PatientIdentifiers
+     */
+    public static Set<PatientIdentifier> getPatientIdentifiers(String id) {
+        PatientIdentifier patientIdentifier = new PatientIdentifier();
+        patientIdentifier.setIdentifierType(getPatientIdentifierType());
+        patientIdentifier.setIdentifier(id);
+        patientIdentifier.setPreferred(true);
+        Set<PatientIdentifier> patientIdentifiers = new HashSet<PatientIdentifier>();
+        patientIdentifiers.add(patientIdentifier);
+        return patientIdentifiers;
+    }
+    
+    /**
+     * Convenience method constructing a PatientIdentifierType
+     */
+    public static PatientIdentifierType getPatientIdentifierType() {
+        PatientIdentifierType patientIdentifierType = new PatientIdentifierType();
+        patientIdentifierType.setPatientIdentifierTypeId(1);
+        patientIdentifierType.setName("Test Identifier Type");
+        patientIdentifierType.setDescription("Test description");
+        
+        return patientIdentifierType;
+    }
+    
+    /**
+     * Convenience method constructing a mock user with role RADIOLOGY_REFERRING_PHYSICIAN for the
+     * tests
+     */
+    public static User getMockRadiologyReferringPhysician() {
+        
+        Role role = new Role(REFERRING_PHYSICIAN);
+        Set<Role> roles = new HashSet<Role>();
+        roles.add(role);
+        
+        User radiologyReferringPhysician = new User();
+        radiologyReferringPhysician.setRoles(roles);
+        radiologyReferringPhysician.setPerson(getMockUserPerson());
+        
+        return radiologyReferringPhysician;
+    }
+    
+    /**
+     * Convenience method constructing a mock user with role RADIOLOGY_PERFORMING_PHYSICIAN for the
+     * tests
+     */
+    public static User getMockRadiologyPerformingPhysician() {
+        
+        Role role = new Role(PERFORMING_PHYSICIAN);
+        Set<Role> roles = new HashSet<Role>();
+        roles.add(role);
+        
+        User radiologyPerformingPhysician = new User();
+        radiologyPerformingPhysician.setRoles(roles);
+        radiologyPerformingPhysician.setPerson(getMockUserPerson());
+        
+        return radiologyPerformingPhysician;
+    }
+    
+    /**
+     * Convenience method constructing a mock user with role RADIOLOGY_READING_PHYSICIAN for the
+     * tests
+     */
+    public static User getMockRadiologyReadingPhysician() {
+        Role role = new Role(READING_PHYSICIAN);
+        Set<Role> roles = new HashSet<Role>();
+        roles.add(role);
+        
+        User radiologyReadingPhysician = new User();
+        radiologyReadingPhysician.setRoles(roles);
+        radiologyReadingPhysician.setPerson(getMockUserPerson());
+        
+        return radiologyReadingPhysician;
+    }
+    
+    /**
+     * Convenience method constructing a mock user with role RADIOLOGY_SCHEDULER for the tests
+     */
+    public static User getMockRadiologyScheduler() {
+        
+        Role role = new Role(SCHEDULER);
+        Set<Role> roles = new HashSet<Role>();
+        roles.add(role);
+        
+        User radiologyScheduler = new User();
+        radiologyScheduler.setRoles(roles);
+        radiologyScheduler.setPerson(getMockUserPerson());
+        
+        return radiologyScheduler;
+    }
+    
+    /**
+     * Convenience method constructing a mock user with role RADIOLOGY_SCHEDULER for the tests
+     */
+    public static User getMockRadiologySuperUser() {
+        
+        Role role = new Role(RoleConstants.SUPERUSER);
+        Set<Role> roles = new HashSet<Role>();
+        roles.add(role);
+        
+        User radiologySuperUser = new User();
+        radiologySuperUser.setRoles(roles);
+        radiologySuperUser.setPerson(getMockUserPerson());
+        
+        return radiologySuperUser;
+    }
+    
+    /**
+     * Convenience method constructing a mock person for the tests
+     */
+    public static Person getMockUserPerson() {
+        
+        PersonName name = new PersonName();
+        name.setFamilyName("Karlsson");
+        name.setGivenName("Karl");
+        Set<PersonName> names = new HashSet<PersonName>();
+        names.add(name);
+        
+        Person person = new Person();
+        person.setNames(names);
+        
+        return person;
+    }
+    
+    public static Provider getMockProvider1() {
+        Provider provider = new Provider();
+        provider.setId(1);
+        provider.setName("doctor");
+        return provider;
+    }
+    
+    public static RadiologyReport getMockRadiologyReport1() {
+        
+        RadiologyReport radiologyReport = new RadiologyReport(getMockRadiologyOrder1());
+        radiologyReport.setId(1);
+        return radiologyReport;
+    }
 }

--- a/tools/formatter/OpenMRSFormatter.xml
+++ b/tools/formatter/OpenMRSFormatter.xml
@@ -1,295 +1,295 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="12">
 <profile kind="CodeFormatterProfile" name="OpenMRS Formatter" version="12">
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="48"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
-<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="125"/>
-<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="20"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="20"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="20"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="81"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="125"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="0"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="20"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="19"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="125"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="48"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="81"/>
-<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
-<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="48"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="19"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="insert"/>
-<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="tab"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
-<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="125"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="49"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
 </profile>
 </profiles>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
tabs are a pain. makes code look different depending on your editor settings.
using whitespace only is a widely used convention. lets use it to.

* adapt eclipse formatter to only use spaces
* convert all tabs to spaces

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-263


