### PR TITLE
RAD-253 Remove hapi dependency

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -47,10 +47,6 @@
 			<artifactId>openmrs-test</artifactId>
 			<type>pom</type>
 		</dependency>
-		<dependency>
-			<groupId>ca.uhn.hapi</groupId>
-			<artifactId>hapi-structures-v231</artifactId>
-		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,6 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<openMRSVersion>1.11.4</openMRSVersion>
-		<hapiVersion>2.0</hapiVersion>
 		<emr-apiVersion>1.13</emr-apiVersion>
 		<formatterPluginVersion>0.5.2</formatterPluginVersion>
 		<eclipseFormatterStyle>${project.parent.basedir}/tools/formatter/java.xml</eclipseFormatterStyle>
@@ -78,18 +77,6 @@
 				<groupId>org.openmrs.tools</groupId>
 				<artifactId>openmrs-tools</artifactId>
 				<version>${openMRSVersion}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>ca.uhn.hapi</groupId>
-				<artifactId>hapi-structures-v231</artifactId>
-				<version>${hapiVersion}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>*</groupId>
-						<artifactId>*</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 		</dependencies>
 


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
since we removed the hl7 package there is no need for the hapi dependency
anymore

* delete hapi dependency

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-253

