### PR TITLE
RAD-277 OpenmrsServices slow to load with autowired

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
@@ -15,8 +15,6 @@ import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.Patient;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
 
 /**
  * Hibernate specific RadiologyOrder related functions. This class should not be used directly. All
@@ -25,11 +23,9 @@ import org.springframework.stereotype.Repository;
  * @see org.openmrs.module.radiology.order.RadiologyOrderDAO
  * @see org.openmrs.module.radiology.order.RadiologyOrderService
  */
-@Repository
 class HibernateRadiologyOrderDAO implements RadiologyOrderDAO {
     
     
-    @Autowired
     private SessionFactory sessionFactory;
     
     /**

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
@@ -27,7 +27,6 @@ import org.openmrs.module.emrapi.encounter.EmrEncounterService;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.study.RadiologyStudyService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyOrderService {
@@ -35,23 +34,41 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     
     private static final Log log = LogFactory.getLog(RadiologyOrderServiceImpl.class);
     
-    @Autowired
     private RadiologyOrderDAO radiologyOrderDAO;
     
-    @Autowired
     private RadiologyStudyService radiologyStudyService;
     
-    @Autowired
     private OrderService orderService;
     
-    @Autowired
     private EncounterService encounterService;
     
-    @Autowired
     private EmrEncounterService emrEncounterService;
     
-    @Autowired
     private RadiologyProperties radiologyProperties;
+    
+    public void setRadiologyOrderDAO(RadiologyOrderDAO radiologyOrderDAO) {
+        this.radiologyOrderDAO = radiologyOrderDAO;
+    }
+    
+    public void setRadiologyStudyService(RadiologyStudyService radiologyStudyService) {
+        this.radiologyStudyService = radiologyStudyService;
+    }
+    
+    public void setOrderService(OrderService orderService) {
+        this.orderService = orderService;
+    }
+    
+    public void setEncounterService(EncounterService encounterService) {
+        this.encounterService = encounterService;
+    }
+    
+    public void setEmrEncounterService(EmrEncounterService emrEncounterService) {
+        this.emrEncounterService = emrEncounterService;
+    }
+    
+    public void setRadiologyProperties(RadiologyProperties radiologyProperties) {
+        this.radiologyProperties = radiologyProperties;
+    }
     
     /**
      * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)

--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -14,8 +14,6 @@ import java.util.List;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.radiology.order.RadiologyOrder;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
 
 /**
  * Hibernate specific RadiologyReport related functions. This class should not be used directly. All
@@ -24,11 +22,9 @@ import org.springframework.stereotype.Repository;
  * @see org.openmrs.module.radiology.report.RadiologyReportDAO
  * @see org.openmrs.module.radiology.report.RadiologyReportService
  */
-@Repository
 class HibernateRadiologyReportDAO implements RadiologyReportDAO {
     
     
-    @Autowired
     private SessionFactory sessionFactory;
     
     /**

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -9,7 +9,6 @@ import org.apache.commons.logging.LogFactory;
 import org.openmrs.Provider;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.radiology.order.RadiologyOrder;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 class RadiologyReportServiceImpl extends BaseOpenmrsService implements RadiologyReportService {
@@ -17,8 +16,11 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     
     private static final Log log = LogFactory.getLog(RadiologyReportServiceImpl.class);
     
-    @Autowired
     private RadiologyReportDAO radiologyReportDAO;
+    
+    public void setRadiologyReportDAO(RadiologyReportDAO radiologyReportDAO) {
+        this.radiologyReportDAO = radiologyReportDAO;
+    }
     
     /**
      * @see RadiologyReportService#createAndClaimRadiologyReport(RadiologyOrder)

--- a/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
@@ -15,8 +15,6 @@ import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.radiology.order.RadiologyOrder;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Repository;
 
 /**
  * Hibernate specific RadiologyStudy related functions. This class should not be used directly. All calls
@@ -25,11 +23,9 @@ import org.springframework.stereotype.Repository;
  * @see org.openmrs.module.radiology.study.RadiologyStudyDAO
  * @see org.openmrs.module.radiology.study.RadiologyStudyService
  */
-@Repository
 class HibernateRadiologyStudyDAO implements RadiologyStudyDAO {
     
     
-    @Autowired
     private SessionFactory sessionFactory;
     
     /**

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
@@ -17,7 +17,6 @@ import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
 import org.openmrs.module.radiology.dicom.code.ScheduledProcedureStepStatus;
 import org.openmrs.module.radiology.order.RadiologyOrder;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyStudyService {
@@ -25,11 +24,17 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     
     private static final Log log = LogFactory.getLog(RadiologyStudyServiceImpl.class);
     
-    @Autowired
     private RadiologyStudyDAO radiologyStudyDAO;
     
-    @Autowired
     private RadiologyProperties radiologyProperties;
+    
+    public void setRadiologyStudyDAO(RadiologyStudyDAO radiologyStudyDAO) {
+        this.radiologyStudyDAO = radiologyStudyDAO;
+    }
+    
+    public void setRadiologyProperties(RadiologyProperties radiologyProperties) {
+        this.radiologyProperties = radiologyProperties;
+    }
     
     /**
      * @see RadiologyStudyService#saveStudy(RadiologyStudy)

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -22,6 +22,19 @@
 		</property>
 		<property name="target">
 			<bean class="org.openmrs.module.radiology.order.RadiologyOrderServiceImpl">
+				<property name="radiologyOrderDAO">
+					<bean
+						class="org.openmrs.module.radiology.order.HibernateRadiologyOrderDAO">
+						<property name="sessionFactory">
+							<ref bean="sessionFactory" />
+						</property>
+					</bean>
+				</property>
+				<property name="radiologyStudyService" ref="radiologyStudyService"></property>
+				<property name="orderService" ref="orderService"></property>
+				<property name="encounterService" ref="encounterService"></property>
+				<property name="emrEncounterService" ref="emrEncounterService"></property>
+				<property name="radiologyProperties" ref="radiologyProperties"></property>
 			</bean>
 		</property>
 		<property name="preInterceptors">
@@ -32,9 +45,9 @@
 		</property>
 	</bean>
 
-	<!-- IMPORTANT NOTE: be careful when using formatter on this file. Ensure
-		that there are no line breaks/spaces in between the <value> this will prevent
-		spring from adding these services to the serviceContext since the line breaks/spaces
+	<!-- IMPORTANT NOTE: be careful when using formatter on this file. Ensure 
+		that there are no line breaks/spaces in between the <value> this will prevent 
+		spring from adding these services to the serviceContext since the line breaks/spaces 
 		will be part of the class name -->
 	<bean parent="serviceContext">
 		<property name="moduleService">
@@ -52,6 +65,15 @@
 		</property>
 		<property name="target">
 			<bean class="org.openmrs.module.radiology.study.RadiologyStudyServiceImpl">
+				<property name="radiologyStudyDAO">
+					<bean
+						class="org.openmrs.module.radiology.study.HibernateRadiologyStudyDAO">
+						<property name="sessionFactory">
+							<ref bean="sessionFactory" />
+						</property>
+					</bean>
+				</property>
+				<property name="radiologyProperties" ref="radiologyProperties"></property>
 			</bean>
 		</property>
 		<property name="preInterceptors">
@@ -79,6 +101,14 @@
 		<property name="target">
 			<bean
 				class="org.openmrs.module.radiology.report.RadiologyReportServiceImpl">
+				<property name="radiologyReportDAO">
+					<bean
+						class="org.openmrs.module.radiology.report.HibernateRadiologyReportDAO">
+						<property name="sessionFactory">
+							<ref bean="sessionFactory" />
+						</property>
+					</bean>
+				</property>
 			</bean>
 		</property>
 		<property name="preInterceptors">


### PR DESCRIPTION
## Description
* do not use @Autowired in OpenMrsService's since these slow down services down
* make RadiologyReportEditorComponentTest a unit test since changing the wiring
back xml prevented Context.getService(RadiologyReportService.class) from
finding the service

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-277
