### PR TITLE
RAD-285 Rename service methods ByEntityId

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
@@ -38,10 +38,10 @@ class HibernateRadiologyOrderDAO implements RadiologyOrderDAO {
     }
     
     /**
-     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrder(Integer)
      */
     @Override
-    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
+    public RadiologyOrder getRadiologyOrder(Integer orderId) {
         return (RadiologyOrder) sessionFactory.getCurrentSession()
                 .get(RadiologyOrder.class, orderId);
     }

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
@@ -21,9 +21,9 @@ interface RadiologyOrderDAO {
     
     
     /**
-     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrder(Integer)
      */
-    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId);
+    public RadiologyOrder getRadiologyOrder(Integer orderId);
     
     /**
      * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatient(Patient)

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -69,7 +69,7 @@ public interface RadiologyOrderService extends OpenmrsService {
             throws Exception;
     
     /**
-     * Get RadiologyOrder by its orderId
+     * Get the {@code RadiologyOrder} by its {@code orderId}.
      *
      * @param orderId of wanted RadiologyOrder
      * @return RadiologyOrder matching given orderId
@@ -79,7 +79,7 @@ public interface RadiologyOrderService extends OpenmrsService {
      * @should throw illegal argument exception given null
      */
     @Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
-    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) throws IllegalArgumentException;
+    public RadiologyOrder getRadiologyOrder(Integer orderId) throws IllegalArgumentException;
     
     /**
      * Get RadiologyOrder's by its associated Patient

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
@@ -181,16 +181,16 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     }
     
     /**
-     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @see RadiologyOrderService#getRadiologyOrder(Integer)
      */
     @Transactional(readOnly = true)
     @Override
-    public RadiologyOrder getRadiologyOrderByOrderId(Integer orderId) {
+    public RadiologyOrder getRadiologyOrder(Integer orderId) {
         if (orderId == null) {
             throw new IllegalArgumentException("orderId is required");
         }
         
-        return radiologyOrderDAO.getRadiologyOrderByOrderId(orderId);
+        return radiologyOrderDAO.getRadiologyOrder(orderId);
     }
     
     /**

--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -37,12 +37,12 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
     }
     
     /**
-     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReport(Integer)
      */
     @Override
-    public RadiologyReport getRadiologyReportById(Integer radiologyReportId) {
+    public RadiologyReport getRadiologyReport(Integer reportId) {
         return (RadiologyReport) sessionFactory.getCurrentSession()
-                .get(RadiologyReport.class, radiologyReportId);
+                .get(RadiologyReport.class, reportId);
     }
     
     /**

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
@@ -21,9 +21,9 @@ interface RadiologyReportDAO {
     
     
     /**
-     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReport(Integer)
      */
-    RadiologyReport getRadiologyReportById(Integer radiologyReportId);
+    RadiologyReport getRadiologyReport(Integer reportId);
     
     /**
      * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportByUuid(String)

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportEditor.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportEditor.java
@@ -39,7 +39,7 @@ public class RadiologyReportEditor extends PropertyEditorSupport {
         final RadiologyReportService radiologyReportService = Context.getService(RadiologyReportService.class);
         if (StringUtils.hasText(text)) {
             try {
-                setValue(radiologyReportService.getRadiologyReportByRadiologyReportId(Integer.valueOf(text)));
+                setValue(radiologyReportService.getRadiologyReport(Integer.valueOf(text)));
             }
             catch (Exception ex) {
                 final RadiologyReport radiologyReport = radiologyReportService.getRadiologyReportByUuid(text);

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -105,16 +105,16 @@ public interface RadiologyReportService extends OpenmrsService {
             throws IllegalArgumentException, UnsupportedOperationException;
     
     /**
-     * Get a RadiologyReport matching the radiologyReportId
+     * Get the {@code RadiologyReport} by its {@code reportId}.
      *
-     * @param radiologyReportId of RadiologyReport
-     * @return RadiologyReport matching given radiologyReportId
-     * @throws IllegalArgumentException if radiologyReportId is null
-     * @should fetch RadiologyReport matching given radiologyReportId
-     * @should throw IllegalArgumentException if radiologyReportId is null
+     * @param reportId Report Id of wanted RadiologyReport
+     * @return RadiologyReport matching given reportId
+     * @throws IllegalArgumentException if reportId is null
+     * @should fetch RadiologyReport matching given reportId
+     * @should throw IllegalArgumentException if reportId is null
      */
     @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
-    RadiologyReport getRadiologyReportByRadiologyReportId(Integer radiologyReportId) throws IllegalArgumentException;
+    RadiologyReport getRadiologyReport(Integer reportId) throws IllegalArgumentException;
     
     /**
      * Get a RadiologyReport matching the radiologyReport uuid

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -125,16 +125,16 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     }
     
     /**
-     * @see RadiologyReportService#getRadiologyReportByRadiologyReportId(Integer)
+     * @see RadiologyReportService#getRadiologyReport(Integer)
      */
     @Transactional(readOnly = true)
     @Override
-    public RadiologyReport getRadiologyReportByRadiologyReportId(Integer radiologyReportId) throws IllegalArgumentException {
+    public RadiologyReport getRadiologyReport(Integer reportId) throws IllegalArgumentException {
         
-        if (radiologyReportId == null) {
-            throw new IllegalArgumentException("radiologyReportId cannot be null");
+        if (reportId == null) {
+            throw new IllegalArgumentException("reportId cannot be null");
         }
-        return radiologyReportDAO.getRadiologyReportById(radiologyReportId);
+        return radiologyReportDAO.getRadiologyReport(reportId);
     }
     
     /**

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
@@ -341,7 +341,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
             discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWhichDiscontinuesGivenRadiologyOrderThatIsNotInProgressOrCompleted()
                     throws Exception {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         radiologyOrder.getStudy()
                 .setPerformedStatus(null);
         String discontinueReason = "Wrong Procedure";
@@ -373,7 +373,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
             is(not(empty())));
         
         RadiologyOrder radiologyOrder =
-                radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_ENCOUNTER_AND_ACTIVE_VISIT);
+                radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_ENCOUNTER_AND_ACTIVE_VISIT);
         
         assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient())
                 .size(),
@@ -422,7 +422,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     public void
             discontinueRadiologyOrder_shouldCreateDiscontinuationOrderWithEncounterAttachedToNewActiveVisitIfPatientWithoutActiveVisit()
                     throws Exception {
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         
         assertThat(visitService.getActiveVisitsByPatient(radiologyOrder.getPatient()), is(empty()));
         
@@ -454,7 +454,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     @Test
     public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenEmptyRadiologyOrder() throws Exception {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         String discontinueReason = "Wrong Procedure";
         
         expectedException.expect(IllegalArgumentException.class);
@@ -486,7 +486,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsDiscontinued()
             throws Exception {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         radiologyOrder.getStudy()
                 .setPerformedStatus(null);
         String discontinueReason = "Wrong Procedure";
@@ -511,7 +511,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsInProgress()
             throws Exception {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         radiologyOrder.getStudy()
                 .setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
         String discontinueReason = "Wrong Procedure";
@@ -528,7 +528,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     @Test
     public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionIfRadiologyOrderIsCompleted() throws Exception {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         radiologyOrder.getStudy()
                 .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
         String discontinueReason = "Wrong Procedure";
@@ -545,7 +545,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     @Test
     public void discontinueRadiologyOrder_shouldThrowIllegalArgumentExceptionGivenEmptyProvider() throws Exception {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         radiologyOrder.getStudy()
                 .setPerformedStatus(null);
         String discontinueReason = "Wrong Procedure";
@@ -556,40 +556,40 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     }
     
     /**
-     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @see RadiologyOrderService#getRadiologyOrder(Integer)
      * @verifies should return radiology order matching order id
      */
     @Test
-    public void getRadiologyOrderByOrderId_shouldReturnRadiologyOrderMatchingOrderId() {
+    public void getRadiology_shouldReturnRadiologyOrderMatchingOrderId() {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         
         assertNotNull(radiologyOrder);
         assertThat(radiologyOrder.getOrderId(), is(EXISTING_RADIOLOGY_ORDER_ID));
     }
     
     /**
-     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @see RadiologyOrderService#getRadiologyOrder(Integer)
      * @verifies should return null if no match was found
      */
     @Test
-    public void getRadiologyOrderByOrderId_shouldReturnNullIfNoMatchIsFound() {
+    public void getRadiology_shouldReturnNullIfNoMatchIsFound() {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(NON_EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(NON_EXISTING_RADIOLOGY_ORDER_ID);
         
         assertNull(radiologyOrder);
     }
     
     /**
-     * @see RadiologyOrderService#getRadiologyOrderByOrderId(Integer)
+     * @see RadiologyOrderService#getRadiologyOrder(Integer)
      * @verifies should throw illegal argument exception given null
      */
     @Test
-    public void getRadiologyOrderByOrderId_shouldThrowIllegalArgumentExceptionGivenNull() {
+    public void getRadiology_shouldThrowIllegalArgumentExceptionGivenNull() {
         
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("orderId is required");
-        radiologyOrderService.getRadiologyOrderByOrderId(null);
+        radiologyOrderService.getRadiologyOrder(null);
     }
     
     /**

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportEditorComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportEditorComponentTest.java
@@ -53,7 +53,7 @@ public class RadiologyReportEditorComponentTest extends BaseModuleContextSensiti
         RadiologyReportEditor editor = new RadiologyReportEditor();
         editor.setAsText("1");
         assertThat(editor.getValue(), is(notNullValue()));
-        assertThat((RadiologyReport) editor.getValue(), is(radiologyReportService.getRadiologyReportByRadiologyReportId(1)));
+        assertThat((RadiologyReport) editor.getValue(), is(radiologyReportService.getRadiologyReport(1)));
     }
     
     /**

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -104,7 +104,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             createAndClaimRadiologyReport_shouldCreateARadiologyOrderWithReportStatusClaimedGivenACompletedRadiologyOrder()
                     throws Exception {
         
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(EXISTING_RADIOLOGY_ORDER_ID);
         radiologyOrder.getStudy()
                 .setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
         RadiologyReport radiologyReport = radiologyReportService.createAndClaimRadiologyReport(radiologyOrder);
@@ -134,7 +134,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         RadiologyOrder existingRadiologyOrder =
-                radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT);
+                radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT);
         existingRadiologyOrder.getStudy()
                 .setPerformedStatus(PerformedProcedureStepStatus.IN_PROGRESS);
         expectedException.expect(IllegalArgumentException.class);
@@ -152,9 +152,8 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             createAndClaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfGivenOrderHasACompletedRadiologyReport()
                     throws Exception {
         RadiologyOrder existingRadiologyOrder =
-                radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT);
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+                radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         existingRadiologyReport.setReportStatus(RadiologyReportStatus.CLAIMED);
         radiologyReportService.saveRadiologyReport(existingRadiologyReport);
         radiologyReportService.completeRadiologyReport(existingRadiologyReport, providerService.getProvider(1));
@@ -174,7 +173,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
                     throws Exception {
         
         RadiologyOrder existingRadiologyOrder =
-                radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT);
+                radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT);
         expectedException.expect(UnsupportedOperationException.class);
         expectedException
                 .expectMessage("cannot create radiologyReport for this radiologyOrder because it is already claimed");
@@ -188,8 +187,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     @Test
     public void saveRadiologyReport_shouldSaveRadiologyReportInDatabaseAndReturnIt() throws Exception {
         
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         existingRadiologyReport.setReportStatus(RadiologyReportStatus.CLAIMED);
         existingRadiologyReport.setReportBody("test - text");
         
@@ -210,8 +208,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void saveRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
             throws Exception {
         
-        RadiologyReport radiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
         
         expectedException.expect(UnsupportedOperationException.class);
@@ -227,8 +224,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void saveRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
             throws Exception {
         
-        RadiologyReport radiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
         
         expectedException.expect(UnsupportedOperationException.class);
@@ -255,8 +251,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     @Test
     public void saveRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull() throws Exception {
         
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         existingRadiologyReport.setReportStatus(null);
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyReportStatus cannot be null");
@@ -270,8 +265,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     @Test
     public void unclaimRadiologyReport_shouldSetTheRadiologyReportStatusOfRadiologyReportToDiscontinued() throws Exception {
         
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         RadiologyReport radiologyReport = radiologyReportService.unclaimRadiologyReport(existingRadiologyReport);
         assertNotNull(radiologyReport);
         assertThat(radiologyReport.getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
@@ -298,8 +292,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void unclaimRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull()
             throws Exception {
         
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         existingRadiologyReport.setReportStatus(null);
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyReportStatus cannot be null");
@@ -314,8 +307,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void unclaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
             throws Exception {
         
-        RadiologyReport radiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
         
         expectedException.expect(UnsupportedOperationException.class);
@@ -331,8 +323,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void unclaimRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
             throws Exception {
         
-        RadiologyReport radiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
         
         expectedException.expect(UnsupportedOperationException.class);
@@ -351,8 +342,8 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.completeRadiologyReport(
-            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID),
-            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID)
+            radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID),
+            radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID)
                     .getPrincipalResultsInterpreter());
         
         assertNotNull(radiologyReport);
@@ -368,8 +359,8 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void completeRadiologyReport_shouldSetTheRadiologyReportStatusToComplete() throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.completeRadiologyReport(
-            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID),
-            radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID)
+            radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID),
+            radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID)
                     .getPrincipalResultsInterpreter());
         
         assertNotNull(radiologyReport);
@@ -385,8 +376,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfPrincipalResultsInterpreterIsNull()
             throws Exception {
         
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyReport cannot be null");
         radiologyReportService.completeRadiologyReport(null, existingRadiologyReport.getPrincipalResultsInterpreter());
@@ -400,8 +390,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     @Test
     public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportIsNull() throws Exception {
         
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         existingRadiologyReport.setPrincipalResultsInterpreter(null);
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("principalResultsInterpreter cannot be null");
@@ -417,8 +406,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void completeRadiologyReport_shouldThrowAnIllegalArgumentExceptionIfRadiologyReportStatusIsNull()
             throws Exception {
         
-        RadiologyReport existingRadiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport existingRadiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         existingRadiologyReport.setReportStatus(null);
         Provider provider = new Provider();
         provider.setId(1);
@@ -437,8 +425,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void completeRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsCompleted()
             throws Exception {
         
-        RadiologyReport radiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         radiologyReport.setReportStatus(RadiologyReportStatus.COMPLETED);
         Provider provider = new Provider();
         provider.setId(1);
@@ -458,8 +445,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void completeRadiologyReport_shouldThrowAnUnsupportedOperationExceptionIfRadiologyReportIsDiscontinued()
             throws Exception {
         
-        RadiologyReport radiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         radiologyReport.setReportStatus(RadiologyReportStatus.DISCONTINUED);
         Provider provider = new Provider();
         provider.setId(1);
@@ -471,29 +457,26 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     }
     
     /**
-     * @see RadiologyOrderService#getRadiologyReportByRadiologyReportId(Integer)
-     * @verifies fetch RadiologyReport matching given radiologyReportId
+     * @see RadiologyOrderService#getRadiologyReport(Integer)
+     * @verifies fetch RadiologyReport matching given reportId
      */
     @Test
-    public void getRadiologyReportByRadiologyReportId_shouldFetchRadiologyReportMatchingGivenRadiologyReportId()
-            throws Exception {
+    public void getRadiologyReport_shouldFetchRadiologyReportMatchingGivenReportId() throws Exception {
         
-        RadiologyReport radiologyReport =
-                radiologyReportService.getRadiologyReportByRadiologyReportId(EXISTING_RADIOLOGY_REPORT_ID);
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(EXISTING_RADIOLOGY_REPORT_ID);
         assertThat(radiologyReport.getId(), is(EXISTING_RADIOLOGY_REPORT_ID));
     }
     
     /**
-     * @see RadiologyOrderService#getRadiologyReportByRadiologyReportId(Integer)
-     * @verifies throw IllegalArgumentException if radiologyReportId is null
+     * @see RadiologyOrderService#getRadiologyReport(Integer)
+     * @verifies throw IllegalArgumentException if reportId is null
      */
     @Test
-    public void getRadiologyReportByRadiologyReportId_shouldThrowIllegalArgumentExceptionIfRadiologyReportIdIsNull()
-            throws Exception {
+    public void getRadiologyReport_shouldThrowIllegalArgumentExceptionIfReportIdIsNull() throws Exception {
         
         expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("radiologyReportId cannot be null");
-        radiologyReportService.getRadiologyReportByRadiologyReportId(null);
+        expectedException.expectMessage("reportId cannot be null");
+        radiologyReportService.getRadiologyReport(null);
     }
     
     /**
@@ -542,7 +525,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
                     throws Exception {
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT),
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT),
             RadiologyReportStatus.CLAIMED);
         assertNotNull(radiologyReports);
         assertThat(radiologyReports.size(), is(1));
@@ -560,7 +543,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
                     throws Exception {
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT),
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT),
             RadiologyReportStatus.COMPLETED);
         assertNotNull(radiologyReports);
         assertThat(radiologyReports.size(), is(1));
@@ -577,7 +560,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
                     throws Exception {
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT),
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT),
             RadiologyReportStatus.DISCONTINUED);
         assertNotNull(radiologyReports);
         assertThat(radiologyReports.size(), is(1));
@@ -594,7 +577,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
                     throws Exception {
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT),
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_WITHOUT_RADIOLOGY_REPORT),
             RadiologyReportStatus.CLAIMED);
         assertThat(radiologyReports.size(), is(0));
     }
@@ -627,7 +610,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyReportStatus cannot be null");
         radiologyReportService.getRadiologyReportsByRadiologyOrderAndReportStatus(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT), null);
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT), null);
     }
     
     /**
@@ -639,7 +622,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
         assertFalse(hasRadiologyOrderClaimedRadiologyReport);
     }
     
@@ -652,7 +635,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderClaimedRadiologyReport(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
         assertTrue(hasRadiologyOrderClaimedRadiologyReport);
     }
     
@@ -676,7 +659,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         boolean hasRadiologyOrderCompletedRadiologyReport = radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_DISCONTINUED_RADIOLOGY_REPORT));
         assertFalse(hasRadiologyOrderCompletedRadiologyReport);
     }
     
@@ -689,7 +672,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         boolean hasRadiologyOrderClaimedRadiologyReport = radiologyReportService.hasRadiologyOrderCompletedRadiologyReport(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
         assertTrue(hasRadiologyOrderClaimedRadiologyReport);
     }
     
@@ -715,7 +698,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         RadiologyReport activeReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_CLAIMED_RADIOLOGY_REPORT));
         
         assertNotNull(activeReport);
     }
@@ -729,7 +712,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
             throws Exception {
         
         RadiologyReport activeReport = radiologyReportService.getActiveRadiologyReportByRadiologyOrder(
-            radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
+            radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_WITH_STUDY_AND_COMPLETED_RADIOLOGY_REPORT));
         
         assertNotNull(activeReport);
     }

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
@@ -109,7 +109,7 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
     public void saveStudy_shouldCreateNewStudyFromGivenStudyObject() throws Exception {
         
         RadiologyStudy radiologyStudy = getUnsavedStudy();
-        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
+        RadiologyOrder radiologyOrder = radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
         radiologyOrder.setStudy(radiologyStudy);
         
         RadiologyStudy createdStudy = radiologyStudyService.saveStudy(radiologyStudy);
@@ -287,7 +287,7 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
             throws Exception {
         
         RadiologyOrder radiologyOrderWithoutStudy =
-                radiologyOrderService.getRadiologyOrderByOrderId(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
+                radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
         List<RadiologyOrder> radiologyOrders = Arrays.asList(radiologyOrderWithoutStudy);
         
         List<RadiologyStudy> radiologyStudies = radiologyStudyService.getStudiesByRadiologyOrders(radiologyOrders);

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
@@ -230,7 +230,7 @@ public class RadiologyOrderFormController {
             if (radiologyOrderErrors.hasErrors()) {
                 modelAndView.addObject("order", radiologyOrderToDiscontinue);
                 modelAndView.addObject("radiologyOrder",
-                    radiologyOrderService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
+                    radiologyOrderService.getRadiologyOrder(radiologyOrderToDiscontinue.getOrderId()));
                 
                 return modelAndView;
             }
@@ -249,7 +249,7 @@ public class RadiologyOrderFormController {
         
         modelAndView.addObject("order", radiologyOrderToDiscontinue);
         modelAndView.addObject("radiologyOrder",
-            radiologyOrderService.getRadiologyOrderByOrderId(radiologyOrderToDiscontinue.getOrderId()));
+            radiologyOrderService.getRadiologyOrder(radiologyOrderToDiscontinue.getOrderId()));
         modelAndView.addObject("discontinuationOrder", discontinuationOrder);
         return modelAndView;
     }

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
@@ -457,7 +457,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
         MockHttpSession mockSession = new MockHttpSession();
         mockRequest.setSession(mockSession);
         
-        when(radiologyOrderService.getRadiologyOrderByOrderId(mockRadiologyOrderToDiscontinue.getOrderId()))
+        when(radiologyOrderService.getRadiologyOrder(mockRadiologyOrderToDiscontinue.getOrderId()))
                 .thenReturn(mockRadiologyOrderToDiscontinue);
         when(radiologyOrderService.discontinueRadiologyOrder(mockRadiologyOrderToDiscontinue,
             mockDiscontinuationOrder.getOrderer(), mockDiscontinuationOrder.getOrderReasonNonCoded()))


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
the openmrs-core convention is that the service get methods which to get the
entity the service is for by its internal id are simply called
getEntity(Integer entityId)

Remove the ByXXX substring from our service and DAO methods
 * RadiologyOrderService.getRadiologyOrderByOrderId()
 * RadiologyReportService.getRadiologyReportByRadiologyReportId()

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-285

