### PR TITLE
RAD-299 Show dashboard title and reorganize properties

### DIFF
--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
@@ -17,7 +17,7 @@ public class GutterListExt extends LinkExt {
     
     @Override
     public String getLabel() {
-        return "radiology.home.title";
+        return "radiology.gutterlist.title";
     }
     
     @Override

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
@@ -18,7 +18,7 @@ public class PatientDashboardRadiologyTabExt extends PatientDashboardTabExt {
     
     @Override
     public String getTabName() {
-        return "radiology.home.title";
+        return "radiology.patientDashboardForm.tabs.radiology";
     }
     
     @Override

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -1,11 +1,13 @@
 @MODULE_ID@.title=Radiology Module
-@MODULE_ID@.home.title=Radiology
+@MODULE_ID@.gutterlist.title=Radiology
+@MODULE_ID@.dashboard.title=Radiology
+@MODULE_ID@.dashboard.tabs.orders=Orders
+@MODULE_ID@.patientDashboardForm.tabs.radiology=Radiology
 @MODULE_ID@.manageOrders=Manage Radiology Orders
 @MODULE_ID@.radiologyOrder=Radiology Order
 @MODULE_ID@.radiologyOrders=Radiology Orders
 @MODULE_ID@.addOrder=Add Radiology Order
 @MODULE_ID@.imagingProcedure=Imaging Procedure
-@MODULE_ID@.radiologyTabs.orders=Orders
 
 @MODULE_ID@.discontinuedOrder=Discontinued Order
 @MODULE_ID@.isNotActiveOrder=This order is not active.

--- a/omod/src/main/webapp/portlets/patientDashboardRadiologyTab.jsp
+++ b/omod/src/main/webapp/portlets/patientDashboardRadiologyTab.jsp
@@ -75,13 +75,6 @@
                                             }
                                           },
                                           {
-                                            "name": "patient",
-                                            "render": function(data, type,
-                                                    full, meta) {
-                                              return full.patient.display;
-                                            }
-                                          },
-                                          {
                                             "name": "urgency",
                                             "render": function(data, type,
                                                     full, meta) {
@@ -225,24 +218,27 @@
         code="radiology.addOrder" /></a> <br />
   </p>
 </openmrs:hasPrivilege>
-
-<div id="results">
-  <table id="radiologyOrdersTable" cellspacing="0" width="100%" class="display nowrap">
-    <thead>
-      <tr>
-        <th></th>
-        <th><spring:message code="radiology.datatables.column.orderNumber" /></th>
-        <th><spring:message code="radiology.datatables.column.patient" /></th>
-        <th><spring:message code="radiology.datatables.column.priority" /></th>
-        <th><spring:message code="radiology.datatables.column.imagingProcedure" /></th>
-        <th><spring:message code="radiology.datatables.column.referringPhysician" /></th>
-        <th><spring:message code="radiology.datatables.column.scheduledDate" /></th>
-        <th><spring:message code="radiology.datatables.column.dateActivated" /></th>
-        <th><spring:message code="radiology.datatables.column.orderReason" /></th>
-        <th><spring:message code="radiology.datatables.column.orderReasonNonCoded" /></th>
-        <th><spring:message code="radiology.datatables.column.instructions" /></th>
-      </tr>
-    </thead>
-  </table>
+<span class="boxHeader"> <b><spring:message code="radiology.radiologyOrders" /></b>
+</span>
+<div class="box">
+  <br>
+  <div id="results">
+    <table id="radiologyOrdersTable" cellspacing="0" width="100%" class="display nowrap">
+      <thead>
+        <tr>
+          <th></th>
+          <th><spring:message code="radiology.datatables.column.orderNumber" /></th>
+          <th><spring:message code="radiology.datatables.column.priority" /></th>
+          <th><spring:message code="radiology.datatables.column.imagingProcedure" /></th>
+          <th><spring:message code="radiology.datatables.column.referringPhysician" /></th>
+          <th><spring:message code="radiology.datatables.column.scheduledDate" /></th>
+          <th><spring:message code="radiology.datatables.column.dateActivated" /></th>
+          <th><spring:message code="radiology.datatables.column.orderReason" /></th>
+          <th><spring:message code="radiology.datatables.column.orderReasonNonCoded" /></th>
+          <th><spring:message code="radiology.datatables.column.instructions" /></th>
+        </tr>
+      </thead>
+    </table>
+  </div>
 </div>
 <input type="hidden" id="patientUuid" value="${patient.uuid}" />

--- a/omod/src/main/webapp/radiologyDashboardForm.jsp
+++ b/omod/src/main/webapp/radiologyDashboardForm.jsp
@@ -7,6 +7,10 @@
 <openmrs:htmlInclude file="/scripts/jquery-ui/js/jquery-ui-1.7.2.custom.min.js" />
 <openmrs:htmlInclude file="/moduleResources/radiology/css/radiology.css" />
 
+<h2>
+  <spring:message code="radiology.dashboard.title" />
+</h2>
+
 <script type="text/javascript">
   var timeOut = null;
 
@@ -69,7 +73,7 @@
   <ul>
     <openmrs:hasPrivilege privilege="View Orders">
       <li><a id="radiologyOrdersTab" href="#" onclick="return changeTab(this);" hidefocus="hidefocus"><openmrs:message
-            code="radiology.radiologyTabs.orders" /></a></li>
+            code="radiology.dashboard.tabs.orders" /></a></li>
     </openmrs:hasPrivilege>
   </ul>
 </div>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
in the UI

* show a dashboard title, so the user knows where he is, since clicking on the
gutterlist does visually show where on the gutterlist you are
* add box around patientDashboardRadiologyTab table
* remove patient column in patientDashboardRadiologyTab since we have a huge
patient header showing us the patient we are at.
* restructure message properties for dashboard, gutterlist,
patientDashboardRadiologyTab

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-299
