### PR TITLE
RAD-286 Fix display of orderReason

### DIFF
--- a/omod/src/main/webapp/orders/radiologyOrderDetailsSegment.jsp
+++ b/omod/src/main/webapp/orders/radiologyOrderDetailsSegment.jsp
@@ -15,9 +15,13 @@
       </tr>
       <tr>
         <td><spring:message code="radiology.radiologyOrder.orderReason" /></td>
-        <td><spring:bind path="concept.name.name">
-                    ${status.value}
-                </spring:bind></td>
+        <td><spring:bind path="orderReason">
+            <c:if test="${not empty status.value}">
+              <spring:bind path="${status.expression}.name.name">
+                                ${status.value}
+                        </spring:bind>
+            </c:if>
+          </spring:bind></td>
       </tr>
       <tr>
         <td><spring:message code="radiology.radiologyOrder.orderReasonNonCoded" /></td>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
added orderReason to order entry page and to display of existing orders but did
show the orderable field "concept" instead of the orderReason

* show orderReason in radiologyOrderDetailsSegment

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-286



