### PR TITLE
RAD-188 Hide scheduledDate by default

### DIFF
--- a/omod/src/main/webapp/orders/radiologyOrderCreationSegment.jsp
+++ b/omod/src/main/webapp/orders/radiologyOrderCreationSegment.jsp
@@ -16,6 +16,7 @@
     var showOrHideScheduledDate = function() {
       if (urgencySelect.val() === "ON_SCHEDULED_DATE") {
         scheduledDate.show();
+        scheduledDate.click();
       } else {
         scheduledDate.hide();
         scheduledDateErrorSpan.hide();
@@ -99,8 +100,8 @@
               </c:forEach>
             </select>
           </spring:bind> <spring:bind path="scheduledDate">
-            <input name="${status.expression}" id="${status.expression}Id" type="text" onclick="showDateTimePicker(this)"
-              value="${status.value}">
+            <input name="${status.expression}" id="${status.expression}Id" type="text" style="display: none;"
+              onclick="showDateTimePicker(this)" value="${status.value}">
             <c:if test="${status.errorMessage != ''}">
               <span id="scheduledDateErrorSpan" class="error">${status.errorMessage}</span>
             </c:if>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
added scheduledDate to radiologyOrderCreationSegment in previous commit but it
the input element was visible by default and on page load the js was executed
which set it to hidden since default urgency="ROUTINE". this lead to the
element being visible for a short amount of time if page load is slow.

* hide scheduledDate input by default

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-188


