### PR TITLE
RAD-173 Prevent empty report body

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
@@ -16,22 +16,22 @@ import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
 
 /**
- * Validates the {@link RadiologyReport} class.
+ * Validates {@link RadiologyReport}.
  */
 @Component
 public class RadiologyReportValidator implements Validator {
     
     
-    /** Log for this class and subclasses */
-    protected final Log log = LogFactory.getLog(getClass());
+    protected final Log log = LogFactory.getLog(RadiologyReportValidator.class);
     
     /**
      * Determines if the command object being submitted is a valid type
      *
      * @see org.springframework.validation.Validator#supports(java.lang.Class)
-     * @should return true for RadiologyReport objects
+     * @should return true for radiology report objects
      * @should return false for other object types
      */
+    @Override
     public boolean supports(Class clazz) {
         return RadiologyReport.class.isAssignableFrom(clazz);
     }
@@ -39,18 +39,21 @@ public class RadiologyReportValidator implements Validator {
     /**
      * Checks the form object for any inconsistencies/errors
      *
-     * @see org.springframework.validation.Validator#validate(java.lang.Object, org.springframework.validation.Errors)
-     * @should fail validation if radiologyReport is null
-     * @should fail validation if principalResultsInterpreter is empty or whitespace
+     * @see org.springframework.validation.Validator#validate(Object, Errors)
+     * @should fail validation if radiology report is null
+     * @should fail validation if principal results interpreter is null or empty or whitespaces only
+     * @should fail validation if report body is null or empty or whitespaces only
      * @should pass validation if all fields are correct
      */
+    @Override
     public void validate(Object obj, Errors errors) {
         RadiologyReport radiologyReport = (RadiologyReport) obj;
         if (radiologyReport == null) {
             errors.reject("error.general");
         } else {
             ValidationUtils.rejectIfEmptyOrWhitespace(errors, "principalResultsInterpreter", "error.null",
-                "Provider can not be null");
+                "Provider cannot be null");
+            ValidationUtils.rejectIfEmptyOrWhitespace(errors, "reportBody", "error.null", "Diagnosis cannot be null");
         }
     }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.Provider;
 import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
@@ -27,9 +28,27 @@ import org.springframework.validation.Errors;
 public class RadiologyReportValidatorTest {
     
     
+    RadiologyOrder radiologyOrder;
+    
+    RadiologyStudy radiologyStudy;
+    
+    RadiologyReport radiologyReport;
+    
+    @Before
+    public void setUp() {
+        
+        radiologyOrder = new RadiologyOrder();
+        radiologyStudy = new RadiologyStudy();
+        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
+        radiologyOrder.setStudy(radiologyStudy);
+        radiologyReport = new RadiologyReport(radiologyOrder);
+        radiologyReport.setPrincipalResultsInterpreter(new Provider());
+        radiologyReport.setReportBody("Found a broken bone.");
+    }
+    
     /**
-     * @verifies return false for other object types
      * @see RadiologyReportValidator#supports(Class)
+     * @verifies return false for other object types
      */
     @Test
     public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
@@ -39,8 +58,8 @@ public class RadiologyReportValidatorTest {
     }
     
     /**
-     * @verifies return true for RadiologyReport objects
      * @see RadiologyReportValidator#supports(Class)
+     * @verifies return true for radiology report objects
      */
     @Test
     public void supports_shouldReturnTrueForRadiologyReportObjects() throws Exception {
@@ -50,60 +69,102 @@ public class RadiologyReportValidatorTest {
     }
     
     /**
-     * @verifies fail validation if principalResultsInterpreter is empty or whitespace
      * @see RadiologyReportValidator#validate(Object, Errors)
-     */
-    @Test
-    public void validate_shouldFailValidationIfPrincipalResultsInterpreterIsEmptyOrWhitespace() throws Exception {
-        
-        RadiologyOrder radiologyOrder = new RadiologyOrder();
-        RadiologyStudy radiologyStudy = new RadiologyStudy();
-        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-        radiologyOrder.setStudy(radiologyStudy);
-        RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
-        radiologyReport.setPrincipalResultsInterpreter(null);
-        
-        Errors errors = new BindException(radiologyReport, "radiologyReport");
-        new RadiologyReportValidator().validate(radiologyReport, errors);
-        
-        assertTrue(errors.hasFieldErrors("principalResultsInterpreter"));
-    }
-    
-    /**
-     * @verifies fail validation if radiologyReport is null
-     * @see RadiologyReportValidator#validate(Object, Errors)
+     * @verifies fail validation if radiology report is null
      */
     @Test
     public void validate_shouldFailValidationIfRadiologyReportIsNull() throws Exception {
-        
-        RadiologyOrder radiologyOrder = new RadiologyOrder();
-        RadiologyStudy radiologyStudy = new RadiologyStudy();
-        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-        radiologyOrder.setStudy(radiologyStudy);
-        RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
         
         Errors errors = new BindException(radiologyReport, "radiologyReport");
         new RadiologyReportValidator().validate(null, errors);
         
         assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
         assertThat((errors.getAllErrors()).get(0)
                 .getCode(),
             is("error.general"));
     }
     
     /**
-     * @verifies pass validation if all fields are correct
      * @see RadiologyReportValidator#validate(Object, Errors)
+     * @verifies fail validation if principal results interpreter is null or empty or whitespaces only
+     */
+    @Test
+    public void validate_shouldFailValidationIfPrincipalResultsInterpreterIsNullOrEmptyOrWhitespacesOnly() throws Exception {
+        
+        radiologyReport.setPrincipalResultsInterpreter(null);
+        
+        Errors errors = new BindException(radiologyReport, "radiologyReport");
+        new RadiologyReportValidator().validate(radiologyReport, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(),
+            is("error.null"));
+        assertTrue(errors.hasFieldErrors("principalResultsInterpreter"));
+    }
+    
+    /**
+     * @see RadiologyReportValidator#validate(Object,Errors)
+     * @verifies fail validation if report body is null or empty or whitespaces only
+     */
+    @Test
+    public void validate_shouldFailValidationIfReportBodyIsNullOrEmptyOrWhitespacesOnly() throws Exception {
+        
+        radiologyReport.setReportBody(null);
+        
+        Errors errors = new BindException(radiologyReport, "radiologyReport");
+        new RadiologyReportValidator().validate(radiologyReport, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(),
+            is("error.null"));
+        assertTrue(errors.hasFieldErrors("reportBody"));
+        
+        radiologyReport.setReportBody("");
+        
+        errors = new BindException(radiologyReport, "radiologyReport");
+        new RadiologyReportValidator().validate(radiologyReport, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(),
+            is("error.null"));
+        assertTrue(errors.hasFieldErrors("reportBody"));
+        
+        radiologyReport.setReportBody("  ");
+        
+        errors = new BindException(radiologyReport, "radiologyReport");
+        new RadiologyReportValidator().validate(radiologyReport, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(),
+            is("error.null"));
+        assertTrue(errors.hasFieldErrors("reportBody"));
+    }
+    
+    /**
+     * @see RadiologyReportValidator#validate(Object, Errors)
+     * @verifies pass validation if all fields are correct
      */
     @Test
     public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
-        
-        RadiologyOrder radiologyOrder = new RadiologyOrder();
-        RadiologyStudy radiologyStudy = new RadiologyStudy();
-        radiologyStudy.setPerformedStatus(PerformedProcedureStepStatus.COMPLETED);
-        radiologyOrder.setStudy(radiologyStudy);
-        RadiologyReport radiologyReport = new RadiologyReport(radiologyOrder);
-        radiologyReport.setPrincipalResultsInterpreter(new Provider());
         
         Errors errors = new BindException(radiologyReport, "radiologyReport");
         new RadiologyReportValidator().validate(radiologyReport, errors);

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
@@ -39,6 +39,9 @@ public class RadiologyReportFormController {
     @Autowired
     private DicomWebViewer dicomWebViewer;
     
+    @Autowired
+    private RadiologyReportValidator radiologyReportValidator;
+    
     /**
      * Handles GET requests for the radiologyReportForm creating a new radiology report for given
      * radiology order
@@ -87,7 +90,8 @@ public class RadiologyReportFormController {
      */
     @RequestMapping(method = RequestMethod.POST, params = "saveRadiologyReport")
     protected ModelAndView saveRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport) {
-        ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
+        
+        final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
         radiologyReportService.saveRadiologyReport(radiologyReport);
         
         addObjectsToModelAndView(modelAndView, radiologyReport);
@@ -104,6 +108,7 @@ public class RadiologyReportFormController {
      */
     @RequestMapping(method = RequestMethod.POST, params = "unclaimRadiologyReport")
     protected ModelAndView unclaimRadiologyReport(@ModelAttribute("radiologyReport") RadiologyReport radiologyReport) {
+        
         radiologyReportService.unclaimRadiologyReport(radiologyReport);
         return new ModelAndView("redirect:" + RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING + "?orderId="
                 + radiologyReport.getRadiologyOrder()
@@ -127,7 +132,9 @@ public class RadiologyReportFormController {
         
         final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_REPORT_FORM_VIEW);
         
-        if (validateForm(modelAndView, radiologyReport, bindingResult)) {
+        radiologyReportValidator.validate(radiologyReport, bindingResult);
+        if (bindingResult.hasErrors()) {
+            addObjectsToModelAndView(modelAndView, radiologyReport);
             return modelAndView;
         }
         
@@ -135,27 +142,6 @@ public class RadiologyReportFormController {
             radiologyReport.getPrincipalResultsInterpreter());
         addObjectsToModelAndView(modelAndView, completedRadiologyReport);
         return modelAndView;
-    }
-    
-    /**
-     * Convenience method to check, if RadiologyReportForm has BindingErrors (e.g. Provider is not
-     * set)
-     *
-     * @param radiologyReport radiology report to be validated
-     * @param bindingResult BindingResult
-     * @param modelAndView model and view where radiology report is added
-     * @return true, if RadiologyReportFrom has errors (e.g. Provider is missing), false if
-     *         RadiologyReportForm has no errors
-     */
-    private boolean validateForm(ModelAndView modelAndView, RadiologyReport radiologyReport, BindingResult bindingResult) {
-        if (radiologyReport.getPrincipalResultsInterpreter() == null) {
-            new RadiologyReportValidator().validate(radiologyReport, bindingResult);
-        }
-        if (bindingResult.hasErrors()) {
-            addObjectsToModelAndView(modelAndView, radiologyReport);
-            return true;
-        }
-        return false;
     }
     
     /**

--- a/omod/src/main/webapp/reports/radiologyReportForm.jsp
+++ b/omod/src/main/webapp/reports/radiologyReportForm.jsp
@@ -5,29 +5,25 @@
 
 <openmrs:htmlInclude file="/moduleResources/radiology/scripts/tinymce/tinymce.min.js" />
 <script type="text/javascript">
-  onload = initEverything();
-  function initEverything() {
-    tinymce
-            .init({
-              selector: '#reportText',
-              setup: function(ed) {
-                if (document.getElementById("reportText").getAttribute(
-                        "disabled") != null) {
-                  ed.settings.readonly = true;
-                  ed.settings.toolbar = false;
-                  ed.settings.menubar = false;
-                }
-              },
-              menubar: "edit,format",
-              elementpath: false
-            });
-  }
+  var $j = jQuery.noConflict();
+  $j(document).ready(function() {
+    var reportBody = $j("#reportBodyId");
+
+    tinymce.init({
+      selector: '#reportBodyId',
+      setup: function(editor) {
+        if (reportBody.attr("disabled") != null) {
+          editor.settings.readonly = true;
+          editor.settings.toolbar = false;
+          editor.settings.menubar = false;
+        }
+      },
+      menubar: "edit,format",
+      elementpath: false,
+    });
+  });
 </script>
 
-<spring:hasBindErrors name="radiologyReport">
-  <spring:message code="fix.error" />
-</spring:hasBindErrors>
-<br>
 <openmrs:portlet url="patientHeader" id="patientDashboardHeader" patientId="${order.patient.patientId}" />
 <br>
 <div>
@@ -36,6 +32,12 @@
   <%@ include file="/WEB-INF/view/module/radiology/orders/radiologyOrderDetailsSegment.jsp"%>
 </div>
 <br>
+<spring:hasBindErrors name="radiologyReport">
+  <div class="error">
+    <spring:message code="fix.error" />
+  </div>
+  <br>
+</spring:hasBindErrors>
 <span class="boxHeader"> <b><spring:message code="radiology.radiologyReportTitle" /></b>
 </span>
 <form:form modelAttribute="radiologyReport" method="post">
@@ -65,10 +67,17 @@
         <td><spring:message code="radiology.radiologyReportDiagnosis" /></td>
         <td><c:choose>
             <c:when test="${radiologyReport.reportStatus == 'COMPLETED'}">
-              <form:textarea id="reportText" path="reportBody" disabled="true"></form:textarea>
+              <spring:bind path="reportBody">
+                <textarea id="${status.expression}Id" name="${status.expression}" disabled="true">${status.value}</textarea>
+              </spring:bind>
             </c:when>
             <c:otherwise>
-              <form:textarea id="reportText" path="reportBody"></form:textarea>
+              <spring:bind path="reportBody">
+                <textarea id="${status.expression}Id" name="${status.expression}">${status.value}</textarea>
+                <c:if test="${status.errorMessage != ''}">
+                  <span class="error">${status.errorMessage}</span>
+                </c:if>
+              </spring:bind>
             </c:otherwise>
           </c:choose></td>
       </tr>

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
@@ -16,6 +16,7 @@ import org.openmrs.module.radiology.order.RadiologyOrder;
 import org.openmrs.module.radiology.report.RadiologyReport;
 import org.openmrs.module.radiology.report.RadiologyReportService;
 import org.openmrs.module.radiology.report.RadiologyReportStatus;
+import org.openmrs.module.radiology.report.RadiologyReportValidator;
 import org.openmrs.module.radiology.test.RadiologyTestData;
 import org.openmrs.test.BaseContextMockTest;
 import org.springframework.validation.BindingResult;
@@ -29,6 +30,9 @@ public class RadiologyReportFormControllerTest extends BaseContextMockTest {
     
     @Mock
     private DicomWebViewer dicomWebViewer;
+    
+    @Mock
+    private RadiologyReportValidator radiologyReportValidator;
     
     @InjectMocks
     private RadiologyReportFormController radiologyReportFormController = new RadiologyReportFormController();


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
RadiologyReportValidator prevents an empty report body when completing a
report, so a completed report always has a report body.

* adjusted RadiologyReportValidator to fail on empty report body
* adjusted radiologyReportForm to show error spans properly
* use jquery in tinymce init
* autowire RadiologyReportValidator since its already available as component
* fix error in RadiologyReportFormController, did not make proper use of the
Validator

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-173
