### PR TITLE
RAD-107 Enforce valid DICOM UID for org root

### DIFF
--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyEncounterMatcherComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyEncounterMatcherComponentTestDataset.xml
@@ -13,7 +13,7 @@
   <location location_id="1" name="Radiology Department" creator="1" date_created="2015-01-01 00:00:00.0" retired="false" uuid="c36006e5-9fbb-4f20-866b-0ece245615a1"/>
 
   <!-- define the metadata for the Radiology Module -->
-  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
+  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^[012]((\.0)|(\.[1-9]\d*))+$" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
   <global_property property="radiology.radiologyCareSetting" property_value="6f0c9a92-6f24-11e3-af88-005056821db0" uuid="a3209d7c-ae4c-41a4-96de-876facd77226"/> <!--  set to uuid from CareSetting OUTPATIENT in openmrs core -->
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
@@ -13,7 +13,7 @@
   <location location_id="1" name="Radiology Department" creator="1" date_created="2015-01-01 00:00:00.0" retired="false" uuid="c36006e5-9fbb-4f20-866b-0ece245615a1"/>
 
   <!-- define the metadata for the Radiology Module -->
-  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
+  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^[012]((\.0)|(\.[1-9]\d*))+$" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
   <global_property property="radiology.radiologyCareSetting" property_value="6f0c9a92-6f24-11e3-af88-005056821db0" uuid="a3209d7c-ae4c-41a4-96de-876facd77226"/> <!--  set to uuid from CareSetting OUTPATIENT in openmrs core -->
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -13,7 +13,7 @@
   <location location_id="1" name="Radiology Department" creator="1" date_created="2015-01-01 00:00:00.0" retired="false" uuid="c36006e5-9fbb-4f20-866b-0ece245615a1"/>
 
   <!-- define the metadata for the Radiology Module -->
-  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
+  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^[012]((\.0)|(\.[1-9]\d*))+$" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
   <global_property property="radiology.radiologyCareSetting" property_value="6f0c9a92-6f24-11e3-af88-005056821db0" uuid="a3209d7c-ae4c-41a4-96de-876facd77226"/> <!--  set to uuid from CareSetting OUTPATIENT in openmrs core -->
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml
@@ -13,7 +13,7 @@
   <location location_id="1" name="Radiology Department" creator="1" date_created="2015-01-01 00:00:00.0" retired="false" uuid="c36006e5-9fbb-4f20-866b-0ece245615a1"/>
 
   <!-- define the metadata for the Radiology Module -->
-  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
+  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^[012]((\.0)|(\.[1-9]\d*))+$" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
   <global_property property="radiology.radiologyCareSetting" property_value="6f0c9a92-6f24-11e3-af88-005056821db0" uuid="a3209d7c-ae4c-41a4-96de-876facd77226"/> <!--  set to uuid from CareSetting OUTPATIENT in openmrs core -->
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -58,9 +58,10 @@
 			the default which should be used for development purpose only! Refer
 			to DICOM Standard DICOM PS3.5 Chapter 9 Unique Identifiers.
 
-			Module
+			This
+			modules
 			DICOM UIDs
-			adhere to: [org root].[unique]
+			adhere to scheme: [org root].[unique]
 			Allowed to
 			contain
 			only
@@ -70,7 +71,12 @@
 			without
 			non-significant
 			leading zeroes and without trailing '.'
+			(Validated by Java Regex
+			"^[012]((\\.0)|(\\.[1-9]\\d*))+$")
 		</description>
+		<datatypeClassname>org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype
+		</datatypeClassname>
+		<datatypeConfig>^[012]((\.0)|(\.[1-9]\d*))+$</datatypeConfig>
 	</globalProperty>
 	<globalProperty>
 		<property>@MODULE_ID@.dicomWebViewerAddress</property>

--- a/omod/src/test/resources/RadiologyOrderResourceComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyOrderResourceComponentTestDataset.xml
@@ -13,7 +13,7 @@
   <location location_id="1" name="Radiology Department" creator="1" date_created="2015-01-01 00:00:00.0" retired="false" uuid="c36006e5-9fbb-4f20-866b-0ece245615a1"/>
 
   <!-- define the metadata for the Radiology Module -->
-  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
+  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^[012]((\.0)|(\.[1-9]\d*))+$" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
   <global_property property="radiology.radiologyCareSetting" property_value="6f0c9a92-6f24-11e3-af88-005056821db0" uuid="a3209d7c-ae4c-41a4-96de-876facd77226"/> <!--  set to uuid from CareSetting OUTPATIENT in openmrs core -->
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>

--- a/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
@@ -13,7 +13,7 @@
   <location location_id="1" name="Radiology Department" creator="1" date_created="2015-01-01 00:00:00.0" retired="false" uuid="c36006e5-9fbb-4f20-866b-0ece245615a1"/>
 
   <!-- define the metadata for the Radiology Module -->
-  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
+  <global_property property="radiology.dicomUIDOrgRoot" property_value="2.25" description="DICOM UID org root component" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^[012]((\.0)|(\.[1-9]\d*))+$" uuid="498e94f1-ebea-4bff-bd39-0e4e3168d239"/>
   <global_property property="radiology.radiologyCareSetting" property_value="6f0c9a92-6f24-11e3-af88-005056821db0" uuid="a3209d7c-ae4c-41a4-96de-876facd77226"/> <!--  set to uuid from CareSetting OUTPATIENT in openmrs core -->
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
the org root UID (DICOM root UID) is entered as a global
property defaults to 2.25 but can be changed by the admin in the settings page.
however validation is missing on entry meaning if the admin configures a wrong
uid it will fail during creation of radiology orders. so the cause and the
event of failiure are separated.

* added RegexDatatypeHandler which was missing for the custom datatype
* configured the dicomUIDOrgRoot as RegexValidatedTextDatatype with a regex
ensuring proper DICOM UID is entered by the admin
* update test datasets GP of dicomUIDOrgRoot

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-107

