### PR TITLE
Can now import templates into the system. 

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -52,6 +52,11 @@
 			<artifactId>openmrs-test</artifactId>
 			<type>pom</type>
 		</dependency>
+		<dependency>
+	  		<groupId>org.jsoup</groupId>
+	  		<artifactId>jsoup</artifactId>
+	  		<version>1.9.2</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<resources>

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
@@ -38,6 +38,8 @@ public class RadiologyConstants {
     
     public static final String GP_RADIOLOGY_VISIT_TYPE = "radiology.radiologyVisitType";
     
+    public static final String GP_MRRT_REPORT_TEMPLATE_DIR = "radiology.reportTemplatesHome";
+    
     private RadiologyConstants() {
         // Utility class not meant to be instantiated.
     }

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyPrivileges.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyPrivileges.java
@@ -22,17 +22,27 @@ public class RadiologyPrivileges {
     
     public static final String ADD_RADIOLOGY_REPORTS = "Add Radiology Reports";
     
+    public static final String ADD_RADIOLOGY_REPORT_TEMPLATES = "Add Radiology Report Templates";
+    
     public static final String DELETE_RADIOLOGY_ORDERS = "Delete Radiology Orders";
     
     public static final String DELETE_RADIOLOGY_REPORTS = "Delete Radiology Reports";
     
+    public static final String DELETE_RADIOLOGY_REPORT_TEMPLATES = "Delete Radiology Report Templates";
+    
     public static final String EDIT_RADIOLOGY_REPORTS = "Edit Radiology Reports";
+    
+    public static final String EDIT_RADIOLOGY_REPORT_TEMPLATES = "Edit Radiology Report Templates";
     
     public static final String GET_RADIOLOGY_ORDERS = "Get Radiology Orders";
     
     public static final String GET_RADIOLOGY_REPORTS = "Get Radiology Reports";
     
+    public static final String GET_RADIOLOGY_REPORT_TEMPLATES = "Get Radiology Report Templates";
+    
     public static final String VIEW_RADIOLOGY_SECTION = "Patient Dashboard - View Radiology Section";
+    
+    public static final String VIEW_RADIOLOGY_REPORT_TEMPLATES = "View Radiology Report Templates";
     
     private RadiologyPrivileges() {
         // Utility class not meant to be instantiated.

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
@@ -9,6 +9,10 @@
  */
 package org.openmrs.module.radiology;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import org.apache.commons.lang.StringUtils;
 import org.openmrs.CareSetting;
 import org.openmrs.ConceptClass;
@@ -21,6 +25,7 @@ import org.openmrs.api.ConceptService;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.VisitService;
+import org.openmrs.util.OpenmrsUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -230,5 +235,27 @@ public class RadiologyProperties {
             throw new IllegalStateException("Configuration required: " + globalPropertyName);
         }
         return result;
+    }
+    
+    /**
+     * Gets folder to store {@code MRRT} templates.
+     * 
+     * @return templates folder
+     * @should return directory specified by global property
+     */
+    public File getReportTemplateHome() {
+        
+        Path templatesPath = Paths.get(getGlobalProperty(RadiologyConstants.GP_MRRT_REPORT_TEMPLATE_DIR, true));
+        
+        if (!templatesPath.isAbsolute()) {
+            templatesPath = Paths.get(OpenmrsUtil.getApplicationDataDirectory(), templatesPath.toString());
+        }
+        if (!templatesPath.toFile()
+                .exists()) {
+            templatesPath.toFile()
+                    .mkdirs();
+        }
+        
+        return templatesPath.toFile();
     }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/DefaultMrrtReportTemplateFileParser.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/DefaultMrrtReportTemplateFileParser.java
@@ -1,0 +1,109 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Component;
+
+/**
+ * A parser to parse MRRT report templates and and return an MrrtReportTemplate object.
+ */
+@Component
+class DefaultMrrtReportTemplateFileParser implements MrrtReportTemplateFileParser {
+    
+    
+    private static final Log log = LogFactory.getLog(DefaultMrrtReportTemplateFileParser.class);
+    
+    private static final String DCTERMS_TITLE = "dcterms.title";
+    
+    private static final String DCTERMS_DESCRIPTION = "dcterms.description";
+    
+    private static final String DCTERMS_IDENTIFIER = "dcterms.identifier";
+    
+    private static final String DCTERMS_TYPE = "dcterms.type";
+    
+    private static final String DCTERMS_LANGUAGE = "dcterms.language";
+    
+    private static final String DCTERMS_PUBLISHER = "dcterms.publisher";
+    
+    private static final String DCTERMS_RIGHTS = "dcterms.rights";
+    
+    private static final String DCTERMS_LICENSE = "dcterms.license";
+    
+    private static final String DCTERMS_DATE = "dcterms.date";
+    
+    private static final String DCTERMS_CREATOR = "dcterms.creator";
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateFileParser#parse(InputStream)
+     */
+    @Override
+    public MrrtReportTemplate parse(InputStream in) throws IOException {
+        
+        Document doc = Jsoup.parse(in, null, "");
+        MrrtReportTemplate result = new MrrtReportTemplate();
+        initializeTemplate(result, doc);
+        return result;
+    }
+    
+    private final void initializeTemplate(MrrtReportTemplate template, Document doc) {
+        Elements metaTags = doc.getElementsByTag("meta");
+        
+        template.setPath(doc.baseUri());
+        template.setCharset(metaTags.attr("charset"));
+        for (Element metaTag : metaTags) {
+            String name = metaTag.attr("name");
+            String content = metaTag.attr("content");
+            
+            switch (name) {
+                case DCTERMS_TITLE:
+                    template.setDcTermsTitle(content);
+                    break;
+                case DCTERMS_DESCRIPTION:
+                    template.setDcTermsDescription(content);
+                    break;
+                case DCTERMS_IDENTIFIER:
+                    template.setDcTermsIdentifier(content);
+                    break;
+                case DCTERMS_TYPE:
+                    template.setDcTermsType(content);
+                    break;
+                case DCTERMS_LANGUAGE:
+                    template.setDcTermsLanguage(content);
+                    break;
+                case DCTERMS_PUBLISHER:
+                    template.setDcTermsPublisher(content);
+                    break;
+                case DCTERMS_RIGHTS:
+                    template.setDcTermsRights(content);
+                    break;
+                case DCTERMS_LICENSE:
+                    template.setDcTermsLicense(content);
+                    break;
+                case DCTERMS_DATE:
+                    template.setDcTermsDate(content);
+                    break;
+                case DCTERMS_CREATOR:
+                    template.setDcTermsCreator(content);
+                    break;
+                default:
+                    log.debug("Unhandled meta tag " + name);
+            }
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/HibernateMrrtReportTemplateDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/HibernateMrrtReportTemplateDAO.java
@@ -1,0 +1,108 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.Criteria;
+import org.hibernate.SessionFactory;
+import org.hibernate.criterion.MatchMode;
+import org.hibernate.criterion.Restrictions;
+
+/**
+ * Hibernate specific MrrtReportTemplate related functions. This class should not be used directly. All
+ * calls should go through the {@link org.openmrs.module.radiology.report.template.MrrtReportTemplateService} methods.
+ *
+ * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateDAO
+ * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService
+ */
+class HibernateMrrtReportTemplateDAO implements MrrtReportTemplateDAO {
+    
+    
+    private SessionFactory sessionFactory;
+    
+    /**
+     * Set session factory that allows us to connect to the database that Hibernate knows about.
+     *
+     * @param sessionFactory SessionFactory
+     */
+    public void setSessionFactory(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplate(Integer)
+     */
+    @Override
+    public MrrtReportTemplate getMrrtReportTemplate(Integer templateId) {
+        return (MrrtReportTemplate) sessionFactory.getCurrentSession()
+                .get(MrrtReportTemplate.class, templateId);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByUuid(String)
+     */
+    @Override
+    public MrrtReportTemplate getMrrtReportTemplateByUuid(String uuid) {
+        final Criteria criteria = createMrrtReportTemplateCriteria();
+        criteria.add(Restrictions.eq("uuid", uuid));
+        return (MrrtReportTemplate) criteria.uniqueResult();
+    }
+    
+    @Override
+    public MrrtReportTemplate getMrrtReportTemplateByIdentifier(String identifier) {
+        final Criteria criteria = createMrrtReportTemplateCriteria();
+        criteria.add(Restrictions.eq("dcTermsIdentifier", identifier));
+        return (MrrtReportTemplate) criteria.uniqueResult();
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByTitle(String)
+     */
+    @Override
+    public List<MrrtReportTemplate> getMrrtReportTemplateByTitle(String title) {
+        
+        final Criteria criteria = createMrrtReportTemplateCriteria();
+        criteria.add(Restrictions.ilike("dcTermsTitle", title + "%", MatchMode.ANYWHERE));
+        @SuppressWarnings("unchecked")
+        List<MrrtReportTemplate> result = (List<MrrtReportTemplate>) criteria.list();
+        return result == null ? new ArrayList<MrrtReportTemplate>() : result;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#saveMrrtReportTemplate(MrrtReportTemplate)
+     */
+    @Override
+    public MrrtReportTemplate saveMrrtReportTemplate(MrrtReportTemplate template) {
+        sessionFactory.getCurrentSession()
+                .save(template);
+        return template;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#purgeMrrtReportTemplate(MrrtReportTemplate)
+     */
+    @Override
+    public void purgeMrrtReportTemplate(MrrtReportTemplate template) {
+        sessionFactory.getCurrentSession()
+                .delete(template);
+    }
+    
+    /**
+     * A utility method creating a criteria for MrrtReportTemplate
+     *
+     * @return criteria for MrrtReportTemplate
+     */
+    private Criteria createMrrtReportTemplateCriteria() {
+        return sessionFactory.getCurrentSession()
+                .createCriteria(MrrtReportTemplate.class);
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplate.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplate.java
@@ -1,0 +1,161 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import org.openmrs.BaseOpenmrsData;
+
+/**
+ * IHE Management of Radiology Report Templates (MRRT)
+ */
+public class MrrtReportTemplate extends BaseOpenmrsData {
+    
+    
+    private static final long serialVersionUID = 4135353950631883493L;
+    
+    private Integer templateId;
+    
+    private String charset;
+    
+    private String path;
+    
+    private String dcTermsTitle;
+    
+    private String dcTermsDescription;
+    
+    private String dcTermsIdentifier;
+    
+    private String dcTermsType;
+    
+    private String dcTermsLanguage;
+    
+    private String dcTermsPublisher;
+    
+    private String dcTermsRights;
+    
+    private String dcTermsLicense;
+    
+    private String dcTermsDate;
+    
+    private String dcTermsCreator;
+    
+    @Override
+    public Integer getId() {
+        return this.templateId;
+    }
+    
+    @Override
+    public void setId(Integer id) {
+        this.templateId = id;
+    }
+    
+    public Integer getTemplateId() {
+        return getId();
+    }
+    
+    public void setTemplateId(Integer templateId) {
+        setId(templateId);
+    }
+    
+    public String getCharset() {
+        return charset;
+    }
+    
+    public void setCharset(String charset) {
+        this.charset = charset;
+    }
+    
+    public String getPath() {
+        return path;
+    }
+    
+    public void setPath(String path) {
+        this.path = path;
+    }
+    
+    public String getDcTermsTitle() {
+        return dcTermsTitle;
+    }
+    
+    public void setDcTermsTitle(String dcTermsTitle) {
+        this.dcTermsTitle = dcTermsTitle;
+    }
+    
+    public String getDcTermsDescription() {
+        return dcTermsDescription;
+    }
+    
+    public void setDcTermsDescription(String dcTermsDescription) {
+        this.dcTermsDescription = dcTermsDescription;
+    }
+    
+    public String getDcTermsIdentifier() {
+        return dcTermsIdentifier;
+    }
+    
+    public void setDcTermsIdentifier(String dcTermsIdentifier) {
+        this.dcTermsIdentifier = dcTermsIdentifier;
+    }
+    
+    public String getDcTermsType() {
+        return dcTermsType;
+    }
+    
+    public void setDcTermsType(String dcTermsType) {
+        this.dcTermsType = dcTermsType;
+    }
+    
+    public String getDcTermsLanguage() {
+        return dcTermsLanguage;
+    }
+    
+    public void setDcTermsLanguage(String dcTermsLanguage) {
+        this.dcTermsLanguage = dcTermsLanguage;
+    }
+    
+    public String getDcTermsPublisher() {
+        return dcTermsPublisher;
+    }
+    
+    public void setDcTermsPublisher(String dcTermsPublisher) {
+        this.dcTermsPublisher = dcTermsPublisher;
+    }
+    
+    public String getDcTermsRights() {
+        return dcTermsRights;
+    }
+    
+    public void setDcTermsRights(String dcTermsRights) {
+        this.dcTermsRights = dcTermsRights;
+    }
+    
+    public String getDcTermsLicense() {
+        return dcTermsLicense;
+    }
+    
+    public void setDcTermsLicense(String dcTermsLicense) {
+        this.dcTermsLicense = dcTermsLicense;
+    }
+    
+    public String getDcTermsDate() {
+        return dcTermsDate;
+    }
+    
+    public void setDcTermsDate(String dcTermsDate) {
+        this.dcTermsDate = dcTermsDate;
+    }
+    
+    public String getDcTermsCreator() {
+        return dcTermsCreator;
+    }
+    
+    public void setDcTermsCreator(String dcTermsCreator) {
+        this.dcTermsCreator = dcTermsCreator;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateDAO.java
@@ -1,0 +1,52 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import java.util.List;
+
+/**
+ * {@code MrrTReportTemplate} related database methods.
+ * 
+ * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService
+ * @see org.openmrs.module.radiology.report.template.MrrtReportTemplate
+ */
+interface MrrtReportTemplateDAO {
+    
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplate(Integer)
+     */
+    public MrrtReportTemplate getMrrtReportTemplate(Integer templateId);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByUuid(String)
+     */
+    public MrrtReportTemplate getMrrtReportTemplateByUuid(String uuid);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByIdentifier(String)
+     */
+    public MrrtReportTemplate getMrrtReportTemplateByIdentifier(String identifier);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByTitle(String)
+     */
+    public List<MrrtReportTemplate> getMrrtReportTemplateByTitle(String title);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#saveMrrtReportTemplate(MrrtReportTemplate)
+     */
+    public MrrtReportTemplate saveMrrtReportTemplate(MrrtReportTemplate template);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#purgeMrrtReportTemplate(MrrtReportTemplate)
+     */
+    public void purgeMrrtReportTemplate(MrrtReportTemplate template);
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParser.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParser.java
@@ -1,0 +1,29 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A parser that is responsible for parsing mrrt report templates and extract metadata.
+ */
+public interface MrrtReportTemplateFileParser {
+    
+    
+    /**
+     * Parse an {@code MRRT} template and extract metadata into a {@code MrrtReportTemplate}.
+     * 
+     * @param in the input stream containing the mrrt template
+     * @return the mrrt report template extracted from the input stream
+     * @throws IOException if the template file could not be read
+     */
+    public MrrtReportTemplate parse(InputStream in) throws IOException;
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateService.java
@@ -1,0 +1,116 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.openmrs.annotation.Authorized;
+import org.openmrs.api.OpenmrsService;
+import org.openmrs.module.radiology.RadiologyPrivileges;
+
+/**
+ * Service layer for {@code MrrtReportTemplate}.
+ * 
+ * @see org.openmrs.module.radiology.report.template.MrrtReportTemplate
+ */
+public interface MrrtReportTemplateService extends OpenmrsService {
+    
+    
+    /**
+     * Import an {@code MrrtReportTemplate} into the system.
+     * 
+     * @param in the input stream of the mrrt template file
+     * @throws IOException if OpenmrsUtil.copyFile throws one
+     * TODO improve javadoc for exceptions and add tests
+     * @should create mrrt report template in the database with metadata from input stream
+     * @should create report template file in report template home directory
+     * @should close input stream after report template file has been created
+     */
+    @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_REPORT_TEMPLATES)
+    public void importMrrtReportTemplate(InputStream in) throws IOException;
+    
+    /**
+     * Get an {@code MrrtReportTemplate} with a given id.
+     * 
+     * @param id the {MrrtReportTemplate} id
+     * @return {@code MrrtReportTemplate} with given id
+     * @throws IllegalArgumentException if given null
+     * @should get template with given id
+     * @should return null if no match was found
+     * @should throw illegal argument exception if given null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORT_TEMPLATES)
+    public MrrtReportTemplate getMrrtReportTemplate(Integer id);
+    
+    /**
+     * Get {@code MrrtReportTemplate} by its UUID.
+     *
+     * @param uuid UUID of {@code MrrtReportTemplate}
+     * @return mrrt {@code MrrtReportTemplate} object or null
+     * @throws IllegalArgumentException if given null
+     * @should find object given existing uuid
+     * @should return null if no object found with given uuid
+     * @should throw illegal argument exception if given null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORT_TEMPLATES)
+    public MrrtReportTemplate getMrrtReportTemplateByUuid(String uuid);
+    
+    /**
+     * Get {@code MrrtReportTemplate} by its identifier.
+     * 
+     * @param identifier dublin identifier for {@code MrrtReportTemplate}
+     * @return {@code MrrtReportTemplate} object or null
+     * @throws IllegalArgumentException if given null
+     * @should find object given valid identifier
+     * @should return null if no object found with give identifier
+     * @should throw illegal argument exception if given null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORT_TEMPLATES)
+    public MrrtReportTemplate getMrrtReportTemplateByIdentifier(String identifier);
+    
+    /**
+     * Get list of {@code MrrtReportTemplate} objects matching a particular title.
+     * 
+     * @param title title of {@code MrrtReportTemplate}
+     * @return list of {@code MrrtReportTemplate} objects matching title
+     * @throws IllegalArgumentException if given null
+     * @should get list of templates that match given title
+     * @should return empty list of no match is found
+     * @should throw illegal argument exception if given null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORT_TEMPLATES)
+    public List<MrrtReportTemplate> getMrrtReportTemplateByTitle(String title);
+    
+    /**
+     * Saves a new or existing {@code MrrtReportTemplate}.
+     *
+     * @param template the {@code MrrtReportTemplate} to save
+     * @return the saved template
+     * @throws IllegalArgumentException if given null
+     * @should throw illegal argument exception if given null
+     * @should save given template
+     * @should prevent template editing
+     */
+    @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_REPORT_TEMPLATES)
+    public MrrtReportTemplate saveMrrtReportTemplate(MrrtReportTemplate template);
+    
+    /**
+     * Delete an {@code MrrtReportTemplate} from the database.
+     *
+     * @param template the {@code MrrtReportTemplate} that is been deleted
+     * @throws IllegalArgumentException if given null
+     * @should delete report from database
+     * @should throw illigal argument exception if given null
+     */
+    @Authorized(RadiologyPrivileges.DELETE_RADIOLOGY_REPORT_TEMPLATES)
+    public void purgeMrrtReportTemplate(MrrtReportTemplate template);
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceImpl.java
@@ -1,0 +1,137 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.openmrs.api.APIException;
+import org.openmrs.api.impl.BaseOpenmrsService;
+import org.openmrs.module.radiology.RadiologyProperties;
+import org.openmrs.util.OpenmrsUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+class MrrtReportTemplateServiceImpl extends BaseOpenmrsService implements MrrtReportTemplateService {
+    
+    
+    @Autowired
+    private MrrtReportTemplateFileParser parser;
+    
+    @Autowired
+    private RadiologyProperties radiologyProperties;
+    
+    private MrrtReportTemplateDAO mrrtReportTemplateDAO;
+    
+    public MrrtReportTemplateDAO getMrrtReportTemplateDAO() {
+        return mrrtReportTemplateDAO;
+    }
+    
+    public void setMrrtReportTemplateDAO(MrrtReportTemplateDAO mrrtReportTemplateDAO) {
+        this.mrrtReportTemplateDAO = mrrtReportTemplateDAO;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#importMrrtReportTemplate(InputStream)
+     */
+    @Override
+    @Transactional
+    public void importMrrtReportTemplate(InputStream in) throws IOException {
+        File tmp = File.createTempFile(java.util.UUID.randomUUID()
+                .toString(),
+            java.util.UUID.randomUUID()
+                    .toString());
+        OpenmrsUtil.copyFile(in, new FileOutputStream(tmp));
+        MrrtReportTemplate template = parser.parse(new FileInputStream(tmp));
+        File destinationFile = new File(radiologyProperties.getReportTemplateHome(), java.util.UUID.randomUUID()
+                .toString());
+        template.setPath(destinationFile.getAbsolutePath());
+        saveMrrtReportTemplate(template);
+        OpenmrsUtil.copyFile(new FileInputStream(tmp), new FileOutputStream(destinationFile));
+        in.close();
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplate(Integer)
+     */
+    @Override
+    public MrrtReportTemplate getMrrtReportTemplate(Integer id) {
+        if (id == null) {
+            throw new IllegalArgumentException("id cannot be null");
+        }
+        return mrrtReportTemplateDAO.getMrrtReportTemplate(id);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByUuid(String)
+     */
+    @Override
+    public MrrtReportTemplate getMrrtReportTemplateByUuid(String uuid) {
+        if (uuid == null) {
+            throw new IllegalArgumentException("uuid cannot be null");
+        }
+        return mrrtReportTemplateDAO.getMrrtReportTemplateByUuid(uuid);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByIdentifier(String)
+     */
+    @Override
+    public MrrtReportTemplate getMrrtReportTemplateByIdentifier(String identifier) {
+        if (identifier == null) {
+            throw new IllegalArgumentException("identifier cannot be null");
+        }
+        return mrrtReportTemplateDAO.getMrrtReportTemplateByIdentifier(identifier);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#getMrrtReportTemplateByTitle(String)
+     */
+    @Override
+    public List<MrrtReportTemplate> getMrrtReportTemplateByTitle(String title) {
+        if (title == null) {
+            throw new IllegalArgumentException("title cannot be null");
+        }
+        return mrrtReportTemplateDAO.getMrrtReportTemplateByTitle(title);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#saveMrrtReportTemplate(MrrtReportTemplate)
+     */
+    @Override
+    @Transactional
+    public MrrtReportTemplate saveMrrtReportTemplate(MrrtReportTemplate template) {
+        if (template == null) {
+            throw new IllegalArgumentException("template cannot be null");
+        }
+        MrrtReportTemplate existing = getMrrtReportTemplateByIdentifier(template.getDcTermsIdentifier());
+        if (existing != null) {
+            throw new APIException("Template already exist in the system.");
+        }
+        return mrrtReportTemplateDAO.saveMrrtReportTemplate(template);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#purgeMrrtReportTemplate(MrrtReportTemplate)
+     */
+    @Override
+    @Transactional
+    public void purgeMrrtReportTemplate(MrrtReportTemplate template) {
+        if (template == null) {
+            throw new IllegalArgumentException("template cannot be null");
+        }
+        mrrtReportTemplateDAO.purgeMrrtReportTemplate(template);
+    }
+}

--- a/api/src/main/resources/MrrtReportTemplate.hbm.xml
+++ b/api/src/main/resources/MrrtReportTemplate.hbm.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping package="org.openmrs.module.radiology">
+	<class name="org.openmrs.module.radiology.report.template.MrrtReportTemplate"
+		table="radiology_report_template" lazy="false">
+		<id name="templateId" column="template_id">
+			<generator class="native">
+				<param name="sequence">radiology_report_template_template_id_seq</param>
+			</generator>
+		</id>
+
+		<property name="charset" type="java.lang.String"/>
+		<property name="path" type="java.lang.String"/>
+		<property name="dcTermsTitle" column="dcterms_title" type="java.lang.String" />
+		<property name="dcTermsDescription" column="dcterms_description" type="java.lang.String"/>
+		<property name="dcTermsIdentifier" column="dcterms_identifier" type="java.lang.String" unique="true"
+			not-null="true"/>
+		<property name="dcTermsType" column="dcterms_type" type="java.lang.String"/>
+		<property name="dcTermsLanguage" column="dcterms_language" type="java.lang.String"/>
+		<property name="dcTermsPublisher" column="dcterms_publisher" type="java.lang.String"/>
+		<property name="dcTermsRights" column="dcterms_rights" type="java.lang.String"/>
+		<property name="dcTermsLicense" column="dcterms_license" type="java.lang.String"/>
+		<property name="dcTermsDate" column="dcterms_date" type="java.lang.String"/>
+		<property name="dcTermsCreator" column="dcterms_creator" type="java.lang.String"/>
+		<many-to-one name="creator" class="org.openmrs.User"
+			not-null="true" />
+		<property name="dateCreated" type="java.util.Date" column="date_created"
+			not-null="true" />
+		<many-to-one name="changedBy" column="changed_by" class="org.openmrs.User" />
+		<property name="dateChanged" type="java.util.Date" column="date_changed" />
+		<property name="uuid" type="java.lang.String" column="uuid" length="38" unique="true" />
+	</class>
+</hibernate-mapping>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -364,4 +364,61 @@
 			</column>
 		</addColumn>
 	</changeSet>
+	<changeSet id="radiology-31" author="ivange94">
+		<comment>Add table for report templates</comment>
+		<createTable tableName="radiology_report_template">
+			<column name="template_id" type="int" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+
+			<column name="charset" type="varchar(32)"/>
+			<column name="path" type="varchar(128)"/>
+			<column name="dcterms_title" type="varchar(256)"/>
+			<column name="dcterms_description" type="text"/>
+			<column name="dcterms_identifier" type="varchar(128)">
+				<constraints nullable="false" unique="true"/>
+			</column>
+			<column name="dcterms_type" type="varchar(32)"/>
+			<column name="dcterms_language" type="varchar(8)"/>
+			<column name="dcterms_publisher" type="varchar(128)"/>
+			<column name="dcterms_rights" type="varchar(128)"/>
+			<column name="dcterms_license" type="varchar(128)"/>
+			<column name="dcterms_date" type="varchar(32)"/>
+			<column name="dcterms_creator" type="varchar(128)"/> 
+			<column name="creator" type="int" defaultValueNumeric="0">
+				<constraints nullable="false" />
+			</column>
+			<column name="date_created" type="datetime">
+				<constraints nullable="false" />
+			</column>
+			<column name="changed_by" type="int" />
+			<column name="date_changed" type="datetime" />
+			<column name="uuid" type="char(38)">
+				<constraints nullable="false" unique="true" />
+			</column>
+		</createTable>
+	</changeSet>
+	<changeSet id="radiology-32" author="ivange94">
+		<comment>Add privilege to work with radiology report templates</comment>
+		<insert tableName="privilege">
+			<column name="privilege" value="Add Radiology Report Templates"/>
+			<column name="description" value="Able to add new report templates"/>
+			<column name="uuid" value="dbc5c91c-a7d0-4012-9447-0168e89b2d3f"/>
+		</insert>
+		<insert tableName="privilege">
+			<column name="privilege" value="Delete Radiology Report Templates"/>
+			<column name="description" value="Able to delete report templates from system"/>
+			<column name="uuid" value="8f63b127-206d-4288-a758-3f8835ac7e1a"/>
+		</insert>
+		<insert tableName="privilege">
+			<column name="privilege" value="Get Radiology Report Templates"/>
+			<column name="description" value="Able to get report templates"/>
+			<column name="uuid" value="2de0970b-3083-48a1-8312-f16098b2fdc2"/>
+		</insert>
+		<insert tableName="privilege">
+			<column name="privilege" value="View Radiology Report Templates"/>
+			<column name="description" value="should be able to view templates"/>
+			<column name="uuid" value="f4e1983a-f2de-42b3-b6a5-7983112ce5da"/>
+		</insert>
+	</changeSet>
 </databaseChangeLog>

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -141,4 +141,39 @@
 			</list>
 		</property>
 	</bean>
+	
+	<bean id="mrrtReportTemplateService"
+		class="org.springframework.transaction.interceptor.TransactionProxyFactoryBean">
+		<property name="transactionManager">
+			<ref bean="transactionManager" />
+		</property>
+		<property name="target">
+			<bean
+				class="org.openmrs.module.radiology.report.template.MrrtReportTemplateServiceImpl">
+				<property name="mrrtReportTemplateDAO">
+					<bean
+						class="org.openmrs.module.radiology.report.template.HibernateMrrtReportTemplateDAO">
+						<property name="sessionFactory">
+							<ref bean="sessionFactory" />
+						</property>
+					</bean>
+				</property>
+			</bean>
+		</property>
+		<property name="preInterceptors">
+			<ref bean="serviceInterceptors" />
+		</property>
+		<property name="transactionAttributeSource">
+			<ref bean="transactionAttributeSource" />
+		</property>
+	</bean>
+	
+	<bean parent="serviceContext">
+		<property name="moduleService">
+			<list merge="true">
+				<value>org.openmrs.module.radiology.report.template.MrrtReportTemplateService</value>
+				<ref local="mrrtReportTemplateService" />
+			</list>
+		</property>
+	</bean>
 </beans>

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
@@ -11,8 +11,10 @@ package org.openmrs.module.radiology;
 
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
+import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.LinkedList;
@@ -22,6 +24,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 import org.openmrs.ConceptClass;
 import org.openmrs.EncounterRole;
 import org.openmrs.EncounterType;
@@ -64,6 +67,9 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+    
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
     
     private Method getGlobalPropertyMethod = null;
     
@@ -536,4 +542,19 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
         
         getGlobalPropertyMethod.invoke(radiologyProperties, new Object[] { RadiologyConstants.GP_DICOM_UID_ORG_ROOT, true });
     }
+    
+    /**
+    * @see RadiologyProperties#getReportTemplateHome()
+    * @verifies return directory specified by global property
+    */
+    @Test
+    public void getReportTemplateHome_shouldReturnDirectorySpecifiedByGlobalProperty() throws Exception {
+        temporaryFolder.newFolder("mrrt_templates");
+        administrationService.setGlobalProperty(RadiologyConstants.GP_MRRT_REPORT_TEMPLATE_DIR, "mrrt_templates");
+        File templateHome = radiologyProperties.getReportTemplateHome();
+        assertNotNull(templateHome);
+        assertThat(templateHome.exists(), is(true));
+        assertThat(templateHome.getName(), is("mrrt_templates"));
+    }
+    
 }

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParserTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParserTest.java
@@ -1,0 +1,91 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Tests {@code MrrtReportTemplateFileParser}.
+ */
+public class MrrtReportTemplateFileParserTest {
+    
+    
+    private MrrtReportTemplateFileParser parser;
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    private static final String CHARSET = "UTF-8";
+    
+    private static final String TEST_DCTERMS_TITLE = "Cardiac MRI: Function and Viability";
+    
+    private static final String TEST_DCTERMS_DESCRIPTION =
+            "Cardiac MRI: Function and Viability template :: Authored by Jacobs JE, et al. ";
+    
+    private static final String TEST_DCTERMS_IDENTIFIER = "http://www.radreport.org/template/0000049";
+    
+    private static final String TEST_DCTERMS_LANGUAGE = "en";
+    
+    private static final String TEST_DCTERMS_TYPE = "IMAGE_REPORT_TEMPLATE";
+    
+    private static final String TEST_DCTERMS_PUBLISHER = "Radiological Society of North America (RSNA)";
+    
+    private static final String TEST_DCTERMS_RIGHTS = "May be used gratis, subject to license agreement";
+    
+    private static final String TEST_DCTERMS_LICENSE = "http://www.radreport.org/license.pdf";
+    
+    private static final String TEST_DCTERMS_DATE = "2012-07-19";
+    
+    private static final String TEST_DCTERMS_CREATOR = "Jacobs JE, et al. ";
+    
+    @Before
+    public void setup() {
+        parser = new DefaultMrrtReportTemplateFileParser();
+    }
+    
+    /**
+     * @see MrrtReportTemplateFileParser#parse()
+     * @verifies return an mrrt template object if file is valid
+     */
+    @Test
+    public void parse_shouldReturnAnMrrtTemplateObjectIfFileIsValid() throws Exception {
+        File file = new File(getClass().getClassLoader()
+                .getResource("mrrttemplates/radreport/0000049.html")
+                .getFile());
+        
+        FileInputStream in = new FileInputStream(file);
+        MrrtReportTemplate template = parser.parse(in);
+        in.close();
+        
+        assertNotNull(template);
+        assertThat(template.getCharset(), is(CHARSET));
+        assertThat(template.getDcTermsTitle(), is(TEST_DCTERMS_TITLE));
+        assertThat(template.getDcTermsDescription(), is(TEST_DCTERMS_DESCRIPTION));
+        assertThat(template.getDcTermsIdentifier(), is(TEST_DCTERMS_IDENTIFIER));
+        assertThat(template.getDcTermsLanguage(), is(TEST_DCTERMS_LANGUAGE));
+        assertThat(template.getDcTermsLanguage(), is(TEST_DCTERMS_LANGUAGE));
+        assertThat(template.getDcTermsType(), is(TEST_DCTERMS_TYPE));
+        assertThat(template.getDcTermsPublisher(), is(TEST_DCTERMS_PUBLISHER));
+        assertThat(template.getDcTermsRights(), is(TEST_DCTERMS_RIGHTS));
+        assertThat(template.getDcTermsLicense(), is(TEST_DCTERMS_LICENSE));
+        assertThat(template.getDcTermsDate(), is(TEST_DCTERMS_DATE));
+        assertThat(template.getDcTermsCreator(), is(TEST_DCTERMS_CREATOR));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
@@ -1,0 +1,267 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openmrs.api.APIException;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class MrrtReportTemplateServiceComponentTest extends BaseModuleContextSensitiveTest {
+    
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    private static final String TEST_DATASET =
+            "org/openmrs/module/radiology/include/MrrtReportTemplateServiceComponentTestDataset.xml";
+    
+    private static final int EXISTING_TEMPLATE_ID = 1;
+    
+    private static final int NON_EXISTING_TEMPLATE_ID = 23;
+    
+    private static final String EXISTING_UUID = "2379d290-96f7-408a-bbae-270387e3b92e";
+    
+    private static final String NON_EXISTING_UUID = "invalid uuid";
+    
+    private static final String EXISTING_TEMPLATE_TITLE = "title1";
+    
+    private static final String NON_EXISTING_TEMPLATE_TITLE = "invalid";
+    
+    @Autowired
+    private MrrtReportTemplateService mrrtReportTemplateService;
+    
+    @Before
+    public void setUp() throws Exception {
+        executeDataSet(TEST_DATASET);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplate(Integer)
+    * @verifies get template with given id
+    */
+    @Test
+    public void getMrrtReportTemplate_shouldGetTemplateWithGivenId() throws Exception {
+        MrrtReportTemplate existingTemplate = mrrtReportTemplateService.getMrrtReportTemplate(EXISTING_TEMPLATE_ID);
+        
+        assertNotNull(existingTemplate);
+        assertEquals(existingTemplate.getCharset(), "UTF-8");
+        assertEquals(existingTemplate.getDcTermsTitle(), "title1");
+        assertEquals(existingTemplate.getDcTermsLanguage(), "en");
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplate(Integer)
+    * @verifies return null if no match was found
+    */
+    @Test
+    public void getMrrtReportTemplate_shouldReturnNullIfNoMatchWasFound() throws Exception {
+        assertNull(mrrtReportTemplateService.getMrrtReportTemplate(NON_EXISTING_TEMPLATE_ID));
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplate(Integer)
+    * @verifies throw illegal argument exception if given null
+    */
+    @Test
+    public void getMrrtReportTemplate_shouldThrowIllegalArgumentExceptionIfGivenNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("id cannot be null");
+        mrrtReportTemplateService.getMrrtReportTemplate(null);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplateByUuid(String)
+    * @verifies find object given existing uuid
+    */
+    @Test
+    public void getMrrtReportTemplateByUuid_shouldFindObjectGivenExistingUuid() {
+        MrrtReportTemplate valid = mrrtReportTemplateService.getMrrtReportTemplateByUuid(EXISTING_UUID);
+        
+        assertNotNull(valid);
+        assertThat(valid.getTemplateId(), is(EXISTING_TEMPLATE_ID));
+        assertThat(valid.getUuid(), is(EXISTING_UUID));
+    }
+    
+    /**
+     * @see MrrtReportTemplateService#getMrrtReportTemplateByUuid(String)
+     * @verifies return null if no object found with given uuid
+     */
+    @Test
+    public void getMrrtReportTemplateByUuid_shouldReturnNullIfNoObjectFoundWithGivenUuid() {
+        assertNull(mrrtReportTemplateService.getMrrtReportTemplateByUuid(NON_EXISTING_UUID));
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplateByUuid(String)
+    * @verifies throw illegal argument exception if given null
+    */
+    @Test
+    public void getMrrtReportTemplateByUuid_shouldThrowIllegalArgumentExceptionIfGivenNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("uuid cannot be null");
+        mrrtReportTemplateService.getMrrtReportTemplateByUuid(null);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplateByIdentifier(String)
+    * @verifies find object given valid identifier
+    */
+    @Test
+    public void getMrrtReportTemplateByIdentifier_shouldFindObjectGivenValidIdentifier() throws Exception {
+        MrrtReportTemplate template = mrrtReportTemplateService.getMrrtReportTemplateByIdentifier("identifier1");
+        
+        assertNotNull(template);
+        assertThat(template.getDcTermsIdentifier(), is("identifier1"));
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplateByIdentifier(String)
+    * @verifies return null if no object found with give identifier
+    */
+    @Test
+    public void getMrrtReportTemplateByIdentifier_shouldReturnNullIfNoObjectFoundWithGiveIdentifier() throws Exception {
+        assertNull(mrrtReportTemplateService.getMrrtReportTemplateByIdentifier("invalid identifier"));
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplateByIdentifier(String)
+    * @verifies throw illegal argument exception if given null
+    */
+    @Test
+    public void getMrrtReportTemplateByIdentifier_shouldThrowIllegalArgumentExceptionIfGivenNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("identifier cannot be null");
+        mrrtReportTemplateService.getMrrtReportTemplateByIdentifier(null);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplateByTitle(String)
+    * @verifies should get list of templates that match given title
+    */
+    @Test
+    public void getMrrtReportTemplateByTitle_shouldGetListOfTemplatesThatMatchGivenTitle() throws Exception {
+        List<MrrtReportTemplate> templates = mrrtReportTemplateService.getMrrtReportTemplateByTitle(EXISTING_TEMPLATE_TITLE);
+        
+        assertNotNull(templates);
+        assertThat(templates.size(), is(1));
+        for (MrrtReportTemplate template : templates) {
+            assertThat(template.getDcTermsTitle()
+                    .contains(EXISTING_TEMPLATE_TITLE),
+                is(true));
+        }
+    }
+    
+    /**
+     * @see MrrtReportTemplateService#getMrrtReportTemplateByTitle(String)
+     * @verifies should return empty list of no match is found
+     */
+    @Test
+    public void getMrrtReportTemplateByTitle_shouldReturnEmptyListOfNoMatchIsFound() throws Exception {
+        List<MrrtReportTemplate> templates =
+                mrrtReportTemplateService.getMrrtReportTemplateByTitle(NON_EXISTING_TEMPLATE_TITLE);
+        assertNotNull(templates);
+        assertEquals(templates.isEmpty(), true);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#getMrrtReportTemplateByTitle(String)
+    * @verifies throw illegal argument exception if given null
+    */
+    @Test
+    public void getMrrtReportTemplateByTitle_shouldThrowIllegalArgumentExceptionIfGivenNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("title cannot be null");
+        mrrtReportTemplateService.getMrrtReportTemplateByTitle(null);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#purgeMrrtReportTemplate(MrrtReportTemplate)
+    * @verifies delete report from database
+    */
+    @Test
+    public void purgeMrrtReportTemplate_shouldDeleteReportFromDatabase() throws Exception {
+        MrrtReportTemplate template = mrrtReportTemplateService.getMrrtReportTemplate(EXISTING_TEMPLATE_ID);
+        
+        assertNotNull(template);
+        mrrtReportTemplateService.purgeMrrtReportTemplate(template);
+        
+        MrrtReportTemplate deleted = mrrtReportTemplateService.getMrrtReportTemplate(EXISTING_TEMPLATE_ID);
+        assertNull(deleted);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#purgeMrrtReportTemplate(MrrtReportTemplate)
+    * @verifies throw illigal argument exception if given null
+    */
+    @Test
+    public void purgeMrrtReportTemplate_shouldThrowIlligalArgumentExceptionIfGivenNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("template cannot be null");
+        mrrtReportTemplateService.purgeMrrtReportTemplate(null);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#saveMrrtReportTemplate(MrrtReportTemplate)
+    * @verifies save given template
+    */
+    @Test
+    public void saveMrrtReportTemplate_shouldSaveGivenTemplate() throws Exception {
+        MrrtReportTemplate template = new MrrtReportTemplate();
+        
+        template.setDcTermsTitle("sample title");
+        template.setDcTermsDescription("sample description");
+        template.setDcTermsIdentifier("identifier3");
+        
+        MrrtReportTemplate saved = mrrtReportTemplateService.saveMrrtReportTemplate(template);
+        MrrtReportTemplate newTemplate = mrrtReportTemplateService.getMrrtReportTemplate(saved.getTemplateId());
+        
+        assertNotNull(saved);
+        assertNotNull(newTemplate);
+        assertEquals(newTemplate.getDcTermsTitle(), template.getDcTermsTitle());
+        assertEquals(newTemplate.getDcTermsDescription(), template.getDcTermsDescription());
+    }
+    
+    /**
+     * @see MrrtReportTemplateService#saveMrrtReportTemplate(MrrtReportTemplate)
+     * @verifies prevent template editing 
+     */
+    @Test
+    public void saveMrrtReportTemplate_shouldPreventTemplateEditing() {
+        MrrtReportTemplate existing = mrrtReportTemplateService.getMrrtReportTemplate(EXISTING_TEMPLATE_ID);
+        existing.setDcTermsTitle("modified");
+        expectedException.expect(APIException.class);
+        expectedException.expectMessage("Template already exist in the system.");
+        mrrtReportTemplateService.saveMrrtReportTemplate(existing);
+    }
+    
+    /**
+    * @see MrrtReportTemplateService#saveMrrtReportTemplate(MrrtReportTemplate)
+    * @verifies throw illegal argument exception if given null
+    */
+    @Test
+    public void saveMrrtReportTemplate_shouldThrowIllegalArgumentExceptionIfGivenNull() throws Exception {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("template cannot be null");
+        mrrtReportTemplateService.saveMrrtReportTemplate(null);
+    }
+    
+}

--- a/api/src/test/resources/mrrttemplates/radreport/0000049.html
+++ b/api/src/test/resources/mrrttemplates/radreport/0000049.html
@@ -1,0 +1,628 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8"/>
+<meta content="Cardiac MRI: Function and Viability" name="dcterms.title"/>
+<meta content="Cardiac MRI: Function and Viability template :: Authored by Jacobs JE, et al. " name="dcterms.description"/>
+<meta content="http://www.radreport.org/template/0000049" name="dcterms.identifier"/>
+<meta content="en" name="dcterms.language"/>
+<meta content="IMAGE_REPORT_TEMPLATE" name="dcterms.type"/>
+<meta content="Radiological Society of North America (RSNA)" name="dcterms.publisher"/>
+<meta content="May be used gratis, subject to license agreement" name="dcterms.rights"/>
+<meta content="http://www.radreport.org/license.pdf" name="dcterms.license"/>
+<meta content="2012-07-19" name="dcterms.date"/>
+<meta content="Jacobs JE, et al. " name="dcterms.creator"/>
+<meta content="Kahn CE Jr [editor]" name="dcterms.contributor"/>
+<meta content="North American Society for Cardiac Imaging (NASCI)" name="dcterms.contributor"/>
+<link rel="stylesheet" type="text/css" href="IHE_Template_Style.css"/>
+<!-- The absolute link to the CSS file is http://www.radreport.org/html/IHE_Template_Style.css -->
+<script type="text/xml">
+<!--
+<template_attributes>
+<top-level-flag>true</top-level-flag>
+<status>ACTIVE</status>
+<coding_schemes>
+ <coding_scheme name="RadLex" designator="2.16.840.1.113883.6.256" />
+ <coding_scheme name="SNOMEDCT" designator="2.16.840.1.113883.6.96" />
+ <coding_scheme name="LOINC" designator="2.16.840.1.113883.6.1" />
+</coding_schemes>
+<term>
+ <code meaning="function" value="RID28812" scheme="RadLex">
+</term>
+<term>
+ <code meaning="heart" value="RID1385" scheme="RadLex">
+</term>
+<term>
+ <code meaning="magnetic resonance imaging" value="RID10312" scheme="RadLex">
+</term>
+<term>
+ <code meaning="myocardial infarction" value="RID3236" scheme="RadLex">
+</term>
+<term>
+ <code meaning="myocardium" value="RID1398" scheme="RadLex">
+</term>
+<term>
+ <code meaning="viability" value="RID28821" scheme="RadLex">
+</term>
+<coded_content>
+<entry ORIGTXT="T49_2">
+ <term>
+  <code meaning="procedure" value="RID1559" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_11">
+ <term>
+  <code meaning="gadolinium chelate" value="RID11613" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_16">
+ <term>
+  <code meaning="comparison" value="RID28483" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_17">
+ <term>
+  <code meaning="none" value="RID28454" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_18">
+ <term>
+  <code meaning="observations section" value="RID28486" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_19">
+ <term>
+  <code meaning="left ventricle" value="RID1392" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="measurement" value="RID10409" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_20">
+   <term>
+  <code meaning="Left ventricular End diastolic [Volume] by Imaging" value="8821-1" scheme="LOINC">
+ </term>
+</entry>
+<entry ORIGTXT="T49_21">
+   <term>
+  <code meaning="Left ventricular Ejection fraction by MRI" value="8811-2" scheme="LOINC">
+ </term>
+</entry>
+<entry ORIGTXT="T49_22">
+   <term>
+  <code meaning="Left ventricular End systolic [Volume] by Imaging" value="8823-7" scheme="LOINC">
+ </term>
+</entry>
+<entry ORIGTXT="T49_23">
+   <term>
+  <code meaning="Left ventricular End diastolic [Volume] by Imaging" value="8821-1" scheme="LOINC">
+ </term>
+</entry>
+<entry ORIGTXT="T49_31">
+ <term>
+  <code meaning="aortic valve" value="RID1394" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_35">
+ <term>
+  <code meaning="volume" value="RID28668" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_36">
+ <term>
+  <code meaning="regurgitant flow" value="RID5935" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="volume" value="RID28668" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_37">
+ <term>
+  <code meaning="supraaortic valve area" value="RID482" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_38">
+ <term>
+  <code meaning="mitral valve" value="RID1395" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_44">
+ <term>
+  <code meaning="regurgitant flow" value="RID5935" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="volume" value="RID28668" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_45">
+ <term>
+  <code meaning="regurgitant flow" value="RID5935" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_46">
+ <term>
+  <code meaning="ascending aorta" value="RID580" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="diameter" value="RID13432" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_47">
+ <term>
+  <code meaning="left atrium" value="RID1390" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_48">
+ <term>
+  <code meaning="left atrium" value="RID1390" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_57">
+ <term>
+  <code meaning="anterior" value="RID5818" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_58">
+ <term>
+  <code meaning="anterior" value="RID5818" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="laterality" value="RID5821" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="zone of heart" value="RID29046" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_60">
+ <term>
+  <code meaning="inferior" value="RID5823" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_62">
+ <term>
+  <code meaning="anterior" value="RID5818" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="cardiac septum" value="RID34906" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="zone of heart" value="RID29046" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_64">
+ <term>
+  <code meaning="anterior" value="RID5818" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_65">
+ <term>
+  <code meaning="anterior" value="RID5818" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="laterality" value="RID5821" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="zone of heart" value="RID29046" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_67">
+ <term>
+  <code meaning="inferior" value="RID5823" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_69">
+ <term>
+  <code meaning="anterior" value="RID5818" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="cardiac septum" value="RID34906" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="zone of heart" value="RID29046" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_71">
+ <term>
+  <code meaning="anterior" value="RID5818" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_119">
+ <term>
+  <code meaning="global" value="RID5693" scheme="RadLex">
+ </term>
+ <term>
+  <code meaning="function" value="RID28812" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_120">
+ <term>
+  <code meaning="normal" value="RID13173" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_121">
+ <term>
+  <code meaning="mild" value="RID5671" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_122">
+ <term>
+  <code meaning="moderate" value="RID5672" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_123">
+ <term>
+  <code meaning="severe" value="RID5673" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_125">
+ <term>
+  <code meaning="normal" value="RID13173" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_126">
+ <term>
+  <code meaning="mild" value="RID5671" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_127">
+ <term>
+  <code meaning="moderate" value="RID5672" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_128">
+ <term>
+  <code meaning="severe" value="RID5673" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_129">
+ <term>
+  <code meaning="left ventricle" value="RID1392" scheme="RadLex">
+ </term>
+</entry>
+<entry ORIGTXT="T49_130">
+ <term>
+  <code meaning="valvular heart disease" value="RID3260" scheme="RadLex">
+ </term>
+</entry>
+</coded_content>
+</template_attributes>
+-->
+</script>
+<title>Cardiac MRI: Function and Viability</title>
+</head>
+<body>
+<section data-section-name="Procedure">
+<header class="level1">Cardiac MRI: Function and Viability</header>
+<p>
+<textarea id="T49_2" name="Procedure"> </textarea>
+</p>
+</section>
+<section data-section-name="Clinical information">
+<header class="level1">Clinical information</header>
+<p>
+<textarea id="T49_11" name="Clinical information"> </textarea>
+</p>
+</section>
+<section data-section-name="Comparison">
+<header class="level1">Comparison</header>
+<p>
+<textarea id="T49_12" name="Comparison">None. </textarea>
+</p>
+</section>
+<section data-section-name="Findings">
+<header class="level1">Findings</header>
+<section data-section-name="Left ventricular measurements">
+<header class="level2">Left ventricular measurements</header>
+<p>
+<label for="T49_16">End Diastolic Diameter:</label>
+<input type="number" id="T49_16" name="End Diastolic Diameter" data-field-units="mm" min="" max=""/>
+<label for="T49_16"> mm (normal, 36-56 mm)</label>
+</p>
+<p>
+<label for="T49_17">Ejection Fraction:</label>
+<input type="number" id="T49_17" name="Ejection Fraction" data-field-units="%" min="" max=""/>
+<label for="T49_17"> % (normal: male = 56-78%; female = 56-78%)</label>
+</p>
+<p>
+<label for="T49_18">Stroke Volume:</label>
+<input type="number" id="T49_18" name="Stroke Volume" data-field-units="ml" min="" max=""/>
+<label for="T49_18"> ml</label>
+</p>
+<p>
+<label for="T49_19">End Diastolic Volume:</label>
+<input type="number" id="T49_19" name="End Diastolic Volume" data-field-units="ml" min="" max=""/>
+<label for="T49_19"> mL (normal: male = 77-195 mL; female = 52-141 mL)</label>
+</p>
+<p>
+<label for="T49_20">Indexed End Diastolic Volume:</label>
+<input type="number" id="T49_20" name="Indexed End Diastolic Volume" data-field-units="mL/m2" min="" max=""/> 
+<label for="T49_20"> mL/m2</label>
+</p>
+<p>
+<label for="T49_21">End Systolic Volume:</label>
+<input type="number" id="T49_21" name="End Systolic Volume" data-field-units="ml" min="" max=""/>
+<label for="T49_21"> mL (normal: male = 19-72 mL; female = 13-51 mL)</label>
+</p>
+<p>
+<label for="T49_22">Indexed End Systolic Volume:</label>
+<input type="number" id="T49_22" name="Indexed End Systolic Volume" data-field-units="mL/m2" min="" max=""/> 
+<label for="T49_22"> mL/m2</label>
+</p>
+<p>
+<label for="T49_23">Cardiac output:</label>
+<input type="number" id="T49_23" name="Cardiac output" data-field-units=" L/min " min="" max=""/> 
+<label for="T49_23"> L/min (normal: male = 2.82-8.82 L/min; female = 2.7-6.0 l/min)</label>
+</p>
+<p>
+<label for="T49_24">Cardiac Index:</label>
+<input type="number" id="T49_24" name="Cardiac Index" data-field-units="L/min/m2" min="" max=""/> 
+<label for="T49_24"> L/min/m2</label>
+</p>
+<p>
+<label for="T49_25">Index values are normalized to body surface area (BSA) of </label>
+<input type="number" id="T49_25" name="body surface area" data-field-units="" min="" max=""/> 
+<label for="T49_25"> m2</label>
+</p>
+</section>
+
+<section data-section-name="Valve disease">
+<header class="level2">Valve disease</header>
+<p>
+<label for="T49_31">Aortic valve:</label>
+<input type="text" id="T49_31" name="Aortic valve" value="Normal."/>
+</p>
+<p>
+<label for="T49_35">Aortic forward volume:</label>
+<input type="number" id="T49_35" name="Aortic forward volume" data-field-units="ml" min="" max=""/> 
+<label for="T49_35"> ml</label>
+</p>
+<p>
+<label for="T49_36">Aortic regurgitant volume</label>
+<input type="number" id="T49_36" name="Aortic regurgitant volume" data-field-units="ml" min="" max=""/> 
+<label for="T49_36"> ml</label>
+</p>
+<p>
+<label for="T49_37">Aortic valve area</label>
+<input type="number" id="T49_37" name="Aortic valve area" data-field-units="cm2" min="" max=""/> 
+<label for="T49_37"> cm2 (< 1.0 cm2 severe; 1.0-1.5 cm2 moderate;  1.5-2.0 cm2 mild; > 2.0 cm2 normal)</label>
+</p>
+<p>
+<label for="T49_38">Mitral valve:</label>
+<input type="text" id="T49_38" name="Mitral valve" value="Normal."/>
+</p>
+<p>
+<label for="T49_44">Mitral regurgitant volume:</label>
+<input type="number" id="T49_44" name="Mitral regurgitant volume" data-field-units="mL" min="" max=""/> 
+<label for="T49_44"> mL</label>
+</p>
+<p>
+<label for="T49_45">Mitral regurgitant fraction:</label>
+<input type="number" id="T49_45" name="Mitral regurgitant fraction" data-field-units="%mL" min="" max=""/> 
+<label for="T49_45">%mL</label>
+</p>
+<p>
+<label for="T49_46">Ascending aorta diameter:</label>
+<input type="number" id="T49_46" name="Ascending aorta diameter" data-field-units="mm" min="" max=""/> 
+<label for="T49_46"> mm</label>
+</p>
+<p>
+<label for="T49_47">Left atrial dimensions (AP x 4-chamber):</label>
+<input type="text" id="T49_47" name="Left atrial dimensions" /> 
+<label for="T49_47"> mm</label>
+</p>
+<p>
+<label for="T49_48">Left atrial area:</label>
+<input type="number" id="T49_48" name="Left atrial area" data-field-units="cm2" min="" max=""/> 
+<label for="T49_48"> cm2</label>
+</p>
+</section>
+<section data-section-name="Left ventricle regional wall motion">
+<header class="level2">Left ventricle regional wall motion</header>
+<p>
+{0 = normokinetic, 1 = hypokinetic, 2 = akinetic, 3 = dyskinetic}
+</p>
+<section data-section-name="BASE">
+<header class="level3">BASE</header>
+<p>
+<label for="T49_57">Anterior</label>
+<input type="number" id="T49_57" name="Anterior" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_58">Anterolateral</label>
+<input type="number" id="T49_58" name="Anterolateral" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_59">Inferolateral</label>
+<input type="number" id="T49_59" name="Inferolateral" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_60">Inferior</label>
+<input type="number" id="T49_60" name="Inferior" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_61">Inferioseptal</label>
+<input type="number" id="T49_61" name="Inferioseptal" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_62">Anteroseptal</label>
+<input type="number" id="T49_62" name="Anteroseptal" value="0" min="0" max="3" step="1"/>
+</p>
+</section>
+<section data-section-name="MID">
+<header class="level3">MID</header>
+<p>
+<label for="T49_64">Anterior</label>
+<input type="number" id="T49_64" name="Anterior" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_65">Anterolateral</label>
+<input type="number" id="T49_65" name="Anterolateral" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_66">Inferolateral</label>
+<input type="number" id="T49_66" name="Inferolateral" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_67">Inferior</label>
+<input type="number" id="T49_67" name="Inferior" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_68">Inferioseptal</label>
+<input type="number" id="T49_68" name="Inferioseptal" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_69">Anteroseptal</label>
+<input type="number" id="T49_69" name="Anteroseptal" value="0" min="0" max="3" step="1"/>
+</p>
+</section>
+<section data-section-name="APEX">
+<header class="level3">APEX</header>
+<p>
+<label for="T49_71">Anterior</label>
+<input type="number" id="T49_71" name="Anterior" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_72.1">Lateral</label>
+<input type="number" id="T49_72.1" name="Lateral" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_72.2">Inferior</label>
+<input type="number" id="T49_72.2" name="Inferior" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_72.3">Septum</label>
+<input type="number" id="T49_72.3" name="Septum" value="0" min="0" max="3" step="1"/>
+</p>
+<p>
+<label for="T49_73">True apex</label>
+<input type="number" id="T49_73" name="True apex" value="0" min="0" max="3" step="1"/>
+</p>
+</section>
+
+<section data-section-name="Left ventricle myocardial enhancement">
+<header class="level2">Left ventricle myocardial enhancement</header>
+<p>
+(0 = none, 1 = 1-25%, 2 = 26-50%, 3 = 51-75%, 4 = 76-100%)
+</p>
+<section data-section-name="BASE">
+<header class="level3">BASE</header>
+<p>
+<label for="T49_157">Anterior</label>
+<input type="number" id="T49_157" name="Anterior" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_158">Anterolateral</label>
+<input type="number" id="T49_158" name="Anterolateral" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_159">Inferolateral</label>
+<input type="number" id="T49_159" name="Inferolateral" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_160">Inferior</label>
+<input type="number" id="T49_160" name="Inferior" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_161">Inferioseptal</label>
+<input type="number" id="T49_161" name="Inferioseptal" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_162">Anteroseptal</label>
+<input type="number" id="T49_162" name="Anteroseptal" value="4" min="0" max="4" step="1"/>
+</p>
+</section>
+<section data-section-name="MID">
+<header class="level3">MID</header>
+<p>
+<label for="T49_164">Anterior</label>
+<input type="number" id="T49_164" name="Anterior" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_165">Anterolateral</label>
+<input type="number" id="T49_165" name="Anterolateral" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_166">Inferolateral</label>
+<input type="number" id="T49_166" name="Inferolateral" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_167">Inferior</label>
+<input type="number" id="T49_167" name="Inferior" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_168">Inferioseptal</label>
+<input type="number" id="T49_168" name="Inferioseptal" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_169">Anteroseptal</label>
+<input type="number" id="T49_169" name="Anteroseptal" value="4" min="0" max="4" step="1"/>
+</p>
+</section>
+<section data-section-name="APEX">
+<header class="level3">APEX</header>
+<p>
+<label for="T49_171">Anterior</label>
+<input type="number" id="T49_171" name="Anterior" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_172.1">Lateral</label>
+<input type="number" id="T49_172.1" name="Lateral" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_172.2">Inferior</label>
+<input type="number" id="T49_172.2" name="Inferior" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_172.3">Septum</label>
+<input type="number" id="T49_172.3" name="Septum" value="4" min="0" max="4" step="1"/>
+</p>
+<p>
+<label for="T49_173">True apex</label>
+<input type="number" id="T49_173" name="True apex" value="4" min="0" max="4" step="1"/>
+</p>
+</section>
+
+
+</section>
+<section data-section-name="Non-cardiac findings">
+<header class="level2">Non-cardiac findings</header>
+<p>
+<textarea id="T49_74" name="Non-cardiac findings" value=""></textarea>
+</p>
+</section>
+</section>
+</section>
+<section data-section-name="Impression">
+<header class="level1">Impression</header>
+<p>
+<label for="T49_119">Global systolic LV function:</label>
+<select id="T49_119" name="Global systolic LV function">
+<option id="T49_120" name="Normal" value="Normal" selected>Normal</option>
+<option id="T49_121" name="Mild" value="Mild">Mildly impaired</option>
+<option id="T49_122" name="Moderate" value="Moderate">Moderately impaired</option>
+<option id="T49_123" name="Severe" value="Severe">Severely impaired</option>
+</select>
+</p>
+<p>
+<label for="T49_124">Global systolic RV function:</label>
+<select id="T49_124" name="Global systolic RV function">
+<option id="T49_125" name="Normal" value="Normal" selected>Normal</option>
+<option id="T49_126" name="Mild" value="Mild">Mildly impaired</option>
+<option id="T49_127" name="Moderate" value="Moderate">Moderately impaired</option>
+<option id="T49_128" name="Severe" value="Severe">Severely impaired</option>
+</select>
+</p>
+<p>
+<label for="T49_129">LV viability:</label>
+<input type="text" id="T49_129" name="LV viability" value="Normal."/>
+</p>
+<p>
+<label for="T49_130">Valvular disease:</label>
+<input type="text" id="T49_130" name="Valvular disease" value="None."/>
+</p>
+<p>
+<textarea id="T49_999" name="Impression"></textarea>
+</p>
+</section>
+</body>
+</html>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/MrrtReportTemplateServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/MrrtReportTemplateServiceComponentTestDataset.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<dataset>
+	<radiology_report_template template_id="1" charset="UTF-8" path="test/test1.html" dcterms_title="title1" dcterms_description="description1" dcterms_language="en" dcterms_identifier="identifier1" creator="1" date_created="2015-02-02 12:26:35.0" uuid="2379d290-96f7-408a-bbae-270387e3b92e"/>
+	<radiology_report_template template_id="2" charset="UTF-8" path="test/test2.html" dcterms_title="title2" dcterms_description="description2" dcterms_language="en" dcterms_identifier="identifier2" creator="1" date_created="2015-02-03 13:17:15.0" uuid="59273e52-33b1-4fcb-8c1f-9b670bb11259"/>
+</dataset>

--- a/api/src/test/resources/test-hibernate.cfg.xml
+++ b/api/src/test/resources/test-hibernate.cfg.xml
@@ -19,5 +19,6 @@
 		<mapping resource="RadiologyOrder.hbm.xml" />
 		<mapping resource="RadiologyStudy.hbm.xml" />
 		<mapping resource="RadiologyReport.hbm.xml" />
+		<mapping resource="MrrtReportTemplate.hbm.xml"/>
 	</session-factory>
 </hibernate-configuration>

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardFormController.java
@@ -9,9 +9,19 @@
  */
 package org.openmrs.module.radiology.order.web;
 
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.openmrs.api.APIException;
+import org.openmrs.module.radiology.report.template.MrrtReportTemplateService;
+import org.openmrs.web.WebConstants;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
 
 @Controller
@@ -23,8 +33,57 @@ public class RadiologyDashboardFormController {
     
     static final String RADIOLOGY_DASHBOARD_FORM_VIEW = "/module/radiology/radiologyDashboardForm";
     
+    @Autowired
+    private MrrtReportTemplateService mrrtReportTemplateService;
+    
+    /**
+     * Handles normal get requests to the radiology dashboard page.
+     * @return model and view
+     * @should return model and view
+     */
     @RequestMapping(method = RequestMethod.GET)
     protected ModelAndView get() {
+        return new ModelAndView(RADIOLOGY_DASHBOARD_FORM_VIEW);
+    }
+    
+    /**
+     * Handle request for importing new {@code MrrtReportTemplate}.
+     * 
+     * @param request HttpServletRequest to import file
+     * @param templateFile file being imported
+     * @return empty model and view 
+     * @throws IOException when templateFile could not be read or is invalid
+     * @should give error message when template file is empty
+     * @should copy template file to report home
+     * @should imported template file should not be empty
+     * @should give success message when import was successful 
+     * @should give error message when importing the same template twice
+     */
+    @RequestMapping(method = RequestMethod.POST, params = "uploadReportTemplate")
+    protected ModelAndView uploadReportTemplate(HttpServletRequest request, @RequestParam MultipartFile templateFile)
+            throws IOException {
+        
+        if (templateFile.isEmpty()) {
+            request.getSession()
+                    .setAttribute(WebConstants.OPENMRS_ERROR_ATTR, "radiology.MrrtReportTemplate.not.imported.empty");
+            return new ModelAndView(RADIOLOGY_DASHBOARD_FORM_VIEW);
+        }
+        
+        try {
+            mrrtReportTemplateService.importMrrtReportTemplate(templateFile.getInputStream());
+            request.getSession()
+                    .setAttribute(WebConstants.OPENMRS_MSG_ATTR, "radiology.MrrtReportTemplate.imported");
+        }
+        catch (IOException exception) {
+            request.getSession()
+                    .setAttribute(WebConstants.OPENMRS_ERROR_ATTR,
+                        "Failed to import " + templateFile.getOriginalFilename() + " => " + exception.getMessage());
+        }
+        catch (APIException exception) {
+            request.getSession()
+                    .setAttribute(WebConstants.OPENMRS_ERROR_ATTR,
+                        "Failed to import " + templateFile.getOriginalFilename() + " => " + exception.getMessage());
+        }
         return new ModelAndView(RADIOLOGY_DASHBOARD_FORM_VIEW);
     }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/report/template/web/resource/MrrtReportTemplateResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/template/web/resource/MrrtReportTemplateResource.java
@@ -1,0 +1,135 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template.web.resource;
+
+import org.openmrs.api.context.Context;
+import org.openmrs.module.radiology.report.template.MrrtReportTemplate;
+import org.openmrs.module.radiology.report.template.MrrtReportTemplateService;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
+import org.openmrs.module.webservices.rest.web.annotation.Resource;
+import org.openmrs.module.webservices.rest.web.representation.DefaultRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.FullRepresentation;
+import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.module.webservices.rest.web.resource.impl.DataDelegatingCrudResource;
+import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
+import org.openmrs.module.webservices.rest.web.response.ResourceDoesNotSupportOperationException;
+import org.openmrs.module.webservices.rest.web.v1_0.resource.openmrs2_0.RestConstants2_0;
+
+/**
+ *
+ */
+@Resource(name = RestConstants.VERSION_1 + "/mrrtreporttemplate", supportedClass = MrrtReportTemplate.class,
+        supportedOpenmrsVersions = { "2.0.*" })
+public class MrrtReportTemplateResource extends DataDelegatingCrudResource<MrrtReportTemplate> {
+    
+    
+    /**
+     * @see org.openmrs.module.webservices.rest.web.resource.impl.DelegatingCrudResource#getRepresentationDescription(org.openmrs.module.webservices.rest.web.representation.Representation)
+     * @should return default representation given instance of defaultrepresentation
+     * @should return full representation given instance of fullrepresentation
+     * @should return null for representation other then default or full
+     */
+    @Override
+    public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+        if (rep instanceof DefaultRepresentation) {
+            DelegatingResourceDescription description = new DelegatingResourceDescription();
+            
+            description.addProperty("uuid");
+            description.addProperty("templateId");
+            description.addProperty("dcTermsIdentifier");
+            description.addProperty("dcTermsTitle");
+            description.addProperty("dcTermsType");
+            description.addProperty("dcTermsPublisher");
+            description.addProperty("dcTermsCreator");
+            description.addProperty("dcTermsRights");
+            description.addProperty("display");
+            description.addSelfLink();
+            description.addLink("full", ".?v=" + RestConstants.REPRESENTATION_FULL);
+            return description;
+        } else if (rep instanceof FullRepresentation) {
+            DelegatingResourceDescription description = new DelegatingResourceDescription();
+            
+            description.addProperty("uuid");
+            description.addProperty("charset");
+            description.addProperty("path");
+            description.addProperty("templateId");
+            description.addProperty("dcTermsIdentifier");
+            description.addProperty("dcTermsTitle");
+            description.addProperty("dcTermsDescription");
+            description.addProperty("dcTermsType");
+            description.addProperty("dcTermsLanguage");
+            description.addProperty("dcTermsPublisher");
+            description.addProperty("dcTermsCreator");
+            description.addProperty("dcTermsRights");
+            description.addProperty("dcTermsLicense");
+            description.addProperty("dcTermsDate");
+            description.addProperty("display");
+            description.addSelfLink();
+            return description;
+        } else {
+            return null;
+        }
+    }
+    
+    /**
+     * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getByUniqueId(java.lang.String)
+     * @should return radiology order given its uuid
+     */
+    @Override
+    public MrrtReportTemplate getByUniqueId(String uuid) {
+        return Context.getService(MrrtReportTemplateService.class)
+                .getMrrtReportTemplateByUuid(uuid);
+    }
+    
+    /**
+     * Display string for {@link MrrtReportTemplate}
+     *
+     * @param mrrtReportTemplate MrrtReportTemplate of which display string shall be returned
+     * @return templateIdentifier/title of given mrrtReportTemplate
+     * @should return templateIdentifier/title of given mrrtReportTemplate
+     */
+    @PropertyGetter("display")
+    public String getDisplayString(MrrtReportTemplate mrrtReportTemplate) {
+        return mrrtReportTemplate.getDcTermsIdentifier();
+    }
+    
+    @Override
+    protected void delete(MrrtReportTemplate mrrtReportTemplate, String s, RequestContext requestContext)
+            throws ResourceDoesNotSupportOperationException {
+        throw new ResourceDoesNotSupportOperationException();
+    }
+    
+    @Override
+    public void purge(MrrtReportTemplate mrrtReportTemplate, RequestContext requestContext)
+            throws ResourceDoesNotSupportOperationException {
+        throw new ResourceDoesNotSupportOperationException();
+    }
+    
+    @Override
+    public MrrtReportTemplate newDelegate() throws ResourceDoesNotSupportOperationException {
+        throw new ResourceDoesNotSupportOperationException();
+    }
+    
+    @Override
+    public MrrtReportTemplate save(MrrtReportTemplate mrrtReportTemplate) {
+        throw new ResourceDoesNotSupportOperationException();
+    }
+    
+    /**
+     * @see org.openmrs.module.webservices.rest.web.resource.impl.BaseDelegatingResource#getResourceVersion()
+     * @should return supported resource version
+     */
+    @Override
+    public String getResourceVersion() {
+        return RestConstants2_0.RESOURCE_VERSION;
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/radiology/report/template/web/search/MrrtReportTemplateSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/template/web/search/MrrtReportTemplateSearchHandler.java
@@ -1,0 +1,77 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template.web.search;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.openmrs.module.radiology.report.template.MrrtReportTemplate;
+import org.openmrs.module.radiology.report.template.MrrtReportTemplateService;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchConfig;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchHandler;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchQuery;
+import org.openmrs.module.webservices.rest.web.resource.impl.EmptySearchResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Find MrrtReportTemplate's that match the specified search phrase.
+ */
+@Component
+public class MrrtReportTemplateSearchHandler implements SearchHandler {
+    
+    
+    public static final String REQUEST_PARAM_TITLE = "title";
+    
+    public static final String REQUEST_PARAM_TOTAL_COUNT = "totalCount";
+    
+    @Autowired
+    private MrrtReportTemplateService mrrtReportTemplateService;
+    
+    SearchQuery searchQuery = new SearchQuery.Builder("Allows you to search for MrrtReportTemplate's by title")
+            .withRequiredParameters(REQUEST_PARAM_TITLE)
+            .withOptionalParameters(REQUEST_PARAM_TOTAL_COUNT)
+            .build();
+    
+    private final SearchConfig searchConfig = new SearchConfig("default", RestConstants.VERSION_1 + "/mrrtreporttemplate",
+            Arrays.asList("2.0.*"), searchQuery);
+    
+    /**
+     * @see org.openmrs.module.webservices.rest.web.resource.api.SearchHandler#getSearchConfig()
+     */
+    @Override
+    public SearchConfig getSearchConfig() {
+        return this.searchConfig;
+    }
+    
+    /**
+     * @see org.openmrs.module.webservices.rest.web.resource.api.SearchHandler#getSearchConfig()
+     * @should return all report templates that match given title
+     * @should return all report templates for that match given title and totalCount if requested
+     * @should return empty search result if title does not exist
+     */
+    @Override
+    public PageableResult search(RequestContext context) throws ResponseException {
+        final String templateTitle = context.getParameter("title");
+        
+        List<MrrtReportTemplate> result = mrrtReportTemplateService.getMrrtReportTemplateByTitle(templateTitle);
+        if (result.isEmpty()) {
+            return new EmptySearchResult();
+        } else {
+            return new NeedsPaging<MrrtReportTemplate>(result, context);
+        }
+    }
+    
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -161,7 +161,28 @@
 		<defaultValue>fe898a34-1ade-11e1-9c71-00248140a5eb</defaultValue>
 		<description>Radiology Visit Type UUID</description>
 	</globalProperty>
-
+	<!-- we provide the setting for the GP of the emr-api here since it is not 
+		provided by them. otherwise users would need to set the GP via the database. 
+		remove once emr-api defines this GP in their config.xml -->
+	<globalProperty>
+		<property>emr.encounterMatcher</property>
+		<defaultValue>org.openmrs.module.radiology.RadiologyEncounterMatcher
+		</defaultValue>
+		<description>
+			Class name of a custom encounter matcher (e.g.
+			org.openmrs.module.example.CustomEncounterMatcher)
+		</description>
+	</globalProperty>
+	<globalProperty>
+		<property>@MODULE_ID@.reportTemplatesHome</property>
+		<defaultValue>reporttemplates</defaultValue>
+		<description>
+			Directory where report templates are stored. Absolute and
+			relative paths are valid.
+			Relative paths are appended to the application data directory; necessary
+			parent directories are created if they do not exist.
+		</description>
+	</globalProperty>
 	<!--Required Global Properties -->
 
 	<!-- Internationalization -->
@@ -178,7 +199,7 @@
 	<!-- /Internationalization -->
 
 	<mappingFiles>RadiologyStudy.hbm.xml RadiologyOrder.hbm.xml
-		RadiologyReport.hbm.xml
+		RadiologyReport.hbm.xml MrrtReportTemplate.hbm.xml
 	</mappingFiles>
 
 	<!-- Accessed through the url /pageContext()/moduleServlet/<moduleId>/<servlet-name> -->

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -1,12 +1,22 @@
 @MODULE_ID@.title=Radiology Module
 @MODULE_ID@.gutterlist.title=Radiology
 @MODULE_ID@.dashboard.title=Radiology
+@MODULE_ID@.dashboard.tabs.orders=Orders
+@MODULE_ID@.dashboard.tabs.reportTemplates=Report Templates
 @MODULE_ID@.patientDashboardForm.tabs.radiology=Radiology
 @MODULE_ID@.manageOrders=Manage Radiology Orders
 @MODULE_ID@.radiologyOrder=Radiology Order
 @MODULE_ID@.radiologyOrders=Radiology Orders
 @MODULE_ID@.addOrder=Add Radiology Order
 @MODULE_ID@.imagingProcedure=Imaging Procedure
+
+@MODULE_ID@.report.template.boxheader=Report Templates
+@MODULE_ID@.report.template.button.import=Import Report Template
+@MODULE_ID@.report.template.import.boxheader=Import Report Template
+@MODULE_ID@.report.template.search.title=Title
+@MODULE_ID@.report.template.upload=Upload
+@MODULE_ID@.report.template.imported=Report template imported
+@MODULE_ID@.report.template.not.imported.empty=Failed to import report template because it was empty
 
 @MODULE_ID@.discontinuedOrder=Discontinued Order
 @MODULE_ID@.isNotActiveOrder=This order is not active.
@@ -31,6 +41,14 @@
 @MODULE_ID@.dashboard.tabs.reports.filters.status=Status
 @MODULE_ID@.dashboard.tabs.reports.filters.principalResultsInterpreter=Principal Results Interpreter
 @MODULE_ID@.dashboard.tabs.reports.filters.principalResultsInterpreter.title=Proposals after two characters
+
+@MODULE_ID@.dashboard.tabs.reportTemplates=Report Templates
+@MODULE_ID@.dashboard.tabs.reportTemplates.filters.title=Title
+@MODULE_ID@.dashboard.tabs.reportTemplates.boxheader=Report Templates
+
+@MODULE_ID@.reportTemplates.import.popup.boxheader=Import Report Template
+@MODULE_ID@.reportTemplates.import.popup.upload=Upload
+@MODULE_ID@.reportTemplates.import.popup.button=Import Report Template
 
 @MODULE_ID@.datatables.noresult=No Result
 @MODULE_ID@.datatables.loading=Loading...
@@ -63,6 +81,14 @@
 @MODULE_ID@.datatables.column.report.dateCreated=Date created
 @MODULE_ID@.datatables.column.report.createdBy=Created By
 
+@MODULE_ID@.datatables.column.report.template.id=Id
+@MODULE_ID@.datatables.column.report.template.title=Title
+@MODULE_ID@.datatables.column.report.template.creator=Creator
+@MODULE_ID@.datatables.column.report.template.publisher=Publisher
+@MODULE_ID@.datatables.column.report.template.type=Type
+@MODULE_ID@.datatables.column.report.template.description=Description
+@MODULE_ID@.datatables.column.report.template.rights=Rights
+
 @MODULE_ID@.report.boxheader=Reports
 
 @MODULE_ID@.report.principalResultsInterpreter=Principal Results Interpreter
@@ -76,9 +102,20 @@
 @MODULE_ID@.report.status.CLAIMED=Claimed
 @MODULE_ID@.report.status.DISCONTINUED=Discontinued
 
+@MODULE_ID@.datatables.column.report.template.id=Id
+@MODULE_ID@.datatables.column.report.template.title=Title
+@MODULE_ID@.datatables.column.report.template.creator=Creator
+@MODULE_ID@.datatables.column.report.template.publisher=Publisher
+@MODULE_ID@.datatables.column.report.template.type=Type
+@MODULE_ID@.datatables.column.report.template.description=Description
+@MODULE_ID@.datatables.column.report.template.rights=Rights
+
 @MODULE_ID@.radiologyOrder.orderReason=Reason (Coded)
 @MODULE_ID@.radiologyOrder.orderReasonNonCoded=Reason (Free Text)
 @MODULE_ID@.radiologyOrder.clinicalHistory=Clinical History
+
+@MODULE_ID@.MrrtReportTemplate.imported=Report template imported
+@MODULE_ID@.MrrtReportTemplate.not.imported.empty=Failed to import report template because it was empty
 
 @MODULE_ID@.patientId=Patient Id
 @MODULE_ID@.patientFullName=Patient Full Name

--- a/omod/src/main/webapp/portlets/radiologyReportTemplatesTab.jsp
+++ b/omod/src/main/webapp/portlets/radiologyReportTemplatesTab.jsp
@@ -1,0 +1,179 @@
+<%@ include file="/WEB-INF/view/module/radiology/template/include.jsp"%>
+<%@ include file="/WEB-INF/view/module/radiology/template/includeScripts.jsp"%>
+<%@ include file="/WEB-INF/view/module/radiology/template/includeDatatablesWithDefaults.jsp"%>
+
+<script type="text/javascript">
+  var $j = jQuery.noConflict();
+  $j(document)
+          .ready(
+                  function() {
+                    var templateTitle = $j('#reportTemplatesTabTitleFilter');
+                    var find = $j('#reportTemplatesTabFind');
+                    var clearResults = $j('a#reportTemplatesTabClearFilters');
+
+                    var reportTemplatesTable = $j('#reportTemplatesTable')
+                            .DataTable(
+                                    {
+                                      "processing": true,
+                                      "serverSide": true,
+                                      "ajax": {
+                                        headers: {
+                                          Accept: "application/json; charset=utf-8",
+                                          "Content-Type": "text/plain; charset=utf-8",
+                                        },
+                                        cache: true,
+                                        dataType: "json",
+                                        url: "${pageContext.request.contextPath}/ws/rest/v1/mrrtreporttemplate/",
+                                        data: function(data) {
+                                          return {
+                                            startIndex: data.start,
+                                            limit: data.length,
+                                            v: "full",
+                                            title: templateTitle.val(),
+                                            totalCount: true,
+                                          };
+                                        },
+                                        "dataFilter": function(data) {
+                                          var json = $j.parseJSON(data);
+                                          json.recordsTotal = json.totalCount || 0;
+                                          json.recordsFiltered = json.totalCount || 0;
+                                          json.data = json.results;
+                                          return JSON.stringify(json);
+                                        }
+                                      },
+                                      "columns": [
+                                          {
+                                            "name": "templateId",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              return full.templateId;
+                                            }
+                                          },
+                                          {
+                                            "name": "dcTermsTitle",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              return full.dcTermsTitle;
+                                            }
+                                          },
+                                          {
+                                            "name": "dcTermsCreator",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              return full.dcTermsCreator;
+                                            }
+                                          },
+                                          {
+                                            "name": "dcTermsPublisher",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              return full.dcTermsPublisher;
+                                            }
+                                          },
+                                          {
+                                            "name": "dcTermsRights",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              return full.dcTermsRights;
+                                            }
+                                          },
+                                          {
+                                            "name": "dcTermsDescription",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              return full.dcTermsDescription;
+                                            }
+                                          }, ],
+                                    });
+
+                    // prevent form submit when user hits enter
+                    $j(window).keydown(function(event) {
+                      if (event.keyCode == 13) {
+                        event.preventDefault();
+                        return false;
+                      }
+                    });
+
+                    find.on('mouseup keyup', function(event) {
+                      if (event.type == 'keyup' && event.keyCode != 13) return;
+                      reportTemplatesTable.ajax.reload();
+                    });
+
+                    clearResults.on('mouseup keyup', function() {
+                      $j('table#reportTemplatesTableFilters input:text')
+                              .val('');
+                      templateTitle.val('');
+                      reportTemplatesTable.ajax.reload();
+                    });
+                    
+                    $j('#reportTemplatesTabImportPopup')
+                            .dialog(
+                                    {
+                                      autoOpen: false,
+                                      modal: true,
+                                      title: '<openmrs:message code="radiology.reportTemplates.import.popup.boxheader" javaScriptEscape="true"/>',
+                                      width: '90%'
+                                    });
+
+                    $j('#reportTemplatesTabImportTemplates').click(function() {
+                      $j('#reportTemplatesTabImportPopup').dialog('open');
+
+                    });
+                  });
+</script>
+
+<br />
+<div id="buttonPanel">
+  <div style="float: left">
+    <input type="button" id="reportTemplatesTabImportTemplates"
+      value="<openmrs:message code="radiology.reportTemplates.import.popup.button" javaScriptEscape="true"/>" />
+    <div id="reportTemplatesTabImportPopup">
+      <b class="boxHeader"><openmrs:message code="radiology.reportTemplates.import.popup.boxheader" /></b>
+      <div class="box">
+        <form id="templateAddForm" action="radiologyDashboard.form" method="post" enctype="multipart/form-data">
+          <input type="file" name="templateFile" size="40" /> <input type="submit" name="uploadReportTemplate"
+            value='<openmrs:message code="radiology.reportTemplates.import.popup.upload"/>' />
+        </form>
+      </div>
+      <br />
+    </div>
+  </div>
+  <div style="clear: both">&nbsp;</div>
+</div>
+
+<br>
+<span class="boxHeader"> <b><spring:message code="radiology.dashboard.tabs.reportTemplates.boxheader" /></b> <a
+  id="reportTemplatesTabClearFilters" href="#" style="float: right"> <spring:message
+      code="radiology.dashboard.tabs.filters.clearFilters" />
+</a>
+</span>
+<div class="box">
+  <table id="reportTemplatesTableFilters" cellspacing="10">
+    <tr>
+      <form>
+        <td><label><spring:message code="radiology.dashboard.tabs.reportTemplates.filters.title" /></label> <input
+          id="reportTemplatesTabTitleFilter" name="titleQuery" type="text" style="width: 20em"
+          title="<spring:message
+						code="radiology.minChars" />" /></td>
+        <td><input id="reportTemplatesTabFind" type="button"
+          value="<spring:message code="radiology.dashboard.tabs.filters.find"/>" /></td>
+      </form>
+    </tr>
+  </table>
+  <br>
+  <div>
+    <table id="reportTemplatesTable" cellspacing="0" width="100%" class="display nowrap">
+      <thead>
+        <tr>
+          <th><spring:message code="radiology.datatables.column.report.template.id" /></th>
+          <th><spring:message code="radiology.datatables.column.report.template.title" /></th>
+          <th><spring:message code="radiology.datatables.column.report.template.creator" /></th>
+          <th><spring:message code="radiology.datatables.column.report.template.publisher" /></th>
+          <th><spring:message code="radiology.datatables.column.report.template.rights" /></th>
+          <th><spring:message code="radiology.datatables.column.report.template.description" /></th>
+        </tr>
+      </thead>
+    </table>
+  </div>
+</div>
+<br />

--- a/omod/src/main/webapp/radiologyDashboardForm.jsp
+++ b/omod/src/main/webapp/radiologyDashboardForm.jsp
@@ -78,6 +78,10 @@
       <li><a id="radiologyReportsTab" href="#" onclick="return changeTab(this);" hidefocus="hidefocus"><openmrs:message
             code="radiology.dashboard.tabs.reports" /></a></li>
     </openmrs:hasPrivilege>
+    <openmrs:hasPrivilege privilege="View Radiology Report Templates">
+      <li><a id="radiologyReportTemplatesTab" href="#" onclick="return changeTab(this);" hidefocus="hidefocus"><openmrs:message
+            code="radiology.dashboard.tabs.reportTemplates" /></a></li>
+    </openmrs:hasPrivilege>
   </ul>
 </div>
 
@@ -93,7 +97,17 @@
     <div id="radiologyReports" style="display: none;">
 
       <openmrs:portlet url="radiologyReportsTab" id="reportsTab" moduleId="radiology" />
+    </div>
+  </openmrs:hasPrivilege>
+  <openmrs:hasPrivilege privilege="View Radiology Report Templates">
+    <div id="radiologyReportTemplates" style="display: none;">
 
+      <openmrs:portlet url="radiologyReportTemplatesTab" id="reportTemplatesTab" moduleId="radiology" />
+   </div>
+  </openmrs:hasPrivilege>
+  <openmrs:hasPrivilege privilege="View Radiology Report Templates">
+    <div id="radiologyReportTemplates" style="display: none;">
+      <openmrs:portlet url="radiologyReportTemplatesTab" id="reportTemplatesTab" moduleId="radiology" />
     </div>
   </openmrs:hasPrivilege>
 </div>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->
Can now import templates into the system.

## Description
<!--- Describe your changes in detail -->
This pull request holds work done here, https://github.com/openmrs/openmrs-module-radiology/pull/304 . And all comments resolved.

added a parser to parse mrrt template file. Added a unit test and a real life mrrt template for testing

implemented templates tab with popup

removed some duplicate codes in messages.properties that entered due to cherry-picking a commit from another branch

added View Radiology Report Templates privilege which is used in radiologyReportTemplatesTab.jsp

deleted a duplicate file

resolved @teleivo's comment which include, implementing getMrrtReportTemplateByUuid() and deleting MrrtReportTemplateException.java

added unit test covering getMrrtReportTemplateByUuid()

Added MrrtReportTemplateResource.java

can now import templates from ui

attemted to resolve @telivos comment, but still facing a null pointer exception. the problem is with the way i configured my MrrtReportTemplateFileParser bean inside moduleApplicationContext.xml

added a service method to get all templates by title and also implemented a search handler for templates

deleted unnecessary parse(String) method

used Criteria in HibernateDAO

made DefaultMrrtReportTemplateParser package private

made local variables final

reengineered MrrtReportTemplate to extend BaseOpenmrsData and also renamed MrrtReportTemplateServiceTest to MrrtReportTemplateComponentTest to conform to other service tests

changed superclass of MrrtReportTemplateResource

renamed resource properties

resource was returning no description in default representation mode. Fixed it

use REST in template tab

fixed problem with find button not firing in radiologyReportTemplatesTab

moved BaseOpenmrsData properties to the end of the database

added a GP for templates folder

renamed button id on templates tab page

started implementing validator but am still have a null pointer exception

did some code clean ups, adding unit tests, started with implementation of validator, removed code in controller that was importing templates and will put inside an import method in the MrrtReportTemplateService

implemented importReportTemplate method

implemented small part of validation. File validation
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-272

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.