### PR TITLE
RAD-282 Add REST search for RadiologyReport by date

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -11,7 +11,9 @@ package org.openmrs.module.radiology.report;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.radiology.order.RadiologyOrder;
 
@@ -124,5 +126,26 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
                         .add(Restrictions.eq("reportStatus", RadiologyReportStatus.COMPLETED)))
                 .list()
                 .get(0);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria searchCriteria) {
+        
+        Criteria crit = sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyReport.class);
+        
+        if (searchCriteria.getFromDate() != null) {
+            crit.add(Restrictions.ge("reportDate", searchCriteria.getFromDate()));
+        }
+        if (searchCriteria.getToDate() != null) {
+            crit.add(Restrictions.le("reportDate", searchCriteria.getToDate()));
+        }
+        
+        crit.addOrder(Order.asc("reportDate"));
+        return crit.list();
     }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
@@ -57,4 +57,9 @@ interface RadiologyReportDAO {
      * @see org.openmrs.module.radiology.report.RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
      */
     RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     */
+    List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria searchCriteria);
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
@@ -10,10 +10,11 @@ import java.util.Date;
  */
 public class RadiologyReportSearchCriteria {
     
-    private Date fromDate;
     
-    private Date toDate; 
-
+    private final Date fromDate;
+    
+    private final Date toDate;
+    
     private RadiologyReportSearchCriteria(Builder builder) {
         
         this.fromDate = builder.fromDate;
@@ -28,7 +29,6 @@ public class RadiologyReportSearchCriteria {
         return fromDate;
     }
     
-
     /**
      * @return the maximum date (inclusive) the report date
      */
@@ -38,6 +38,7 @@ public class RadiologyReportSearchCriteria {
     }
     
     public static class Builder {
+        
         
         private Date fromDate;
         

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
@@ -1,0 +1,76 @@
+package org.openmrs.module.radiology.report;
+
+import java.util.Date;
+
+/**
+ * The search parameter object for radiology reports. A convenience interface for building
+ * instances is provided by {@link RadiologyReportSearchCriteriaBuilder}.
+ *
+ * @see RadiologyReportSearchCriteriaBuilder
+ */
+public class RadiologyReportSearchCriteria {
+    
+    private Date fromDate;
+    
+    private Date toDate; 
+
+    private RadiologyReportSearchCriteria(Builder builder) {
+        
+        this.fromDate = builder.fromDate;
+        this.toDate = builder.toDate;
+    }
+    
+    /**
+     * @return the minimum date (inclusive) the report date
+     */
+    public Date getFromDate() {
+        
+        return fromDate;
+    }
+    
+
+    /**
+     * @return the maximum date (inclusive) the report date
+     */
+    public Date getToDate() {
+        
+        return toDate;
+    }
+    
+    public static class Builder {
+        
+        private Date fromDate;
+        
+        private Date toDate;
+        
+        /**
+         * @param fromDate the minimum date (inclusive) the report date
+         * @return this builder instance
+         */
+        public Builder setFromDate(Date fromDate) {
+            
+            this.fromDate = fromDate;
+            return this;
+        }
+        
+        /**
+         * @param toDate the maximum date (exclusive) the report date
+         * @return this builder instance
+         */
+        public Builder setToDate(Date toDate) {
+            
+            this.toDate = toDate;
+            return this;
+        }
+        
+        /**
+         * Create an {@link RadiologyReportSearchCriteria} with the properties of this builder instance.
+         * 
+         * @return a new search criteria instance
+         */
+        public RadiologyReportSearchCriteria build() {
+            return new RadiologyReportSearchCriteria(this);
+        }
+    }
+    
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -189,4 +189,19 @@ public interface RadiologyReportService extends OpenmrsService {
      */
     @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
     public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
+    
+    /**
+     * Get all radiology reports that match a variety of (nullable) criteria contained in the parameter object.
+     * Each extra value for a parameter that is provided acts as an "and" and will reduce the number of results returned
+     *
+     * @param radiologyReportSearchCriteria the object containing search parameters
+     * @return a list of radiology reports ordered by increasing report date
+     * @should return a list of radiology reports being within the date range
+     * @should return a list of radiology reports with report date after or equal to from date
+     * @should return a list of radiology reports with report date before or equal to from date 
+     * @should return a empty list if no radiology report matches the criteria
+     * @should throw illegal argument exception if given null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
+    public List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria radiologyReportSearchCriteria);
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -215,4 +215,17 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
         }
         return null;
     }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria radiologyReportSearchCriteria) {
+        
+        if (radiologyReportSearchCriteria == null) {
+            throw new IllegalArgumentException("radiologyReportSearchCriteria cannot be null");
+        }
+        return radiologyReportDAO.getRadiologyReports(radiologyReportSearchCriteria);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
@@ -8,13 +8,13 @@
  */
 package org.openmrs.module.radiology.order;
 
-import java.util.Calendar;
-import java.util.Date;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Calendar;
+import java.util.Date;
 
 import org.junit.Test;
 import org.openmrs.Concept;

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Properties;
@@ -745,7 +746,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     @Test
     public void getRadiologyReports_shouldReturnAListOfRadiologyReportsBeingWithinTheDateRange() throws Exception {
         
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        final DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
                 new RadiologyReportSearchCriteria.Builder().setFromDate(format.parse("2016-05-28"))
                         .setToDate(format.parse("2016-07-01"))
@@ -763,7 +764,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void getRadiologyReports_shouldReturnAListOfRadiologyReportsWithReportDateAfterOrEqualToFromDate()
             throws Exception {
         
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        final DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
                 new RadiologyReportSearchCriteria.Builder().setFromDate(format.parse("2016-05-29"))
                         .build();
@@ -780,7 +781,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     public void getRadiologyReports_shouldReturnAListOfRadiologyReportsWithReportDateBeforeOrEqualToToDate()
             throws Exception {
         
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        final DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
                 new RadiologyReportSearchCriteria.Builder().setToDate(format.parse("2016-06-30"))
                         .build();
@@ -796,7 +797,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     @Test
     public void getRadiologyReports_shouldReturnAEmptyListIfNoRadiologyReportMatchesTheCriteria() throws Exception {
         
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        final DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
                 new RadiologyReportSearchCriteria.Builder().setFromDate(format.parse("2016-04-25"))
                         .setToDate(format.parse("2016-05-27"))

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Properties;
 
@@ -735,5 +736,85 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyOrder cannot be null");
         radiologyReportService.getActiveRadiologyReportByRadiologyOrder(null);
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return a list of radiology reports being within the date range
+     */
+    @Test
+    public void getRadiologyReports_shouldReturnAListOfRadiologyReportsBeingWithinTheDateRange() throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().setFromDate(format.parse("2016-05-28"))
+                        .setToDate(format.parse("2016-07-01"))
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertThat(radiologyReports.size(), is(3));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return a list of radiology reports with report date after or equal to from date
+     */
+    @Test
+    public void getRadiologyReports_shouldReturnAListOfRadiologyReportsWithReportDateAfterOrEqualToFromDate()
+            throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().setFromDate(format.parse("2016-05-29"))
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertThat(radiologyReports.size(), is(2));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return a list of radiology reports with report date before or equal to from date
+     */
+    @Test
+    public void getRadiologyReports_shouldReturnAListOfRadiologyReportsWithReportDateBeforeOrEqualToToDate()
+            throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().setToDate(format.parse("2016-06-30"))
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertThat(radiologyReports.size(), is(2));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return a empty list if no radiology report matches the criteria
+     */
+    @Test
+    public void getRadiologyReports_shouldReturnAEmptyListIfNoRadiologyReportMatchesTheCriteria() throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().setFromDate(format.parse("2016-04-25"))
+                        .setToDate(format.parse("2016-05-27"))
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertThat(radiologyReports.size(), is(0));
+    }
+    
+    /**
+     * @see RadiologyOrderService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies throw illegal argument exception if given null
+     */
+    @Test
+    public void getRadiologyReports_shouldThrowIllegalArgumentExceptionIfGivenNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReportSearchCriteria cannot be null");
+        radiologyReportService.getRadiologyReports(null);
     }
 }

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -74,19 +74,19 @@
   <test_order order_id="2006" />
   <radiology_order order_id="2006" />
   <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="58855a84-3c39-42d8-8d33-6c3f228c0936"/>
-  <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" uuid="e699d90d-e230-4762-8747-d2d0059394b0" />
+  <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" uuid="e699d90d-e230-4762-8747-d2d0059394b0" report_date="2016-05-28" />
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
-  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810"/>
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
 
   <!-- radiology order with associated study and with a discontinued report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="7ed51f0e-5351-4849-9ec3-9e87e18259c5"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="eb6dc805-e79f-4ca2-945b-5e9bdd9491c6"/>
-  <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59"/>
+  <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
@@ -31,7 +31,6 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
      */
     @Override
     public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-        
         if (rep instanceof DefaultRepresentation) {
             final DelegatingResourceDescription description = new DelegatingResourceDescription();
             addDefaultProperties(description);
@@ -50,7 +49,6 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
     }
     
     private void addDefaultProperties(DelegatingResourceDescription description) {
-        
         description.addProperty("uuid");
         description.addProperty("radiologyOrder", Representation.REF);
         description.addProperty("reportDate");
@@ -79,7 +77,7 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
      */
     @PropertyGetter("display")
     public String getDisplayString(RadiologyReport radiologyReport) {
-        
+
         return radiologyReport.getRadiologyOrder()
                 .getOrderNumber() + ", "
                 + radiologyReport.getReportStatus()

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
@@ -31,6 +31,7 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
      */
     @Override
     public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
+        
         if (rep instanceof DefaultRepresentation) {
             final DelegatingResourceDescription description = new DelegatingResourceDescription();
             addDefaultProperties(description);
@@ -49,6 +50,7 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
     }
     
     private void addDefaultProperties(DelegatingResourceDescription description) {
+        
         description.addProperty("uuid");
         description.addProperty("radiologyOrder", Representation.REF);
         description.addProperty("reportDate");
@@ -77,7 +79,7 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
      */
     @PropertyGetter("display")
     public String getDisplayString(RadiologyReport radiologyReport) {
-
+        
         return radiologyReport.getRadiologyOrder()
                 .getOrderNumber() + ", "
                 + radiologyReport.getReportStatus()

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
@@ -1,0 +1,89 @@
+package org.openmrs.module.radiology.report.web.search;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.openmrs.module.radiology.report.RadiologyReport;
+import org.openmrs.module.radiology.report.RadiologyReportSearchCriteria;
+import org.openmrs.module.radiology.report.RadiologyReportService;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestConstants;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchConfig;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchHandler;
+import org.openmrs.module.webservices.rest.web.resource.api.SearchQuery;
+import org.openmrs.module.webservices.rest.web.resource.impl.EmptySearchResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.NeedsPaging;
+import org.openmrs.module.webservices.rest.web.response.ResponseException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Find RadiologyReport's that match the specified search phrase.
+ */
+@Component
+public class RadiologyReportSearchHandler implements SearchHandler {
+    
+    
+    public static final String REQUEST_PARAM_DATE_FROM = "fromdate";
+    
+    public static final String REQUEST_PARAM_DATE_TO = "todate";
+    
+    @Autowired
+    RadiologyReportService radiologyReportService;
+    
+    SearchQuery searchQuery = new SearchQuery.Builder("Allows you to search for RadiologyReport's by from and to date range")
+            .withOptionalParameters(REQUEST_PARAM_DATE_FROM, REQUEST_PARAM_DATE_TO)
+            .build();
+    
+    private final SearchConfig searchConfig =
+            new SearchConfig("default", RestConstants.VERSION_1 + "/radiologyreport", Arrays.asList("2.0.*"), searchQuery);
+    
+    /**
+     * @see org.openmrs.module.webservices.rest.web.resource.api.SearchHandler#getSearchConfig()
+     */
+    @Override
+    public SearchConfig getSearchConfig() {
+        
+        return this.searchConfig;
+    }
+    
+    /**
+     * @see org.openmrs.module.webservices.rest.web.resource.api.SearchHandler#getSearchConfig()
+     * @should return a list of radiology reports being within the date range
+     * @should return a list of radiology reports with report date after or equal to from date
+     * @should return a list of radiology reports with report date before or equal to from date
+     * @should return empty search result if no report is in date range
+     */
+    @Override
+    public PageableResult search(RequestContext context) throws ResponseException {
+        
+        final String fromDateString = context.getRequest()
+                .getParameter(REQUEST_PARAM_DATE_FROM);
+        final String toDateString = context.getRequest()
+                .getParameter(REQUEST_PARAM_DATE_TO);
+        
+        Date fromDate = null;
+        Date toDate = null;
+        if (fromDateString != null) {
+            fromDate = (Date) ConversionUtil.convert(fromDateString, Date.class);
+        }
+        if (toDateString != null) {
+            toDate = (Date) ConversionUtil.convert(toDateString, Date.class);
+        }
+        
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().setFromDate(fromDate)
+                        .setToDate(toDate)
+                        .build();
+        
+        List<RadiologyReport> result = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        
+        if (result.isEmpty()) {
+            return new EmptySearchResult();
+        }
+        return new NeedsPaging<RadiologyReport>(result, context);
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerTest.java
@@ -78,7 +78,6 @@ public class RadiologyOrderSearchHandlerTest {
         
         patientWithoutOrders.setUuid(PATIENT_UUID_WITHOUT_ORDERS);
         
-        PowerMockito.mockStatic(RestUtil.class);
         PowerMockito.mockStatic(Context.class);
         when(Context.getPatientService()).thenReturn(patientService);
         when(patientResource.getByUniqueId(PATIENT_UUID_WITH_ORDERS)).thenReturn(patientWithOrders);

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerTest.java
@@ -1,0 +1,155 @@
+package org.openmrs.module.radiology.report.web.search;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.radiology.order.RadiologyOrder;
+import org.openmrs.module.radiology.order.web.search.RadiologyOrderSearchHandler;
+import org.openmrs.module.radiology.report.RadiologyReport;
+import org.openmrs.module.radiology.report.RadiologyReportSearchCriteria;
+import org.openmrs.module.radiology.report.RadiologyReportService;
+import org.openmrs.module.webservices.rest.web.ConversionUtil;
+import org.openmrs.module.webservices.rest.web.RequestContext;
+import org.openmrs.module.webservices.rest.web.RestUtil;
+import org.openmrs.module.webservices.rest.web.api.RestService;
+import org.openmrs.module.webservices.rest.web.resource.api.PageableResult;
+import org.openmrs.module.webservices.rest.web.resource.impl.EmptySearchResult;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * Tests {@link RadiologyOrderSearchHandler}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ RestUtil.class, Context.class })
+public class RadiologyReportSearchHandlerTest {
+    
+    
+    private static final String REPORT1_DATE = "2016-06-01";
+    
+    private static final String REPORT2_DATE = "2016-07-01";
+    
+    private static final String DATE_AFTER_REPORT_DATES = "2016-07-02";
+    
+    private static final String DATE_BEFORE_REPORT_DATES = "2016-05-28";
+    
+    private static final String DATE_BETWEEN_REPORT_DATES = "2016-06-15";
+    
+    private static final String PATIENT_UUID_UNKNOWN = "99999999-fca0-11e5-9e59-08002719a237";
+    
+    @Mock
+    RestService restService;
+    
+    @Mock
+    RadiologyReportService radiologyReportService;
+    
+    RadiologyReportSearchHandler radiologyReportSearchHandler = new RadiologyReportSearchHandler();
+    
+    @Mock
+    RadiologyOrder radiologyOrder;
+    
+    RadiologyReport radiologyReport1;
+    
+    RadiologyReport radiologyReport2;
+    
+    @Before
+    public void setUp() throws Exception {
+        
+        when(radiologyOrder.isCompleted()).thenReturn(true);
+        
+        radiologyReport1 = new RadiologyReport(radiologyOrder);
+        radiologyReport2 = new RadiologyReport(radiologyOrder);
+        radiologyReport1.setReportDate((Date) ConversionUtil.convert(REPORT1_DATE, Date.class));
+        radiologyReport2.setReportDate((Date) ConversionUtil.convert(REPORT2_DATE, Date.class));
+        
+        PowerMockito.mockStatic(RestUtil.class);
+        PowerMockito.mockStatic(Context.class);
+        when(Context.getService(RadiologyReportService.class)).thenReturn(radiologyReportService);
+        when(Context.getService(RestService.class)).thenReturn(restService);
+    }
+    
+    /**
+     * @see RadiologyReportSearchHandler#search(RequestContext)
+     * @verifies return a list of radiology reports being within the date range
+     */
+    @Test
+    public void search_shouldReturnAListOfRadiologyReportsBeingWithinTheDateRange() throws Exception {
+        
+        //        RadiologyReportSearchCriteria radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder()
+        //                .setFromDate((Date) ConversionUtil.convert(DATE_BEFORE_REPORT_DATES, Date.class))
+        //                .setToDate((Date) ConversionUtil.convert(DATE_AFTER_REPORT_DATES, Date.class))
+        //                .build();
+        //        
+        //        List<RadiologyReport> radiologyReports = new ArrayList<RadiologyReport>();
+        //        radiologyReports.add(radiologyReport1);
+        //        radiologyReports.add(radiologyReport2);
+        //               
+        //        when(radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria))
+        //                .thenReturn(radiologyReports);
+        //        
+        //        MockHttpServletRequest request = new MockHttpServletRequest();
+        //        request.setParameter(RadiologyReportSearchHandler.REQUEST_PARAM_DATE_FROM, PATIENT_UUID_UNKNOWN);
+        //        RequestContext requestContext = new RequestContext();
+        //        requestContext.setRequest(request);
+        //        
+        //        PageableResult pageableResult = radiologyReportSearchHandler.search(requestContext);
+        //        assertThat(pageableResult, is(instanceOf(EmptySearchResult.class)));
+    }
+    
+    /**
+     * @see RadiologyReportSearchHandler#search(RequestContext)
+     * @verifies return a list of radiology reports with report date after or equal to from date
+     */
+    @Test
+    public void search_shouldReturnAListOfRadiologyReportsWithReportDateAfterOrEqualToFromDate() throws Exception {
+        // TODO auto-generated
+        Assert.fail("Not yet implemented");
+    }
+    
+    /**
+     * @see RadiologyReportSearchHandler#search(RequestContext)
+     * @verifies return a list of radiology reports with report date before or equal to from date
+     */
+    @Test
+    public void search_shouldReturnAListOfRadiologyReportsWithReportDateBeforeOrEqualToFromDate() throws Exception {
+        // TODO auto-generated
+        Assert.fail("Not yet implemented");
+    }
+    
+    /**
+     * @see RadiologyReportSearchHandler#search(RequestContext)
+     * @verifies return empty search result if no report is in date range
+     */
+    @Test
+    public void search_shouldReturnEmptySearchResultIfNoReportIsInDateRange() throws Exception {
+        
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder()
+                .setFromDate((Date) ConversionUtil.convert(DATE_AFTER_REPORT_DATES, Date.class))
+                .build();
+        when(radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria))
+                .thenReturn(new ArrayList<RadiologyReport>());
+        
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setParameter(RadiologyReportSearchHandler.REQUEST_PARAM_DATE_FROM, DATE_AFTER_REPORT_DATES);
+        RequestContext requestContext = new RequestContext();
+        requestContext.setRequest(request);
+        
+        PageableResult pageableResult = radiologyReportSearchHandler.search(requestContext);
+        assertThat(pageableResult, is(instanceOf(EmptySearchResult.class)));
+    }
+    
+}


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
Provide search capabilities for the RadiologyReport resource so that a
user of the API can get all RadiologyReports within a certain date
range.

* add RadiologyReportSearchCriteria
* add search method to RadiologyReportService and RadiologyReportDAO
* modified RadiologyReportServiceComponentTestDataset.xml for component tests
* add component tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-282