### PR TITLE
RAD-282 Add REST search for RadiologyReport by date

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -11,7 +11,9 @@ package org.openmrs.module.radiology.report;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
+import org.hibernate.criterion.Order;
 import org.hibernate.criterion.Restrictions;
 import org.openmrs.module.radiology.order.RadiologyOrder;
 
@@ -124,5 +126,26 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
                         .add(Restrictions.eq("reportStatus", RadiologyReportStatus.COMPLETED)))
                 .list()
                 .get(0);
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria searchCriteria) {
+        
+        final Criteria crit = sessionFactory.getCurrentSession()
+                .createCriteria(RadiologyReport.class);
+        
+        if (searchCriteria.getFromDate() != null) {
+            crit.add(Restrictions.ge("reportDate", searchCriteria.getFromDate()));
+        }
+        if (searchCriteria.getToDate() != null) {
+            crit.add(Restrictions.le("reportDate", searchCriteria.getToDate()));
+        }
+        
+        crit.addOrder(Order.asc("reportDate"));
+        return crit.list();
     }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
@@ -57,4 +57,9 @@ interface RadiologyReportDAO {
      * @see org.openmrs.module.radiology.report.RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
      */
     RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
+    
+    /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     */
+    List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria searchCriteria);
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
@@ -1,0 +1,74 @@
+package org.openmrs.module.radiology.report;
+
+import java.util.Date;
+
+/**
+ * The search parameter object for {@code RadiologyReport's}. A convenience interface for building
+ * instances.
+ */
+public class RadiologyReportSearchCriteria {
+    
+    
+    private final Date fromDate;
+    
+    private final Date toDate;
+    
+    /**
+     * @return the minimum date (inclusive) the report date
+     */
+    public Date getFromDate() {
+        
+        return fromDate;
+    }
+    
+    /**
+     * @return the maximum date (inclusive) the report date
+     */
+    public Date getToDate() {
+        
+        return toDate;
+    }
+    
+    public static class Builder {
+        
+        
+        private Date fromDate;
+        
+        private Date toDate;
+        
+        /**
+         * @param fromDate the minimum date (inclusive) the report date
+         * @return this builder instance
+         */
+        public Builder withFromDate(Date fromDate) {
+            
+            this.fromDate = fromDate;
+            return this;
+        }
+        
+        /**
+         * @param toDate the maximum date (inclusive) the report date
+         * @return this builder instance
+         */
+        public Builder withToDate(Date toDate) {
+            
+            this.toDate = toDate;
+            return this;
+        }
+        
+        /**
+         * Create an {@link RadiologyReportSearchCriteria} with the properties of this builder instance.
+         * 
+         * @return a new search criteria instance
+         */
+        public RadiologyReportSearchCriteria build() {
+            return new RadiologyReportSearchCriteria(this);
+        }
+    }
+    
+    private RadiologyReportSearchCriteria(Builder builder) {
+        
+        this.fromDate = builder.fromDate;
+        this.toDate = builder.toDate;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -189,4 +189,20 @@ public interface RadiologyReportService extends OpenmrsService {
      */
     @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
     public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder);
+    
+    /**
+     * Get all {@code RadiologyReport's} matching a variety of (nullable) criteria.
+     * Each extra value for a parameter that is provided acts as an "and" and will reduce the number of results returned
+     *
+     * @param radiologyReportSearchCriteria the object containing search parameters
+     * @return a list of radiology reports ordered by increasing report date
+     * @throws IllegalArgumentException if given null
+     * @should return all radiology reports within given date range if date to and date from are specified
+     * @should return all radiology reports with report date after or equal to from date if only date from was specified
+     * @should return all radiology reports with report date before or equal to to date if only date to was specified
+     * @should return empty list given criteria without match
+     * @should throw illegal argument exception if given null
+     */
+    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_REPORTS)
+    public List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria radiologyReportSearchCriteria);
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -215,4 +215,17 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
         }
         return null;
     }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     */
+    @Transactional(readOnly = true)
+    @Override
+    public List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria radiologyReportSearchCriteria) {
+        
+        if (radiologyReportSearchCriteria == null) {
+            throw new IllegalArgumentException("radiologyReportSearchCriteria cannot be null");
+        }
+        return radiologyReportDAO.getRadiologyReports(radiologyReportSearchCriteria);
+    }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
@@ -8,13 +8,13 @@
  */
 package org.openmrs.module.radiology.order;
 
-import java.util.Calendar;
-import java.util.Date;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import java.util.Calendar;
+import java.util.Date;
 
 import org.junit.Test;
 import org.openmrs.Concept;

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -18,6 +18,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
@@ -735,5 +737,106 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyOrder cannot be null");
         radiologyReportService.getActiveRadiologyReportByRadiologyOrder(null);
+    }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return all radiology reports within given date range if date to and date from are specified
+     */
+    @Test
+    public void getRadiologyReports_shouldReturnAllRadiologyReportsWithinGivenDateRangeIfDateToAndDateFromAreSpecified()
+            throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date fromDate = format.parse("2016-05-28");
+        Date toDate = format.parse("2016-07-01");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
+                        .withToDate(toDate)
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertThat(radiologyReports.size(), is(3));
+        for (RadiologyReport radiologyReport : radiologyReports) {
+            assertTrue(radiologyReport.getReportDate()
+                    .compareTo(fromDate) >= 0);
+            assertTrue(radiologyReport.getReportDate()
+                    .compareTo(toDate) <= 0);
+        }
+    }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return all radiology reports with report date after or equal to from date if only date from was specified
+     */
+    @Test
+    public void
+            getRadiologyReports_shouldReturnAllRadiologyReportsWithReportDateAfterOrEqualToFromDateIfOnlyDateFromWasSpecified()
+                    throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date fromDate = format.parse("2016-05-29");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertThat(radiologyReports.size(), is(2));
+        for (RadiologyReport radiologyReport : radiologyReports) {
+            assertTrue(radiologyReport.getReportDate()
+                    .compareTo(fromDate) >= 0);
+        }
+    }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return all radiology reports with report date before or equal to to date if only date to was specified
+     */
+    @Test
+    public void
+            getRadiologyReports_shouldReturnAllRadiologyReportsWithReportDateBeforeOrEqualToToDateIfOnlyDateToWasSpecified()
+                    throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        Date toDate = format.parse("2016-06-30");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().withToDate(toDate)
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertThat(radiologyReports.size(), is(2));
+        for (RadiologyReport radiologyReport : radiologyReports) {
+            assertTrue(radiologyReport.getReportDate()
+                    .compareTo(toDate) <= 0);
+        }
+    }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies return empty list given criteria without match
+     */
+    @Test
+    public void getRadiologyReports_shouldReturnEmptyListGivenCriteriaWithoutMatch() throws Exception {
+        
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd");
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria =
+                new RadiologyReportSearchCriteria.Builder().withFromDate(format.parse("2016-04-25"))
+                        .withToDate(format.parse("2016-05-27"))
+                        .build();
+        
+        List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
+        assertTrue(radiologyReports.isEmpty());
+    }
+    
+    /**
+     * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
+     * @verifies throw illegal argument exception if given null
+     */
+    @Test
+    public void getRadiologyReports_shouldThrowIllegalArgumentExceptionIfGivenNull() throws Exception {
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("radiologyReportSearchCriteria cannot be null");
+        radiologyReportService.getRadiologyReports(null);
     }
 }

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -74,19 +74,19 @@
   <test_order order_id="2006" />
   <radiology_order order_id="2006" />
   <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="58855a84-3c39-42d8-8d33-6c3f228c0936"/>
-  <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" uuid="e699d90d-e230-4762-8747-d2d0059394b0" />
+  <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" uuid="e699d90d-e230-4762-8747-d2d0059394b0" report_date="2016-05-28" />
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
-  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810"/>
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
 
   <!-- radiology order with associated study and with a discontinued report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="7ed51f0e-5351-4849-9ec3-9e87e18259c5"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="eb6dc805-e79f-4ca2-945b-5e9bdd9491c6"/>
-  <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59"/>
+  <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
@@ -31,7 +31,6 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
      */
     @Override
     public DelegatingResourceDescription getRepresentationDescription(Representation rep) {
-        
         if (rep instanceof DefaultRepresentation) {
             final DelegatingResourceDescription description = new DelegatingResourceDescription();
             addDefaultProperties(description);
@@ -50,7 +49,6 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
     }
     
     private void addDefaultProperties(DelegatingResourceDescription description) {
-        
         description.addProperty("uuid");
         description.addProperty("radiologyOrder", Representation.REF);
         description.addProperty("reportDate");


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Provide search capabilities for the RadiologyReport resource so that a
user of the API can get all RadiologyReports within a certain date
range.

* add RadiologyReportSearchCriteria
* add search method to RadiologyReportService and RadiologyReportDAO
* modified RadiologyReportServiceComponentTestDataset.xml for component tests
* add component tests

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-282

