### PR TITLE
RAD-308 Do not include discontinued reports by default

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -121,9 +121,7 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
         return (RadiologyReport) sessionFactory.getCurrentSession()
                 .createCriteria(RadiologyReport.class)
                 .add(Restrictions.eq("radiologyOrder", radiologyOrder))
-                .add(Restrictions.disjunction()
-                        .add(Restrictions.eq("reportStatus", RadiologyReportStatus.CLAIMED))
-                        .add(Restrictions.eq("reportStatus", RadiologyReportStatus.COMPLETED)))
+                .add(Restrictions.not(Restrictions.eq("reportStatus", RadiologyReportStatus.DISCONTINUED)))
                 .list()
                 .get(0);
     }
@@ -138,6 +136,9 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
         final Criteria crit = sessionFactory.getCurrentSession()
                 .createCriteria(RadiologyReport.class);
         
+        if (!searchCriteria.getIncludeDiscontinued()) {
+            crit.add(Restrictions.not(Restrictions.eq("reportStatus", RadiologyReportStatus.DISCONTINUED)));
+        }
         if (searchCriteria.getFromDate() != null) {
             crit.add(Restrictions.ge("reportDate", searchCriteria.getFromDate()));
         }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
@@ -16,6 +16,8 @@ public class RadiologyReportSearchCriteria {
     
     private final Provider principalResultsInterpreter;
     
+    private final Boolean includeDiscontinued;
+    
     /**
      * @return the minimum date (inclusive) the report date
      */
@@ -30,6 +32,14 @@ public class RadiologyReportSearchCriteria {
     public Date getToDate() {
         
         return toDate;
+    }
+    
+    /**
+     * @return the {@code Boolean} specifying whether or not to include discontinued radiology reports
+     */
+    public Boolean getIncludeDiscontinued() {
+        
+        return includeDiscontinued;
     }
     
     /**
@@ -48,6 +58,8 @@ public class RadiologyReportSearchCriteria {
         private Date toDate;
         
         private Provider principalResultsInterpreter;
+        
+        private Boolean includeDiscontinued = false;
         
         /**
          * @param fromDate the minimum date (inclusive) the report date
@@ -80,6 +92,17 @@ public class RadiologyReportSearchCriteria {
         }
         
         /**
+         * includes discontinued radiology reports
+         * 
+         * @return this builder instance
+         */
+        public Builder includeDiscontinued() {
+            
+            this.includeDiscontinued = true;
+            return this;
+        }
+        
+        /**
          * Create an {@link RadiologyReportSearchCriteria} with the properties of this builder instance.
          * 
          * @return a new search criteria instance
@@ -94,5 +117,6 @@ public class RadiologyReportSearchCriteria {
         this.fromDate = builder.fromDate;
         this.toDate = builder.toDate;
         this.principalResultsInterpreter = builder.principalResultsInterpreter;
+        this.includeDiscontinued = builder.includeDiscontinued;
     }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -197,9 +197,10 @@ public interface RadiologyReportService extends OpenmrsService {
      * @param radiologyReportSearchCriteria the object containing search parameters
      * @return the radiology reports matching given criteria ordered by increasing report date
      * @throws IllegalArgumentException if given null
+     * @should return all radiology reports (including discontinued) matching the search query if include discontinued is set
      * @should return all radiology reports within given date range if date to and date from are specified
-     * @should return all radiology reports with report date after or equal to from date if only date from was specified
-     * @should return all radiology reports with report date before or equal to to date if only date to was specified
+     * @should return all radiology reports with report date after or equal to from date if only date from is specified
+     * @should return all radiology reports with report date before or equal to to date if only date to is specified
      * @should return empty list if from date after to date
      * @should return empty search result if no report is in date range
      * @should return all radiology reports for given principal results interpreter

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -84,10 +84,17 @@
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
   <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
 
-  <!-- radiology order with associated study and with a discontinued report -->
+  <!-- radiology order with associated study and a discontinued report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="7ed51f0e-5351-4849-9ec3-9e87e18259c5"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="eb6dc805-e79f-4ca2-945b-5e9bdd9491c6"/>
   <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
+  
+  <!-- radiology order with associated study and a completed report -->
+  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
+  <test_order order_id="2009" />
+  <radiology_order order_id="2009" />
+  <radiology_study study_id="7" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.7" order_id="2009" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2016-07-01 13:17:15.0" uuid="7ffd5b5e-473f-11e6-beb8-9e71128cae77"/>
+  <radiology_report report_id="4" order_id="2009" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2016-07-01 13:17:15.0" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
@@ -47,8 +47,8 @@ public class RadiologyReportSearchHandler implements SearchHandler {
     
     SearchQuery searchQuery = new SearchQuery.Builder(
             "Allows you to search for RadiologyReport's by from date, to date and principal results interpreter")
-                    .withOptionalParameters(REQUEST_PARAM_DATE_FROM, REQUEST_PARAM_DATE_TO,
-                        REQUEST_PARAM_PRINCIPAL_RESULT_INTERPRETER, REQUEST_PARAM_TOTAL_COUNT)
+                    .withOptionalParameters(RestConstants.REQUEST_PROPERTY_FOR_INCLUDE_ALL, REQUEST_PARAM_DATE_FROM,
+                        REQUEST_PARAM_DATE_TO, REQUEST_PARAM_PRINCIPAL_RESULT_INTERPRETER, REQUEST_PARAM_TOTAL_COUNT)
                     .build();
     
     private final SearchConfig searchConfig =
@@ -65,9 +65,10 @@ public class RadiologyReportSearchHandler implements SearchHandler {
     
     /**
      * @see org.openmrs.module.webservices.rest.web.resource.api.SearchHandler#search()
+     * @should return all radiology reports (including discontinued) matching the search query if include all is set
      * @should return all radiology reports within given date range if date to and date from are specified
-     * @should return all radiology reports with report date after or equal to from date if only date from was specified
-     * @should return all radiology reports with report date before or equal to to date if only date to was specified
+     * @should return all radiology reports with report date after or equal to from date if only date from is specified
+     * @should return all radiology reports with report date before or equal to to date if only date to is specified
      * @should return empty search result if no report is in date range
      * @should return all radiology reports for given principal results interpreter
      * @should return empty search result if no report exists for principal results interpreter
@@ -102,11 +103,19 @@ public class RadiologyReportSearchHandler implements SearchHandler {
             }
         }
         
-        final RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
-                        .withToDate(toDate)
-                        .withPrincipalResultsInterpreter(principalResultsInterpreter)
-                        .build();
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria;
+        if (context.getIncludeAll()) {
+            radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
+                    .withToDate(toDate)
+                    .withPrincipalResultsInterpreter(principalResultsInterpreter)
+                    .includeDiscontinued()
+                    .build();
+        } else {
+            radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
+                    .withToDate(toDate)
+                    .withPrincipalResultsInterpreter(principalResultsInterpreter)
+                    .build();
+        }
         
         final List<RadiologyReport> result = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
         

--- a/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
@@ -54,7 +54,7 @@
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
-  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-07-01"/>
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-30"/>
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:18:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:18:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79656"/>
@@ -63,4 +63,10 @@
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:18:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5ca"/>
   <radiology_report report_id="3" order_id="2008" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29811" report_date="2016-06-01"/>
 
+  <!-- radiology order with associated study and a discontinued report -->
+  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
+  <test_order order_id="2009" />
+  <radiology_order order_id="2009" />
+  <radiology_study study_id="7" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.7" order_id="2009" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2016-07-01 13:17:15.0" uuid="7ffd5b5e-473f-11e6-beb8-9e71128cae77"/>
+  <radiology_report report_id="4" order_id="2009" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2016-07-01 13:17:15.0" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
 </dataset>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
RadiologyReport.reportStatus=DISCONTINUED should only be returned if
specifically asked for.

* add includeAll paramater to RadiologyReportSearchHandler
* add component test for RadiologyReportSearchHandler
* add includeDiscontinued attribute to RadiologyReportSearchCriteria
* modify report dao method getRadiologyReports
* add test to RadiologyReportServiceComponentTest

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-308

