### PR TITLE
RAD-136 Fix bug with null provider and show status

### DIFF
--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -50,6 +50,8 @@
 @MODULE_ID@.datatables.column.report.date=Date
 @MODULE_ID@.datatables.column.report.principalResultsInterpreter=Principal Results Interpreter
 @MODULE_ID@.datatables.column.report.status=Status
+@MODULE_ID@.datatables.column.report.dateCreated=Date created
+@MODULE_ID@.datatables.column.report.createdBy=Created By
 
 @MODULE_ID@.report.boxheader=Reports
 

--- a/omod/src/main/webapp/portlets/radiologyReportsTab.jsp
+++ b/omod/src/main/webapp/portlets/radiologyReportsTab.jsp
@@ -63,7 +63,12 @@
                                             "name": "principalResultsInterpreter",
                                             "render": function(data, type,
                                                     full, meta) {
-                                              return full.principalResultsInterpreter.display;
+                                              if ((typeof (full.principalResultsInterpreter) !== 'undefined')
+                                                      && (full.principalResultsInterpreter !== null)) {
+                                                return full.principalResultsInterpreter.display;
+                                              } else {
+                                                return "";
+                                              }
                                             }
                                           },
                                           {
@@ -72,7 +77,6 @@
                                                     full, meta) {
                                               var result = "";
                                               if (full.reportDate) {
-
                                                 result = moment(full.reportDate)
                                                         .format("LL");
                                               }
@@ -81,10 +85,29 @@
                                           },
                                           {
                                             "name": "reportStatus",
-                                            "visible": false,
                                             "render": function(data, type,
                                                     full, meta) {
                                               return full.reportStatus;
+                                            }
+                                          },
+                                          {
+                                            "name": "dateCreated",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              var result = "";
+                                              if (full.auditInfo.dateCreated) {
+                                                result = moment(
+                                                        full.auditInfo.dateCreated)
+                                                        .format("LLL");
+                                              }
+                                              return result;
+                                            }
+                                          },
+                                          {
+                                            "name": "creatorBy",
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                              return full.auditInfo.creator.display;
                                             }
                                           }, ],
                                     });
@@ -128,6 +151,8 @@
           <th><spring:message code="radiology.datatables.column.report.principalResultsInterpreter" /></th>
           <th><spring:message code="radiology.datatables.column.report.date" /></th>
           <th><spring:message code="radiology.datatables.column.report.status" /></th>
+          <th><spring:message code="radiology.datatables.column.report.dateCreated" /></th>
+          <th><spring:message code="radiology.datatables.column.report.createdBy" /></th>
         </tr>
       </thead>
     </table>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
* when principalResultsInterpreter of a report was null due to the report
being a draft, then the list wouldnt load
* status column was hidden
* show date created and creator

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-136

