### PR TITLE
RAD-332 Fix Transactions Across Service Methods

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -16,14 +16,12 @@ import org.openmrs.Provider;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.radiology.RadiologyPrivileges;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service layer for {@code RadiologyOrder}.
  * 
  * @see org.openmrs.module.radiology.order.RadiologyOrder
  */
-@Transactional
 public interface RadiologyOrderService extends OpenmrsService {
     
     

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
@@ -23,6 +23,7 @@ import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.study.RadiologyStudyService;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyOrderService {
     
     
@@ -59,8 +60,8 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     /**
      * @see RadiologyOrderService#placeRadiologyOrder(RadiologyOrder)
      */
-    @Transactional
     @Override
+    @Transactional
     public RadiologyOrder placeRadiologyOrder(RadiologyOrder radiologyOrder) {
         
         if (radiologyOrder == null) {
@@ -102,7 +103,6 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
      * @return radiology order encounter for given parameters
      * @should create radiology order encounter
      */
-    @Transactional
     private Encounter saveRadiologyOrderEncounter(Patient patient, Provider provider, Date encounterDateTime) {
         Encounter radiologyOrderEncounter = new Encounter();
         radiologyOrderEncounter.setPatient(patient);
@@ -116,8 +116,8 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
      * @throws Exception
      * @see RadiologyOrderService#discontinueRadiologyOrder(RadiologyOrder, Provider, String)
      */
-    @Transactional
     @Override
+    @Transactional
     public Order discontinueRadiologyOrder(RadiologyOrder radiologyOrderToDiscontinue, Provider orderer,
             String nonCodedDiscontinueReason) throws Exception {
         
@@ -155,7 +155,6 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     /**
      * @see RadiologyOrderService#getRadiologyOrder(Integer)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyOrder getRadiologyOrder(Integer orderId) {
         
@@ -169,7 +168,6 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     /**
      * @see RadiologyOrderService#getRadiologyOrderByUuid(String)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyOrder getRadiologyOrderByUuid(String uuid) {
         
@@ -183,7 +181,6 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     /**
      * @see RadiologyOrderService#getRadiologyOrdersByPatient(Patient)
      */
-    @Transactional(readOnly = true)
     @Override
     public List<RadiologyOrder> getRadiologyOrdersByPatient(Patient patient) {
         
@@ -197,7 +194,6 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     /**
      * @see RadiologyOrderService#getRadiologyOrdersByPatients
      */
-    @Transactional(readOnly = true)
     @Override
     public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
         

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -15,14 +15,12 @@ import org.openmrs.annotation.Authorized;
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.radiology.RadiologyPrivileges;
 import org.openmrs.module.radiology.order.RadiologyOrder;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service layer for {@code RadiologyReport}.
  * 
  * @see org.openmrs.module.radiology.report.RadiologyReport
  */
-@Transactional
 public interface RadiologyReportService extends OpenmrsService {
     
     

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -11,6 +11,7 @@ import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.radiology.order.RadiologyOrder;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 class RadiologyReportServiceImpl extends BaseOpenmrsService implements RadiologyReportService {
     
     
@@ -25,8 +26,8 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#createAndClaimRadiologyReport(RadiologyOrder)
      */
-    @Transactional
     @Override
+    @Transactional
     public RadiologyReport createAndClaimRadiologyReport(RadiologyOrder radiologyOrder)
             throws IllegalArgumentException, UnsupportedOperationException {
         
@@ -51,8 +52,8 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      */
-    @Transactional
     @Override
+    @Transactional
     public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport)
             throws IllegalArgumentException, UnsupportedOperationException {
         
@@ -74,8 +75,8 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#unclaimRadiologyReport(RadiologyReport)
      */
-    @Transactional
     @Override
+    @Transactional
     public RadiologyReport unclaimRadiologyReport(RadiologyReport radiologyReport)
             throws IllegalArgumentException, UnsupportedOperationException {
         
@@ -98,8 +99,8 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
      */
-    @Transactional
     @Override
+    @Transactional
     public RadiologyReport completeRadiologyReport(RadiologyReport radiologyReport, Provider principalResultsInterpreter)
             throws IllegalArgumentException, UnsupportedOperationException {
         
@@ -127,7 +128,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#getRadiologyReport(Integer)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyReport getRadiologyReport(Integer reportId) throws IllegalArgumentException {
         
@@ -140,7 +140,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#getRadiologyReportByUuid(String)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyReport getRadiologyReportByUuid(String radiologyReportUuid) throws IllegalArgumentException {
         
@@ -153,7 +152,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder, RadiologyReportStatus)
      */
-    @Transactional(readOnly = true)
     @Override
     public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder radiologyOrder,
             RadiologyReportStatus reportStatus) throws IllegalArgumentException {
@@ -174,7 +172,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
      */
-    @Transactional(readOnly = true)
     @Override
     public boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder) {
         
@@ -187,7 +184,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
      */
-    @Transactional(readOnly = true)
     @Override
     public boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder) {
         
@@ -200,7 +196,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyReport getActiveRadiologyReportByRadiologyOrder(RadiologyOrder radiologyOrder) {
         
@@ -219,7 +214,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     /**
      * @see RadiologyReportService#getRadiologyReports(RadiologyReportSearchCriteria)
      */
-    @Transactional(readOnly = true)
     @Override
     public List<RadiologyReport> getRadiologyReports(RadiologyReportSearchCriteria radiologyReportSearchCriteria) {
         

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
@@ -13,14 +13,12 @@ import java.util.List;
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
 import org.openmrs.module.radiology.order.RadiologyOrder;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Service layer for {@code RadiologyStudy}.
  * 
  * @see org.openmrs.module.radiology.study.RadiologyStudy
  */
-@Transactional
 public interface RadiologyStudyService extends OpenmrsService {
     
     

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
@@ -21,6 +21,7 @@ import org.openmrs.module.radiology.dicom.code.ScheduledProcedureStepStatus;
 import org.openmrs.module.radiology.order.RadiologyOrder;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyStudyService {
     
     
@@ -89,8 +90,8 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     /**
      * @see RadiologyStudyService#updateStudyPerformedStatus(String, PerformedProcedureStepStatus)
      */
-    @Transactional
     @Override
+    @Transactional
     public RadiologyStudy updateStudyPerformedStatus(String studyInstanceUid, PerformedProcedureStepStatus performedStatus) {
         
         if (studyInstanceUid == null) {
@@ -109,7 +110,6 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     /**
      * @see RadiologyStudyService#getRadiologyStudy(Integer)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyStudy getRadiologyStudy(Integer studyId) {
         
@@ -123,7 +123,6 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     /**
      * @see RadiologyStudyService#getRadiologyStudyByUuid(String)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyStudy getRadiologyStudyByUuid(String uuid) {
         
@@ -137,7 +136,6 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     /**
      * @see RadiologyStudyService#getRadiologyStudyByOrderId(Integer)
      */
-    @Transactional(readOnly = true)
     @Override
     public RadiologyStudy getRadiologyStudyByOrderId(Integer orderId) {
         
@@ -151,7 +149,6 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     /**
      * @see RadiologyStudyService#getRadiologyStudyByStudyInstanceUid(String)
      */
-    @Transactional(readOnly = true)
     public RadiologyStudy getRadiologyStudyByStudyInstanceUid(String studyInstanceUid) {
         
         if (studyInstanceUid == null) {
@@ -164,7 +161,6 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
      * @see RadiologyStudyService#getStudiesByRadiologyOrders
      */
     @Override
-    @Transactional(readOnly = true)
     public List<RadiologyStudy> getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
         
         if (radiologyOrders == null) {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Spring advises to annotate only concrete classes with @Transactional

* remove @Transactional from our Service interfaces
* add class level @Transactional(readOnly=true) to our Service implemenations at class level
* override @Transactional(readOnly=true) for methods which are not-read only
* remove @Transactional from private method RadiologyOrderServiceImpl.saveRadiologyOrderEncounter
since it has no effect

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-332
