### PR TITLE
RAD-231 Use maven license header plugin

### DIFF
--- a/acceptanceTest/src/main/java/org/openmrs/module/radiology/acceptancetest/dataset/DbTestSelectSupport.java
+++ b/acceptanceTest/src/main/java/org/openmrs/module/radiology/acceptancetest/dataset/DbTestSelectSupport.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.acceptancetest.dataset;
 
 import org.springframework.dao.EmptyResultDataAccessException;

--- a/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/Aselecttests/FindUsersTest.java
+++ b/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/Aselecttests/FindUsersTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.acceptancetest.dataset.Aselecttests;
 
 import org.openmrs.module.radiology.acceptancetest.dataset.DbTestConfiguration;

--- a/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/DbSetup.java
+++ b/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/DbSetup.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.acceptancetest.dataset;
 
 import org.dbunit.operation.DatabaseOperation;

--- a/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/DbSetupConfiguration.java
+++ b/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/DbSetupConfiguration.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.acceptancetest.dataset;
 
 import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;

--- a/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/DbTestConfiguration.java
+++ b/acceptanceTest/src/test/java/org/openmrs/module/radiology/acceptancetest/dataset/DbTestConfiguration.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.acceptancetest.dataset;
 
 import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;

--- a/acceptanceTest/src/test/resources/org/openmrs/module/radiology/acceptancetest/dataset/DbSetup_setupData.xml
+++ b/acceptanceTest/src/test/resources/org/openmrs/module/radiology/acceptancetest/dataset/DbSetup_setupData.xml
@@ -1,3 +1,14 @@
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <dataset>
   <encounter
           encounter_id="10"

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,9 +1,14 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public 
-	License, v. 2.0. If a copy of the MPL was not distributed with this file, 
-	You can obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed 
-	under the terms of the Healthcare Disclaimer located at http://openmrs.org/license. 
-	Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
-	graphic logo is a trademark of OpenMRS Inc. -->
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/api/src/main/java/org/openmrs/module/radiology/Modality.java
+++ b/api/src/main/java/org/openmrs/module/radiology/Modality.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyActivator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyActivator.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyPrivileges.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyPrivileges.java
@@ -3,10 +3,10 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-
 package org.openmrs.module.radiology;
 
 /**

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyRoles.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyRoles.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/DicomUidGenerator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/DicomUidGenerator.java
@@ -1,13 +1,11 @@
 /**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- * Copyright (C) OpenMRS, LLC. All Rights Reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.radiology.dicom;
 

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/DicomUidValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/DicomUidValidator.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.dicom;
 
 import java.util.regex.Pattern;

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/DicomWebViewer.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/DicomWebViewer.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/UuidDicomUidGenerator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/UuidDicomUidGenerator.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.dicom;
 
 import org.openmrs.module.radiology.util.DecimalUuid;

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatus.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatus.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrder.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrder.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderValidator.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReport.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportEditor.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportEditor.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report;
 
 import java.util.Date;

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report;
 
 import java.util.ArrayList;

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportStatus.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudy.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudy.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyDAO.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/main/java/org/openmrs/module/radiology/util/DecimalUuid.java
+++ b/api/src/main/java/org/openmrs/module/radiology/util/DecimalUuid.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.util;
 
 import java.math.BigInteger;

--- a/api/src/main/resources/RadiologyOrder.hbm.xml
+++ b/api/src/main/resources/RadiologyOrder.hbm.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping package="org.openmrs.module.radiology">

--- a/api/src/main/resources/RadiologyReport.hbm.xml
+++ b/api/src/main/resources/RadiologyReport.hbm.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 

--- a/api/src/main/resources/RadiologyStudy.hbm.xml
+++ b/api/src/main/resources/RadiologyStudy.hbm.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN" "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 
 <hibernate-mapping package="org.openmrs.module.radiology">

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!--<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd"> -->
 <!-- xmlns:mvc="http://www.springframework.org/schema/mvc" http://www.springframework.org/schema/mvc 
 	http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd -->

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
@@ -499,9 +500,9 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     }
     
     /**
-    * @see RadiologyProperties#getGlobalProperty(String)
-    * @verifies return global property given valid global property name
-    */
+     * @see RadiologyProperties#getGlobalProperty(String)
+     * @verifies return global property given valid global property name
+     */
     @Test
     public void getGlobalProperty_shouldReturnGlobalPropertyGivenValidGlobalPropertyName() throws Exception {
         administrationService.saveGlobalProperty(
@@ -513,9 +514,9 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     }
     
     /**
-    * @see RadiologyProperties#getGlobalProperty(String,boolean)
-    * @verifies return null given non required and non configured global property
-    */
+     * @see RadiologyProperties#getGlobalProperty(String, boolean)
+     * @verifies return null given non required and non configured global property
+     */
     @Test
     public void getGlobalProperty_shouldReturnNullGivenNonRequiredAndNonConfiguredGlobalProperty() throws Exception {
         
@@ -525,9 +526,9 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     }
     
     /**
-    * @see RadiologyProperties#getGlobalProperty(String)
-    * @verifies throw illegal state exception given required non configured global property
-    */
+     * @see RadiologyProperties#getGlobalProperty(String)
+     * @verifies throw illegal state exception given required non configured global property
+     */
     @Test
     public void getGlobalProperty_shouldThrowIllegalStateExceptionGivenRequiredNonConfiguredGlobalProperty()
             throws Exception {

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/DicomUidValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/DicomUidValidatorTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.dicom;
 
 import static org.hamcrest.Matchers.greaterThan;

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/DicomWebViewerTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/DicomWebViewerTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.dicom;
 
 import static org.hamcrest.core.Is.is;

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/UuidDicomUidGeneratorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/UuidDicomUidGeneratorTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.dicom;
 
 import static org.hamcrest.Matchers.greaterThan;

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatusTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/code/PerformedProcedureStepStatusTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.dicom.code;
 
 import static org.hamcrest.core.Is.is;

--- a/api/src/test/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatusTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/dicom/code/ScheduledProcedureStepStatusTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.dicom.code;
 
 import static org.hamcrest.core.Is.is;

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
@@ -1,13 +1,11 @@
 /**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- * Copyright (C) OpenMRS, LLC. All Rights Reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.radiology.order;
 

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImplComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImplComponentTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderValidatorTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportEditorComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportEditorComponentTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteriaTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteriaTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -1,13 +1,11 @@
 /**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- * Copyright (C) OpenMRS, LLC. All Rights Reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.radiology.report;
 

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
@@ -1,13 +1,11 @@
 /**
- * The contents of this file are subject to the OpenMRS Public License
- * Version 1.0 (the "License"); you may not use this file except in
- * compliance with the License. You may obtain a copy of the License at
- * http://license.openmrs.org
- * Software distributed under the License is distributed on an "AS IS"
- * basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
- * License for the specific language governing rights and limitations
- * under the License.
- * Copyright (C) OpenMRS, LLC. All Rights Reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
  */
 package org.openmrs.module.radiology.study;
 

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImplTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.study;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.study;
 
 import static org.hamcrest.CoreMatchers.startsWith;

--- a/api/src/test/java/org/openmrs/module/radiology/util/DecimalUuidTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/util/DecimalUuidTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/api/src/test/resources/TestingApplicationContext.xml
+++ b/api/src/test/resources/TestingApplicationContext.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"

--- a/api/src/test/resources/log4j.xml
+++ b/api/src/test/resources/log4j.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 
 <!-- This log4j file is only used by the tests. -->

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
@@ -1,11 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
+
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
+
 -->
 <dataset>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2015-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -1,11 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
+
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
+
 -->
 <dataset>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2015-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml
@@ -1,11 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
+
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
+
 -->
 <dataset>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2015-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>

--- a/api/src/test/resources/test-hibernate.cfg.xml
+++ b/api/src/test/resources/test-hibernate.cfg.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!DOCTYPE hibernate-configuration PUBLIC
 	"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
 	"http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,10 +1,15 @@
 <?xml version="1.0"?>
-<!-- This Source Code Form is subject to the terms of the Mozilla Public 
-	License, v. 2.0. If a copy of the MPL was not distributed with this file, 
-	You can obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed 
-	under the terms of the Healthcare Disclaimer located at http://openmrs.org/license. 
-	Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
-	graphic logo is a trademark of OpenMRS Inc. -->
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!DOCTYPE module PUBLIC
 	  "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
 	  "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -1,9 +1,14 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public 
-	License, v. 2.0. If a copy of the MPL was not distributed with this file, 
-	You can obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed 
-	under the terms of the Healthcare Disclaimer located at http://openmrs.org/license. 
-	Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
-	graphic logo is a trademark of OpenMRS Inc. -->
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/DiscontinuationOrderRequest.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/DiscontinuationOrderRequest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web;
 
 import org.openmrs.Provider;

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/DiscontinuationOrderRequestValidator.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/DiscontinuationOrderRequestValidator.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletController.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardFormController.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderListController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderListController.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResource.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web.resource;
 
 import org.openmrs.api.context.Context;

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandler.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web.search;
 
 import java.util.Arrays;

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportsTabPortletController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportsTabPortletController.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web;
 
 import java.util.LinkedList;

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web.resource;
 
 import org.openmrs.api.context.Context;

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web.search;
 
 import java.util.Arrays;

--- a/omod/src/main/java/org/openmrs/module/radiology/web/RadiologyRestController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/RadiologyRestController.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.web;
 
 import org.openmrs.module.webservices.rest.web.RestConstants;

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/AdminList.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/GutterListExt.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/web/extension/html/PatientDashboardRadiologyTabExt.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <module configVersion="1.3">
 
 	<!-- Basic Module Properties -->

--- a/omod/src/main/resources/webModuleApplicationContext.xml
+++ b/omod/src/main/resources/webModuleApplicationContext.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
 
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!--<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN//EN" "http://www.springframework.org/dtd/spring-beans.dtd"> -->
 <!-- xmlns:mvc="http://www.springframework.org/schema/mvc" http://www.springframework.org/schema/mvc 
 	http://www.springframework.org/schema/mvc/spring-mvc-3.0.xsd -->

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/DiscontinuationOrderRequestValidatorTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/DiscontinuationOrderRequestValidatorTest.java
@@ -3,10 +3,10 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */
-
 package org.openmrs.module.radiology.order.web;
 
 import static org.hamcrest.Matchers.is;

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/PatientDashboardRadiologyTabPortletControllerTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderControllerComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderControllerComponentTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web.resource;
 
 import org.junit.Before;

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceComponentTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web.resource;
 
 import org.junit.Before;

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web.resource;
 
 import static org.hamcrest.Matchers.contains;

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerComponentTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web.search;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.order.web.search;
 
 import static org.hamcrest.Matchers.instanceOf;

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web;
 
 import static org.hamcrest.collection.IsMapContaining.hasKey;

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportControllerComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportControllerComponentTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web.resource;
 
 import org.junit.Before;

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceComponentTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web.resource;
 
 import org.junit.Before;

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web.resource;
 
 import static org.hamcrest.Matchers.contains;

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerComponentTest.java
@@ -1,3 +1,12 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
 package org.openmrs.module.radiology.report.web.search;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/test/RadiologyTestData.java
@@ -3,6 +3,7 @@
  * v. 2.0. If a copy of the MPL was not distributed with this file, You can
  * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
  * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
  * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
  * graphic logo is a trademark of OpenMRS Inc.
  */

--- a/omod/src/test/resources/RadiologyOrderResourceComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyOrderResourceComponentTestDataset.xml
@@ -1,11 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
+
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
+
 -->
 <dataset>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2015-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>

--- a/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
@@ -1,11 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <!--
+
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
+
 -->
 <dataset>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2015-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>

--- a/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
@@ -1,3 +1,4 @@
+<?xml version='1.0' encoding='UTF-8'?>
 <!--
 
     This Source Code Form is subject to the terms of the Mozilla Public License,

--- a/omod/src/test/resources/RadiologyReportResourceComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyReportResourceComponentTestDataset.xml
@@ -1,11 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
+
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
+
 -->
 <dataset>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2015-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>

--- a/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
@@ -1,11 +1,14 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
+
     This Source Code Form is subject to the terms of the Mozilla Public License,
     v. 2.0. If a copy of the MPL was not distributed with this file, You can
     obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
     the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
     Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
     graphic logo is a trademark of OpenMRS Inc.
+
 -->
 <dataset>
   <patient_identifier_type patient_identifier_type_id="1" name="Test Identifier Type" description="Test description" creator="1" date_created="2015-01-01 00:00:00.0" required="false" retired="false" uuid="0cbecb62-7249-4f91-8edf-d0206ecceb63"/>

--- a/omod/src/test/resources/TestingApplicationContext.xml
+++ b/omod/src/test/resources/TestingApplicationContext.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:util="http://www.springframework.org/schema/util"

--- a/omod/src/test/resources/test-hibernate.cfg.xml
+++ b/omod/src/test/resources/test-hibernate.cfg.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <!DOCTYPE hibernate-configuration PUBLIC
 	"-//Hibernate/Hibernate Configuration DTD 3.0//EN"
 	"http://hibernate.sourceforge.net/hibernate-configuration-3.0.dtd">

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,14 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public 
-	License, v. 2.0. If a copy of the MPL was not distributed with this file, 
-	You can obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed 
-	under the terms of the Healthcare Disclaimer located at http://openmrs.org/license. 
-	Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
-	graphic logo is a trademark of OpenMRS Inc. -->
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
@@ -201,6 +206,28 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>com.mycila</groupId>
+				<artifactId>license-maven-plugin</artifactId>
+				<version>2.6</version>
+				<configuration>
+					<header>license-header.txt</header>
+					<includes>
+						<include>**/*.java</include>
+						<include>**/*.txt</include>
+						<include>**/*.xml</include>
+					</includes>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 	</build>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS 
 	graphic logo is a trademark of OpenMRS Inc. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.openmrs.module</groupId>
@@ -48,6 +48,8 @@
 		<maven-formatter-plugin-version>1.6.0</maven-formatter-plugin-version>
 		<maven-formatter-plugin-style-java>${project.parent.basedir}/tools/formatter/java.xml</maven-formatter-plugin-style-java>
 		<maven-formatter-plugin-style-javascript>${project.parent.basedir}/tools/formatter/javascript.xml</maven-formatter-plugin-style-javascript>
+		<skip.integration.tests>false</skip.integration.tests>
+		<skip.unit.tests>false</skip.unit.tests>
 	</properties>
 
 	<dependencyManagement>
@@ -164,6 +166,39 @@
 					<artifactId>coveralls-maven-plugin</artifactId>
 					<version>4.0.0</version>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.18.1</version>
+					<executions>
+						<execution>
+							<id>default-test</id>
+							<phase>test</phase>
+							<goals>
+								<goal>test</goal>
+							</goals>
+							<configuration>
+								<excludes>
+									<exclude>**/*ComponentTest.java</exclude>
+								</excludes>
+								<skipTests>${skip.unit.tests}</skipTests>
+							</configuration>
+						</execution>
+						<execution>
+							<id>integration-test</id>
+							<phase>test</phase>
+							<goals>
+								<goal>test</goal>
+							</goals>
+							<configuration>
+								<includes>
+									<include>**/*ComponentTest.java</include>
+								</includes>
+								<skipTests>${skip.integration.tests}</skipTests>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>
@@ -199,5 +234,22 @@
 			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
+
+	<profiles>
+		<profile>
+			<id>unit-test</id>
+			<properties>
+				<skip.integration.tests>true</skip.integration.tests>
+				<skip.unit.tests>false</skip.unit.tests>
+			</properties>
+		</profile>
+		<profile>
+			<id>integration-test</id>
+			<properties>
+				<skip.integration.tests>false</skip.integration.tests>
+				<skip.unit.tests>true</skip.unit.tests>
+			</properties>
+		</profile>
+	</profiles>
 
 </project>

--- a/tools/formatter/java.xml
+++ b/tools/formatter/java.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <profiles version="12">
 <profile kind="CodeFormatterProfile" name="OpenMRS Radiology Module Formatter" version="12">
 <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
@@ -156,7 +167,6 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
-<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="true"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>

--- a/tools/formatter/javascript.xml
+++ b/tools/formatter/javascript.xml
@@ -1,4 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
 <profiles version="11">
 <profile kind="CodeFormatterProfile" name="OpenMRS Radiology Module JavaScript" version="11">
 <setting id="org.eclipse.wst.jsdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>


### PR DESCRIPTION
## Description
Added the maven license plugin. Therefore removed the {{clear_blank_lines_in_javadoc_comment}} formatter rule and added/reformatted missing licenses in all java/xml files.

Obviously, no test was written.

## Related Issue
see https://issues.openmrs.org/browse/RAD-231

## Checklist:
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


