### PR TITLE
RAD-292 Generate accessionnumber

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
@@ -38,6 +38,8 @@ public class RadiologyConstants {
     
     public static final String GP_RADIOLOGY_VISIT_TYPE = "radiology.radiologyVisitType";
     
+    public static final String GP_NEXT_ACCESSION_NUMBER_SEED = "radiology.nextAccessionNumberSeed";
+    
     private RadiologyConstants() {
         // Utility class not meant to be instantiated.
     }

--- a/api/src/main/java/org/openmrs/module/radiology/order/AccessionNumberGenerator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/AccessionNumberGenerator.java
@@ -1,0 +1,26 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.order;
+
+/**
+ * Generate new unique accession numbers.
+ */
+public interface AccessionNumberGenerator {
+    
+    
+    /**
+     * Generates a new accession number. Note that this method is invoked in a non thread-safe way,
+     * therefore implementations need to be thread safe.
+     * 
+     * @return the new accession number
+     * @should always return a unique accession number when called multiple times
+     */
+    public String getNewAccessionNumber();
+}

--- a/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
@@ -12,10 +12,15 @@ package org.openmrs.module.radiology.order;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.hibernate.Criteria;
+import org.hibernate.LockOptions;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
+import org.openmrs.GlobalProperty;
 import org.openmrs.Patient;
+import org.openmrs.api.APIException;
+import org.openmrs.module.radiology.RadiologyConstants;
 
 /**
  * Hibernate specific RadiologyOrder related functions. This class should not be used directly. All
@@ -36,6 +41,53 @@ class HibernateRadiologyOrderDAO implements RadiologyOrderDAO {
      */
     public void setSessionFactory(SessionFactory sessionFactory) {
         this.sessionFactory = sessionFactory;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getNextAccessionNumberSeedSequenceValue()
+     * @throws APIException if global property radiology.nextAccessionNumberSeed is missing
+     * @throws APIException if global property radiology.nextAccessionNumberSeed value is empty or only contains whitespaces
+     * @throws APIException if global property radiology.nextAccessionNumberSeed value cannot be parsed to Long
+     * @should return the next accession number seed stored as global property radiology next accession number and increment
+     *         the global property value
+     * @should throw an api exception if global property radiology next accession number seed is missing
+     * @should throw an api exception if global property radiology next accession number seed value is empty or only contains
+     *         whitespaces
+     * @should throw an api exception if global property radiology next accession number seed value value cannot be parsed to
+     *         long
+     */
+    @Override
+    public Long getNextAccessionNumberSeedSequenceValue() {
+        
+        final GlobalProperty globalProperty = (GlobalProperty) sessionFactory.getCurrentSession()
+                .get(GlobalProperty.class, RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED, LockOptions.UPGRADE);
+        
+        if (globalProperty == null) {
+            throw new APIException("GlobalProperty.missing",
+                    new Object[] { RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED });
+        }
+        
+        final String gpTextValue = globalProperty.getPropertyValue();
+        if (StringUtils.isBlank(gpTextValue)) {
+            throw new APIException("GlobalProperty.invalid.value",
+                    new Object[] { RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED });
+        }
+        
+        Long globalPropertyValue = null;
+        try {
+            globalPropertyValue = Long.parseLong(gpTextValue);
+        }
+        catch (NumberFormatException ex) {
+            throw new APIException("GlobalProperty.invalid.value",
+                    new Object[] { RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED });
+        }
+        
+        globalProperty.setPropertyValue(String.valueOf(globalPropertyValue + 1));
+        
+        sessionFactory.getCurrentSession()
+                .save(globalProperty);
+        
+        return globalPropertyValue;
     }
     
     /**

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
@@ -23,6 +23,11 @@ interface RadiologyOrderDAO {
     
     
     /**
+     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getNextAccessionNumberSeedSequenceValue()
+     */
+    public Long getNextAccessionNumberSeedSequenceValue();
+    
+    /**
      * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrder(Integer)
      */
     public RadiologyOrder getRadiologyOrder(Integer orderId);

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -15,6 +15,7 @@ import org.openmrs.Order;
 import org.openmrs.Patient;
 import org.openmrs.Provider;
 import org.openmrs.annotation.Authorized;
+import org.openmrs.api.APIException;
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.radiology.RadiologyPrivileges;
 
@@ -25,6 +26,15 @@ import org.openmrs.module.radiology.RadiologyPrivileges;
  */
 public interface RadiologyOrderService extends OpenmrsService {
     
+    
+    /**
+     * Gets the next available accession number seed.
+     * 
+     * @return the accession number seed
+     * @throws APIException
+     * @should return the next accession number seed
+     */
+    public Long getNextAccessionNumberSeedSequenceValue();
     
     /**
      * Saves a new {@code RadiologyOrder} and its {@code RadiologyStudy} to the
@@ -38,6 +48,7 @@ public interface RadiologyOrderService extends OpenmrsService {
      * @throws IllegalArgumentException if radiologyOrder.study.modality is null
      * @should create new radiology order and study from given radiology order object
      * @should create radiology order encounter
+     * @should set the radiology order accession number
      * @should throw illegal argument exception given null
      * @should throw illegal argument exception given existing radiology order
      * @should throw illegal argument exception if given radiology order has no study

--- a/api/src/test/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAOComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAOComponentTest.java
@@ -1,0 +1,149 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.order;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.hibernate.SessionFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.openmrs.GlobalProperty;
+import org.openmrs.api.APIException;
+import org.openmrs.api.AdministrationService;
+import org.openmrs.module.radiology.RadiologyConstants;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+/**
+ * Tests {@link HibernateRadiologyOrderDAO}.
+ */
+public class HibernateRadiologyOrderDAOComponentTest extends BaseModuleContextSensitiveTest {
+    
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    @Qualifier("adminService")
+    @Autowired
+    AdministrationService administrationService;
+    
+    @Autowired
+    private SessionFactory sessionFactory;
+    
+    private HibernateRadiologyOrderDAO hibernateRadiologyOrderDAO;
+    
+    private String globalPropertyMissing =
+            "Missing global property named: " + RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED;
+    
+    private String globalPropertyInvalid =
+            "Invalid value for global property named: " + RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED;
+    
+    @Before
+    public void setUp() {
+        
+        hibernateRadiologyOrderDAO = new HibernateRadiologyOrderDAO();
+        hibernateRadiologyOrderDAO.setSessionFactory(sessionFactory);
+    }
+    
+    /**
+     * @see HibernateRadiologyOrderDAO#getNextAccessionNumberSeedSequenceValue()
+     * @verifies return the next accession number seed stored as global property radiology next accession number and
+     *           increment the global property value
+     */
+    @Test
+    public void
+            getNextAccessionNumberSeedSequenceValue_shouldReturnTheNextAccessionNumberSeedStoredAsGlobalPropertyRadiologyNextAccessionNumberAndIncrementTheGlobalPropertyValue()
+                    throws Exception {
+        
+        GlobalProperty nextAccessionNumberGlobalProperty =
+                new GlobalProperty(RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED);
+        nextAccessionNumberGlobalProperty.setPropertyValue("1");
+        administrationService.saveGlobalProperty(nextAccessionNumberGlobalProperty);
+        
+        Long seed = (Long) hibernateRadiologyOrderDAO.getNextAccessionNumberSeedSequenceValue();
+        assertThat(seed, is(1L));
+        
+        for (int i = 0; i < 10; i++) {
+            assertThat(hibernateRadiologyOrderDAO.getNextAccessionNumberSeedSequenceValue(), is(++seed));
+        }
+    }
+    
+    /**
+     * @see HibernateRadiologyOrderDAO#getNextAccessionNumberSeedSequenceValue()
+     * @verifies throw an api exception if global property radiology next accession number seed is missing
+     */
+    @Test
+    public void
+            getNextAccessionNumberSeedSequenceValue_shouldThrowAnApiExceptionIfGlobalPropertyRadiologyNextAccessionNumberSeedIsMissing()
+                    throws Exception {
+        
+        expectedException.expect(APIException.class);
+        expectedException.expectMessage(globalPropertyMissing);
+        hibernateRadiologyOrderDAO.getNextAccessionNumberSeedSequenceValue();
+    }
+    
+    /**
+     * @see HibernateRadiologyOrderDAO#getNextAccessionNumberSeedSequenceValue()
+     * @verifies throw an api exception if global property radiology next accession number seed value is empty or only
+     *           contains whitespaces
+     */
+    @Test
+    public void
+            getNextAccessionNumberSeedSequenceValue_shouldThrowAnApiExceptionIfGlobalPropertyRadiologyNextAccessionNumberSeedValueIsEmptyOrOnlyContainsWhitespaces()
+                    throws Exception {
+        
+        GlobalProperty nextAccessionNumberGlobalProperty =
+                new GlobalProperty(RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED);
+        nextAccessionNumberGlobalProperty.setPropertyValue("1");
+        administrationService.saveGlobalProperty(nextAccessionNumberGlobalProperty);
+        
+        String[] invalidEmptyValues = { "", "  ", null };
+        
+        for (String invalidValue : invalidEmptyValues) {
+            administrationService.updateGlobalProperty(RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED, invalidValue);
+            nextAccessionNumberGlobalProperty.setPropertyValue(invalidValue);
+            administrationService.saveGlobalProperty(nextAccessionNumberGlobalProperty);
+            
+            expectedException.expect(APIException.class);
+            expectedException.expectMessage(globalPropertyInvalid);
+            hibernateRadiologyOrderDAO.getNextAccessionNumberSeedSequenceValue();
+        }
+    }
+    
+    /**
+     * @see HibernateRadiologyOrderDAO#getNextAccessionNumberSeedSequenceValue()
+     * @verifies throw an api exception if global property radiology next accession number seed value value cannot be parsed
+     *           to long
+     */
+    @Test
+    public void
+            getNextAccessionNumberSeedSequenceValue_shouldThrowAnApiExceptionIfGlobalPropertyRadiologyNextAccessionNumberSeedValueValueCannotBeParsedToLong()
+                    throws Exception {
+        
+        GlobalProperty nextAccessionNumberGlobalProperty =
+                new GlobalProperty(RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED);
+        nextAccessionNumberGlobalProperty.setPropertyValue("1");
+        administrationService.saveGlobalProperty(nextAccessionNumberGlobalProperty);
+        
+        String[] invalidLongValues = { "xxx", "3.2", Long.MAX_VALUE + "1" };
+        
+        for (String invalidValue : invalidLongValues) {
+            administrationService.updateGlobalProperty(RadiologyConstants.GP_NEXT_ACCESSION_NUMBER_SEED, invalidValue);
+            
+            expectedException.expect(APIException.class);
+            expectedException.expectMessage(globalPropertyInvalid);
+            hibernateRadiologyOrderDAO.getNextAccessionNumberSeedSequenceValue();
+        }
+    }
+}

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImplComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImplComponentTest.java
@@ -15,7 +15,6 @@ import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -23,6 +22,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.hibernate.SessionFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,6 +65,11 @@ public class RadiologyOrderServiceImplComponentTest extends BaseModuleContextSen
     @Autowired
     private OrderService orderService;
     
+    @Autowired
+    private SessionFactory sessionFactory;
+    
+    private HibernateRadiologyOrderDAO radiologyOrderDAO = new HibernateRadiologyOrderDAO();
+    
     private RadiologyOrderServiceImpl radiologyOrderServiceImpl = null;
     
     @Autowired
@@ -83,18 +88,12 @@ public class RadiologyOrderServiceImplComponentTest extends BaseModuleContextSen
         
         if (radiologyOrderServiceImpl == null) {
             radiologyOrderServiceImpl = new RadiologyOrderServiceImpl();
-            Field radiologyStudyServiceField = RadiologyOrderServiceImpl.class.getDeclaredField("radiologyStudyService");
-            radiologyStudyServiceField.setAccessible(true);
-            radiologyStudyServiceField.set(radiologyOrderServiceImpl, radiologyStudyService);
-            Field orderServiceField = RadiologyOrderServiceImpl.class.getDeclaredField("orderService");
-            orderServiceField.setAccessible(true);
-            orderServiceField.set(radiologyOrderServiceImpl, orderService);
-            Field encounterServiceField = RadiologyOrderServiceImpl.class.getDeclaredField("encounterService");
-            encounterServiceField.setAccessible(true);
-            encounterServiceField.set(radiologyOrderServiceImpl, encounterService);
-            Field radiologyPropertiesField = RadiologyOrderServiceImpl.class.getDeclaredField("radiologyProperties");
-            radiologyPropertiesField.setAccessible(true);
-            radiologyPropertiesField.set(radiologyOrderServiceImpl, radiologyProperties);
+            radiologyOrderDAO.setSessionFactory(sessionFactory);
+            radiologyOrderServiceImpl.setRadiologyOrderDAO(radiologyOrderDAO);
+            radiologyOrderServiceImpl.setRadiologyStudyService(radiologyStudyService);
+            radiologyOrderServiceImpl.setOrderService(orderService);
+            radiologyOrderServiceImpl.setEncounterService(encounterService);
+            radiologyOrderServiceImpl.setRadiologyProperties(radiologyProperties);
         }
         
         saveRadiologyOrderEncounterMethod = RadiologyOrderServiceImpl.class.getDeclaredMethod("saveRadiologyOrderEncounter",
@@ -105,9 +104,9 @@ public class RadiologyOrderServiceImplComponentTest extends BaseModuleContextSen
     }
     
     /**
-    * @see RadiologyOrderServiceImpl#saveRadiologyOrderEncounter(Patient,Provider,Date)
-    * @verifies create radiology order encounter
-    */
+     * @see RadiologyOrderServiceImpl#saveRadiologyOrderEncounter(Patient,Provider,Date)
+     * @verifies create radiology order encounter
+     */
     @Test
     public void saveRadiologyOrderEncounter_shouldCreateRadiologyOrderEncounter() throws Exception {
         // given

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
@@ -21,6 +21,7 @@
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>
   <global_property property="radiology.radiologyTestOrderType" property_value="dbdb9a9b-56ea-11e5-a47f-08002719a237" description="Radiology Test Order Type UUID"/>
+  <global_property property="radiology.nextAccessionNumberSeed" property_value="4" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^\d+$" uuid="f45d1722-d983-427b-82ed-c4e8beffd1c7"/>
 
   <encounter_type encounter_type_id="1001" name="Radiology Order Encounter Type" description="Ordering radiology exams" creator="1" date_created="2015-09-09 00:00:00.0" retired="false" uuid="19db8c0d-3520-48f2-babd-77f2d450e5c7"/>
   <encounter_role encounter_role_id="1001" name="Radiology Ordering Provider Encounter Role " description="Provider ordering tests, exams, drugs, ..." creator="1" retired="false" date_created="2015-09-09 14:00:00.0" uuid="13fc9b4a-49ed-429c-9dde-ca005b387a3d" />
@@ -58,17 +59,15 @@
   <!-- radiology orders with study -->
   <encounter encounter_id="2001" encounter_type="1001" patient_id="70021" location_id="1" form_id="1" encounter_datetime="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="6849c394-2c58-49d9-b928-215a75a90959"/>
   <encounter_provider encounter_provider_id="1" encounter_id="2001" provider_id="1" encounter_role_id="1001" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="c92be2b5-b167-4c3b-9bab-5f8c01ae727a" />
-  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
+  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="1" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
   <test_order order_id="2001"/>
   <radiology_order order_id="2001" />
   <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="CT" creator="1" date_created="2015-02-02 12:24:10.0" uuid="dde7399b-6092-4a3d-88a2-405b6b4499fc"/>
 
-  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
+  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" accession_number="2" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
   <test_order order_id="2002"/>
   <radiology_order order_id="2002" />
   <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" creator="1" date_created="2015-02-02 12:26:35.0" uuid="d1307f3e-a02a-4f1d-91cf-f9537c5cc93f"/>
-
-  <obs obs_id="20021" person_id="70021" order_id="2002" concept_id="178" obs_datetime="2015-02-06 17:14:00.0" location_id="1" creator="1" date_created="2015-02-06 17:14:35.0" voided="false" uuid="be3a4d7a-f9ab-47bb-aaad-bc0b452fcda4" accession_number="RAD2002"/>
 
   <!-- patient with one radiology order with no associated study -->
   <encounter encounter_id="2004" encounter_type="1001" patient_id="70022" location_id="1" form_id="1" encounter_datetime="2015-02-03 13:17:15.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" uuid="05715654-a566-4cb3-921f-2f7067eb119f"/>
@@ -78,7 +77,7 @@
   <person_name person_name_id="3" preferred="true" person_id="70022" given_name="John" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a134"/>
 
   <!-- radiology order with no associated study -->
-  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
+  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
   <test_order order_id="2004"/>
   <radiology_order order_id="2004" />
 </dataset>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -21,6 +21,7 @@
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>
   <global_property property="radiology.radiologyTestOrderType" property_value="dbdb9a9b-56ea-11e5-a47f-08002719a237" description="Radiology Test Order Type UUID"/>
+  <global_property property="radiology.nextAccessionNumberSeed" property_value="8" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^\d+$" uuid="f45d1722-d983-427b-82ed-c4e8beffd1c7"/>
 
   <encounter_type encounter_type_id="1001" name="Radiology Order Encounter Type" description="Ordering radiology exams" creator="1" date_created="2015-09-09 00:00:00.0" retired="false" uuid="19db8c0d-3520-48f2-babd-77f2d450e5c7"/>
   <encounter_role encounter_role_id="1001" name="Radiology Ordering Provider Encounter Role " description="Provider ordering tests, exams, drugs, ..." creator="1" retired="false" date_created="2015-09-09 14:00:00.0" uuid="13fc9b4a-49ed-429c-9dde-ca005b387a3d" />
@@ -45,12 +46,12 @@
   <patient_identifier patient_identifier_id="1" patient_id="70021" identifier="4321" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="1ac98ec8-e9d9-4626-998c-c795c2f0aa9f"/>
   
   <encounter encounter_id="2001" encounter_type="1001" patient_id="70021" location_id="1" form_id="1" encounter_datetime="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="6849c394-2c58-49d9-b928-215a75a90959"/>
-  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
+  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="1" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
   <test_order order_id="2001"/>
   <radiology_order order_id="2001" />
   <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="CT" creator="1" date_created="2015-02-02 12:24:10.0" uuid="dde7399b-6092-4a3d-88a2-405b6b4499fc"/>
 
-  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
+  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" accession_number="2" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
   <test_order order_id="2002"/>
   <radiology_order order_id="2002" />
   <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" creator="1" date_created="2015-02-02 12:26:35.0" uuid="d1307f3e-a02a-4f1d-91cf-f9537c5cc93f"/>
@@ -63,34 +64,34 @@
   <person_name person_name_id="3" preferred="true" person_id="70022" given_name="John" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a134"/>
   
   <!-- radiology order with associated study and without a report -->
-  <orders order_id="2005" order_number="2005" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="9bef9483-63b3-4b50-be86-a56b309c3f50"/>
+  <orders order_id="2005" order_number="2005" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="9bef9483-63b3-4b50-be86-a56b309c3f50"/>
   <test_order order_id="2005" />
   <radiology_order order_id="2005" />
   <radiology_study study_id="3" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.3" order_id="2005" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="4bf44730-258f-4c4c-8c6d-bf93d8e1832f"/>
 
   <!-- radiology order with associated study and with a claimed report -->
-  <orders order_id="2006" order_number="2006" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="d5cd1541-ecaa-44e8-a063-720c14ea7ba5"/>
+  <orders order_id="2006" order_number="2006" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="4" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="d5cd1541-ecaa-44e8-a063-720c14ea7ba5"/>
   <test_order order_id="2006" />
   <radiology_order order_id="2006" />
   <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="58855a84-3c39-42d8-8d33-6c3f228c0936"/>
   <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" uuid="e699d90d-e230-4762-8747-d2d0059394b0" report_date="2016-05-28" />
 
   <!-- radiology order with associated study and a completed report -->
-  <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
+  <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="5" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
   <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
 
   <!-- radiology order with associated study and a discontinued report -->
-  <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="7ed51f0e-5351-4849-9ec3-9e87e18259c5"/>
+  <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="6" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="7ed51f0e-5351-4849-9ec3-9e87e18259c5"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="eb6dc805-e79f-4ca2-945b-5e9bdd9491c6"/>
   <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
   
   <!-- radiology order with associated study and a completed report -->
-  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
+  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="7" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
   <test_order order_id="2009" />
   <radiology_order order_id="2009" />
   <radiology_study study_id="7" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.7" order_id="2009" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2016-07-01 13:17:15.0" uuid="7ffd5b5e-473f-11e6-beb8-9e71128cae77"/>

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml
@@ -21,6 +21,7 @@
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>
   <global_property property="radiology.radiologyTestOrderType" property_value="dbdb9a9b-56ea-11e5-a47f-08002719a237" description="Radiology Test Order Type UUID"/>
+  <global_property property="radiology.nextAccessionNumberSeed" property_value="4" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^\d+$" uuid="f45d1722-d983-427b-82ed-c4e8beffd1c7"/>
 
   <encounter_type encounter_type_id="1001" name="Radiology Order Encounter Type" description="Ordering radiology exams" creator="1" date_created="2015-09-09 00:00:00.0" retired="false" uuid="19db8c0d-3520-48f2-babd-77f2d450e5c7"/>
   <encounter_role encounter_role_id="1001" name="Radiology Ordering Provider Encounter Role " description="Provider ordering tests, exams, drugs, ..." creator="1" retired="false" date_created="2015-09-09 14:00:00.0" uuid="13fc9b4a-49ed-429c-9dde-ca005b387a3d" />
@@ -57,12 +58,12 @@
 
   <!-- radiology orders with study -->
   <encounter encounter_id="2001" encounter_type="1001" patient_id="70021" location_id="1" form_id="1" encounter_datetime="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="6849c394-2c58-49d9-b928-215a75a90959"/>
-  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
+  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="1" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
   <test_order order_id="2001"/>
   <radiology_order order_id="2001" />
   <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="CT" creator="1" date_created="2015-02-02 12:24:10.0" uuid="dde7399b-6092-4a3d-88a2-405b6b4499fc"/>
 
-  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
+  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" accession_number="2" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
   <test_order order_id="2002"/>
   <radiology_order order_id="2002" />
   <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" creator="1" date_created="2015-02-02 12:26:35.0" uuid="d1307f3e-a02a-4f1d-91cf-f9537c5cc93f"/>
@@ -75,7 +76,7 @@
   <person_name person_name_id="3" preferred="true" person_id="70022" given_name="John" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a134"/>
 
   <!-- radiology order with no associated study -->
-  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
+  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
   <test_order order_id="2004"/>
   <radiology_order order_id="2004" />
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResource.java
@@ -115,21 +115,23 @@ public class RadiologyOrderResource extends DataDelegatingCrudResource<Radiology
     }
     
     /**
-     * Display string for {@link RadiologyOrder}
+     * Get the display string for a {@link RadiologyOrder}.
      * 
-     * @param radiologyOrder RadiologyOrder of which display string shall be returned
-     * @return ConceptName of given radiologyOrder
-     * @should return concept name of given radiologyOrder
+     * @param radiologyOrder the radiology order of which the display string shall be returned
+     * @return the accession number and the concept name of given radiology order
+     * @should return accession number and concept name of given radiology order
      * @should return no concept string if given radiologyOrders concept is null
      */
     @PropertyGetter("display")
     public String getDisplayString(RadiologyOrder radiologyOrder) {
         
-        if (radiologyOrder.getConcept() == null)
-            return "[No Concept]";
-        return radiologyOrder.getConcept()
-                .getName()
-                .getName();
+        if (radiologyOrder.getConcept() == null) {
+            return radiologyOrder.getAccessionNumber() + " - " + "[No Concept]";
+        } else {
+            return radiologyOrder.getAccessionNumber() + " - " + radiologyOrder.getConcept()
+                    .getName()
+                    .getName();
+        }
     }
     
     /**

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -161,7 +161,17 @@
 		<defaultValue>fe898a34-1ade-11e1-9c71-00248140a5eb</defaultValue>
 		<description>Radiology Visit Type UUID</description>
 	</globalProperty>
-
+	<globalProperty>
+		<property>@MODULE_ID@.nextAccessionNumberSeed</property>
+		<defaultValue>1</defaultValue>
+		<description>
+			The next accession number available for assignment to a
+			radiology order. (Validated by Java Regex "^\\d+$")
+		</description>
+		<datatypeClassname>org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype
+		</datatypeClassname>
+		<datatypeConfig>^\d+$</datatypeConfig>
+	</globalProperty>
 	<!--Required Global Properties -->
 
 	<!-- Internationalization -->

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceComponentTest.java
@@ -37,7 +37,7 @@ public class RadiologyOrderResourceComponentTest extends BaseDelegatingResourceT
     @Override
     public String getDisplayProperty() {
         
-        return "FRACTURE";
+        return "4 - FRACTURE";
     }
     
     /**

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/resource/RadiologyOrderResourceTest.java
@@ -67,6 +67,7 @@ public class RadiologyOrderResourceTest {
     public void setUp() throws Exception {
         
         radiologyOrder.setUuid(RADIOLOGY_ORDER_UUID);
+        radiologyOrder.setAccessionNumber("1");
         
         PowerMockito.mockStatic(RestUtil.class);
         
@@ -218,10 +219,10 @@ public class RadiologyOrderResourceTest {
     
     /**
      * @see RadiologyOrderResource#getDisplayString(RadiologyOrder)
-     * @verifies return concept name of given radiologyOrder
+     * @verifies return accession number and concept name of given radiology order
      */
     @Test
-    public void getDisplayString_shouldReturnConceptNameOfGivenRadiologyOrder() throws Exception {
+    public void getDisplayString_shouldReturnAccessionNumberAndConceptNameOfGivenRadiologyOrder() throws Exception {
         
         ConceptName conceptName = new ConceptName();
         conceptName.setName("X-RAY, HEAD");
@@ -231,8 +232,7 @@ public class RadiologyOrderResourceTest {
         concept.setPreferredName(conceptName);
         radiologyOrder.setConcept(concept);
         
-        assertThat(radiologyOrderResource.getDisplayString(radiologyOrder), is("X-RAY, HEAD"));
-        
+        assertThat(radiologyOrderResource.getDisplayString(radiologyOrder), is("1 - X-RAY, HEAD"));
     }
     
     /**
@@ -242,7 +242,7 @@ public class RadiologyOrderResourceTest {
     @Test
     public void getDisplayString_shouldReturnNoConceptStringIfGivenRadiologyOrdersConceptIsNull() throws Exception {
         
-        assertThat(radiologyOrderResource.getDisplayString(radiologyOrder), is("[No Concept]"));
+        assertThat(radiologyOrderResource.getDisplayString(radiologyOrder), is("1 - [No Concept]"));
     }
     
     /**

--- a/omod/src/test/resources/RadiologyOrderResourceComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyOrderResourceComponentTestDataset.xml
@@ -21,6 +21,7 @@
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>
   <global_property property="radiology.radiologyTestOrderType" property_value="dbdb9a9b-56ea-11e5-a47f-08002719a237" description="Radiology Test Order Type UUID"/>
+  <global_property property="radiology.nextAccessionNumberSeed" property_value="5" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^\d+$" uuid="f45d1722-d983-427b-82ed-c4e8beffd1c7"/>
 
   <encounter_type encounter_type_id="1001" name="Radiology Order Encounter Type" description="Ordering radiology exams" creator="1" date_created="2015-09-09 00:00:00.0" retired="false" uuid="19db8c0d-3520-48f2-babd-77f2d450e5c7"/>
   <encounter_role encounter_role_id="1001" name="Radiology Ordering Provider Encounter Role " description="Provider ordering tests, exams, drugs, ..." creator="1" retired="false" date_created="2015-09-09 14:00:00.0" uuid="13fc9b4a-49ed-429c-9dde-ca005b387a3d" />
@@ -65,17 +66,15 @@
 
   <!-- radiology orders with study -->
   <encounter encounter_id="2001" encounter_type="1001" patient_id="70021" location_id="1" form_id="1" encounter_datetime="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="6849c394-2c58-49d9-b928-215a75a90959"/>
-  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
+  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="1" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
   <test_order order_id="2001"/>
   <radiology_order order_id="2001" />
   <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="CT" creator="1" date_created="2015-02-02 12:24:10.0" uuid="dde7399b-6092-4a3d-88a2-405b6b4499fc"/>
 
-  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
+  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" accession_number="2" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
   <test_order order_id="2002"/>
   <radiology_order order_id="2002" />
   <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" creator="1" date_created="2015-02-02 12:26:35.0" uuid="d1307f3e-a02a-4f1d-91cf-f9537c5cc93f"/>
-
-  <obs obs_id="20021" person_id="70021" order_id="2002" concept_id="178" obs_datetime="2015-02-06 17:14:00.0" location_id="1" creator="1" date_created="2015-02-06 17:14:35.0" voided="false" uuid="be3a4d7a-f9ab-47bb-aaad-bc0b452fcda4" accession_number="RAD2002"/>
 
   <!-- patient with one radiology order with no associated study -->
   <encounter encounter_id="2004" encounter_type="1001" patient_id="70022" location_id="1" form_id="1" encounter_datetime="2015-02-03 13:17:15.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" uuid="05715654-a566-4cb3-921f-2f7067eb119f"/>
@@ -85,7 +84,7 @@
   <person_name person_name_id="3" preferred="true" person_id="70022" given_name="John" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a134"/>
 
   <!-- radiology order with no associated study -->
-  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
+  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
   <test_order order_id="2004"/>
   <radiology_order order_id="2004" />
 
@@ -103,7 +102,7 @@
   <person_name person_name_id="3" preferred="true" person_id="70055" given_name="John" family_name="Cena" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="76dbd350-fc9e-11e5-9e59-08002719a237"/>
 	
   <encounter encounter_id="2009" encounter_type="1001" patient_id="70055" visit_id="3004" location_id="1" form_id="1" encounter_datetime="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="18208334-fca0-11e5-9e59-08002719a237"/>
-  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2009" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70055" uuid="1bae735a-fca0-11e5-9e59-08002719a237" />
+  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2009" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="4" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70055" uuid="1bae735a-fca0-11e5-9e59-08002719a237" />
   <test_order order_id="2009"/>
   <radiology_order order_id="2009" />
   <visit visit_id="3004" patient_id="70055" visit_type_id="3" date_started="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="0" uuid="30a57ce7-fca0-11e5-9e59-08002719a237" />

--- a/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyOrderSearchHandlerComponentTestDataset.xml
@@ -21,6 +21,7 @@
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>
   <global_property property="radiology.radiologyTestOrderType" property_value="dbdb9a9b-56ea-11e5-a47f-08002719a237" description="Radiology Test Order Type UUID"/>
+  <global_property property="radiology.nextAccessionNumberSeed" property_value="5" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^\d+$" uuid="f45d1722-d983-427b-82ed-c4e8beffd1c7"/>
 
   <encounter_type encounter_type_id="1001" name="Radiology Order Encounter Type" description="Ordering radiology exams" creator="1" date_created="2015-09-09 00:00:00.0" retired="false" uuid="19db8c0d-3520-48f2-babd-77f2d450e5c7"/>
   <encounter_role encounter_role_id="1001" name="Radiology Ordering Provider Encounter Role " description="Provider ordering tests, exams, drugs, ..." creator="1" retired="false" date_created="2015-09-09 14:00:00.0" uuid="13fc9b4a-49ed-429c-9dde-ca005b387a3d" />
@@ -65,17 +66,15 @@
 
   <!-- radiology orders with study -->
   <encounter encounter_id="2001" encounter_type="1001" patient_id="70021" location_id="1" form_id="1" encounter_datetime="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="6849c394-2c58-49d9-b928-215a75a90959"/>
-  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
+  <orders order_id="2001" order_number="2001" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="1" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70021" uuid="44f24d7e-ebbd-4500-bfba-1db19561ca04"/>
   <test_order order_id="2001"/>
   <radiology_order order_id="2001" />
   <radiology_study study_id="1" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.1" order_id="2001" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="CT" creator="1" date_created="2015-02-02 12:24:10.0" uuid="dde7399b-6092-4a3d-88a2-405b6b4499fc"/>
 
-  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
+  <orders order_id="2002" order_number="2002" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2001" urgency="ROUTINE"  orderer="1" concept_id="178" accession_number="2" instructions="MR Left Knee" date_activated="2015-02-02 12:26:35.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-02 12:26:35.0" voided="false" patient_id="70021" uuid="65d68058-c75b-4807-a8ba-1728558c9f8e"/>
   <test_order order_id="2002"/>
   <radiology_order order_id="2002" />
   <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" creator="1" date_created="2015-02-02 12:26:35.0" uuid="d1307f3e-a02a-4f1d-91cf-f9537c5cc93f"/>
-
-  <obs obs_id="20021" person_id="70021" order_id="2002" concept_id="178" obs_datetime="2015-02-06 17:14:00.0" location_id="1" creator="1" date_created="2015-02-06 17:14:35.0" voided="false" uuid="be3a4d7a-f9ab-47bb-aaad-bc0b452fcda4" accession_number="RAD2002"/>
 
   <!-- patient with one radiology order with no associated study -->
   <encounter encounter_id="2004" encounter_type="1001" patient_id="70022" location_id="1" form_id="1" encounter_datetime="2015-02-03 13:17:15.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" uuid="05715654-a566-4cb3-921f-2f7067eb119f"/>
@@ -85,7 +84,7 @@
   <person_name person_name_id="3" preferred="true" person_id="70022" given_name="John" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a134"/>
 
   <!-- radiology order with no associated study -->
-  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
+  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
   <test_order order_id="2004"/>
   <radiology_order order_id="2004" />
 
@@ -103,7 +102,7 @@
   <person_name person_name_id="3" preferred="true" person_id="70055" given_name="John" family_name="Cena" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="76dbd350-fc9e-11e5-9e59-08002719a237"/>
 	
   <encounter encounter_id="2009" encounter_type="1001" patient_id="70055" visit_id="3004" location_id="1" form_id="1" encounter_datetime="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" uuid="18208334-fca0-11e5-9e59-08002719a237"/>
-  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2009" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70055" uuid="1bae735a-fca0-11e5-9e59-08002719a237" />
+  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2009" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="4" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="false" patient_id="70055" uuid="1bae735a-fca0-11e5-9e59-08002719a237" />
   <test_order order_id="2009"/>
   <radiology_order order_id="2009" />
   <visit visit_id="3004" patient_id="70055" visit_type_id="3" date_started="2015-02-02 12:24:10.0" creator="1" date_created="2015-02-02 12:24:10.0" voided="0" uuid="30a57ce7-fca0-11e5-9e59-08002719a237" />

--- a/omod/src/test/resources/RadiologyReportResourceComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyReportResourceComponentTestDataset.xml
@@ -21,6 +21,7 @@
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>
   <global_property property="radiology.radiologyTestOrderType" property_value="dbdb9a9b-56ea-11e5-a47f-08002719a237" description="Radiology Test Order Type UUID"/>
+  <global_property property="radiology.nextAccessionNumberSeed" property_value="2" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^\d+$" uuid="f45d1722-d983-427b-82ed-c4e8beffd1c7"/>
 
   <encounter_type encounter_type_id="1001" name="Radiology Order Encounter Type" description="Ordering radiology exams" creator="1" date_created="2015-09-09 00:00:00.0" retired="false" uuid="19db8c0d-3520-48f2-babd-77f2d450e5c7"/>
   <encounter_role encounter_role_id="1001" name="Radiology Ordering Provider Encounter Role " description="Provider ordering tests, exams, drugs, ..." creator="1" retired="false" date_created="2015-09-09 14:00:00.0" uuid="13fc9b4a-49ed-429c-9dde-ca005b387a3d" />
@@ -46,7 +47,7 @@
   <encounter encounter_id="2004" encounter_type="1001" patient_id="70022" location_id="1" form_id="1" encounter_datetime="2015-02-03 13:17:15.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" uuid="05715654-a566-4cb3-921f-2f7067eb119f"/>
   
   <!-- radiology order with associated study and a completed report -->
-  <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
+  <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="1" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>

--- a/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
@@ -21,6 +21,7 @@
   <global_property property="radiology.radiologyOrderingProviderEncounterRole" property_value="13fc9b4a-49ed-429c-9dde-ca005b387a3d" description="Radiology Ordering Provider Encounter Role UUID"/>
   <global_property property="radiology.radiologyOrderEncounterType" property_value="19db8c0d-3520-48f2-babd-77f2d450e5c7" description="Radiology Order Encounter Type UUID"/>
   <global_property property="radiology.radiologyTestOrderType" property_value="dbdb9a9b-56ea-11e5-a47f-08002719a237" description="Radiology Test Order Type UUID"/>
+  <global_property property="radiology.nextAccessionNumberSeed" property_value="4" datatype="org.openmrs.customdatatype.datatype.RegexValidatedTextDatatype" datatype_config="^\d+$" uuid="f45d1722-d983-427b-82ed-c4e8beffd1c7"/>
 
   <encounter_type encounter_type_id="1001" name="Radiology Order Encounter Type" description="Ordering radiology exams" creator="1" date_created="2015-09-09 00:00:00.0" retired="false" uuid="19db8c0d-3520-48f2-babd-77f2d450e5c7"/>
   <encounter_role encounter_role_id="1001" name="Radiology Ordering Provider Encounter Role " description="Provider ordering tests, exams, drugs, ..." creator="1" retired="false" date_created="2015-09-09 14:00:00.0" uuid="13fc9b4a-49ed-429c-9dde-ca005b387a3d" />
@@ -30,7 +31,6 @@
   <person_name person_name_id="4" preferred="true" person_id="70021" given_name="Karl" family_name="Karlsson" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a135"/>
   <provider provider_id="1" person_id="70021" name="Radiology Technician" identifier="1" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="c2299800-cca9-11e0-9572-0800200c9a66" />
   <provider provider_id="2" name="Radiology Technician" identifier="2" creator="1" date_created="2005-01-02 00:00:00.0" retired="false" uuid="550e8400-e29b-11d4-a716-446655440000" />
-	
 
   <!-- concept name and concept -->
   <concept concept_id="178" retired="false" datatype_id="4" class_id="4" is_set="false" creator="1" date_created="2004-01-01 00:00:00" changed_by="1" date_changed="2005-02-16 00:00:00" version="" uuid="1565b6e6-df81-11e4-98ec-08002798a7ad"/>
@@ -48,21 +48,21 @@
   <encounter encounter_id="2004" encounter_type="1001" patient_id="70022" location_id="1" form_id="1" encounter_datetime="2015-02-03 13:17:15.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" uuid="05715654-a566-4cb3-921f-2f7067eb119f"/>
   
   <!-- radiology order with associated study and a completed report -->
-  <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
+  <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="1" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
   <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-30"/>
 
   <!-- radiology order with associated study and a completed report -->
-  <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:18:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:18:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79656"/>
+  <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="2" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:18:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:18:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79656"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2015-02-03 13:18:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5ca"/>
   <radiology_report report_id="3" order_id="2008" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29811" report_date="2016-06-01"/>
 
   <!-- radiology order with associated study and a discontinued report -->
-  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
+  <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
   <test_order order_id="2009" />
   <radiology_order order_id="2009" />
   <radiology_study study_id="7" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.7" order_id="2009" scheduled_status="SCHEDULED" performed_status="COMPLETED" modality="CT" creator="1" date_created="2016-07-01 13:17:15.0" uuid="7ffd5b5e-473f-11e6-beb8-9e71128cae77"/>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Generate an accessionnumber for radiology orders in same approach chosen by
order entry for orderNumber.

* add global property for accessionnr seed
* add accessionnr seed in config.xml (validated as regex so we only get digits)
* fix testdatasets for new global property
* remove unused obs row from testdatasets
* add AccessionNumberGenerator interface
* RadiologyOrderServiceImpl implements AccessionNumberGenerator
* add HibernateRadiologyOrderDAO method to get next accessionnr seed
* add HibernateRadiologyOrderDAOTest
* add test for placeRadiologyOrder
* show accessionnr in RadiologyOrderResource getDisplayString()

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-292
