### PR TITLE
RAD-231 Exclude acceptance test build dirs from license plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.openmrs.module</groupId>
@@ -225,6 +225,22 @@
 						<include>**/*.txt</include>
 						<include>**/*.xml</include>
 					</includes>
+					<excludes>
+						<exclude>acceptanceTest/**/build/**</exclude>
+						<exclude>license-header.txt</exclude>
+						<exclude>.git/**</exclude>
+						<exclude>tools/formatter/**</exclude>
+						<!-- From gitignore -->
+						<exclude>.idea/**</exclude>
+						<exclude>target/**</exclude>
+						<exclude>bin/**</exclude>
+						<exclude>tmp/**</exclude>
+						<exclude>.settings/**</exclude>
+						<exclude>.externalToolBuilders/</exclude>
+						<exclude>build/</exclude>
+						<exclude>bin/</exclude>
+						<exclude>dist/</exclude>
+					</excludes>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
acceptance tests generate directories "build" when executed with test reports
and other temporary resources which we do not keep track in git and thus should
also not cause the plugin to complain that license headers are missing.

* exclude those directories in the mycila plugin config
* exlude other directories like .git, target ...

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-231
