### PR TITLE
RAD-340 Default reportlist filter to last week

### DIFF
--- a/omod/src/main/webapp/portlets/radiologyReportsTab.jsp
+++ b/omod/src/main/webapp/portlets/radiologyReportsTab.jsp
@@ -20,6 +20,11 @@
                     var find = $j('#reportsTabFind');
                     var clearResults = $j('a#reportsTabClearFilters');
 
+                    fromDate.val(moment().subtract(1, 'weeks').startOf('week')
+                            .format('YYYY-MM-DD'));
+                    toDate.val(moment().subtract(1, 'weeks').endOf('week')
+                            .format('YYYY-MM-DD'));
+
                     var radiologyReportsTable = $j('#reportsTabTable')
                             .DataTable(
                                     {
@@ -144,6 +149,8 @@
                                       $j(
                                               '#reportsTabTableFilterFields input, #reportsTabTableFilterFields select')
                                               .val('');
+                                      $j('#reportsTabDateRangePicker').data(
+                                              'dateRangePicker').clear();
                                       radiologyReportsTable.ajax.reload();
                                     });
 

--- a/omod/src/main/webapp/radiologyDashboardForm.jsp
+++ b/omod/src/main/webapp/radiologyDashboardForm.jsp
@@ -30,6 +30,7 @@
                       show: function(event, ui) {
                         localStorage.setItem("selectedRadiologyTab", $j(this)
                                 .tabs("option", "selected"));
+                        $j('.date-picker-wrapper').hide();
                       }
                     });
             $j('.ui-corner-all,.ui-corner-top').removeClass(


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
On the reports tab portlet make sure that the filter defaults to the
reports of last week.

* add default value to date filter in radiologyReportsTab.jsp
* add new shortcut to daterangepicker in radiologyReportsTab.jsp
* add entry for date filter shortcut to message.properties
* hide date range picker when switching tab

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-340