### PR TITLE
RAD-333 Use fabric8io docker plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 1. [Overview](#overview)
 2. [Build](#build)
 3. [Install](#install)
+  * [Docker](#docker-whale)
+  * [Demo data](#demo-data)
 4. [Documentation](#documentation)
 5. [Contributing](#contributing)
 6. [Issues](#issues)
@@ -66,57 +68,58 @@ This module can be baked into a Docker image so you can easily run and test it.
 
 #### Prerequisites
 
-Build the module as described under [Build](#build).
+After you have taken care of the [Build Prerequisites](#prerequisites)
 
 Make sure you have [Docker](https://docs.docker.com/) installed.
 
-This Docker image cannot run without the correct database appropriate for the OpenMRS Platform 2.0 version used.
-
-I suggest you install and use [Docker Compose](https://docs.docker.com/compose/install/) to install the Docker image for the Radiology Module you built together with
-the Docker image [OpenMRS Platform MySQL](https://github.com/teleivo/docker-openmrs-platform-mysql) for the database.
-
-Just follow the next sections.
-
 #### Build
 
-Enter the omod directory and build the Docker image for the Radiology Module
-you just built:
+Build the Radiology Module and its Docker image:
 
 ```bash
-cd omod
-mvn docker:build
+cd openmrs-module-radiology
+mvn clean package docker:build
 ```
 
 #### Run
 
-To run an instance of the OpenMRS Platform MySQL database, the Platform itself
-and the Radiology Module execute:
+To run an instance of the OpenMRS Radiology Module execute (assumes you have
+created a Docker image):
 
+```bash
+cd openmrs-module-radiology
+mvn docker:start
 ```
-docker-compose up
-```
 
-in the root directory of this repository.
+OpenMRS will be accessible at `http://<IP ADDRESS>:8080/openmrs`
 
-OpenMRS will be accessible at `localhost:8080/openmrs`
+**NOTE: The IP address varies depending on your setup.**
 
-Look at `docker-compose.yml` which connects the required Docker images
-and sets credentials and exposed ports.
+If you are using [Docker machine](https://docs.docker.com/machine/) refer to its documentation on how to get the IP address.
+If you are on Linux it will probably be will be `localhost`.
 
-#### Demo data
+#### Documentation
+
+Please read the corresponding [DOCKER.md](docs/DOCKER.md) for more detailed
+explanations on using Docker with the Radiology Module.
+
+### Demo data
 
 You can import the demo data set [demo-data.sql](acceptanceTest/resources/demo-data.sql) into
 your database which enables you to try out the modules features or test your
 changes.
 
-Please read the corresponding [DEMO-DATA.md](acceptanceTest/resources/DEMO-DATA.md).
+Please read the corresponding [DEMO-DATA.md](docs/DEMO-DATA.md).
 
 ## Documentation
 
 For a detailed guide on ways to install and configure this module see
 
-https://wiki.openmrs.org/display/docs/Radiology+Module
+http://teleivo.github.io/docs-openmrs-module-radiology/
 
+For some more background informations on the module see
+
+https://wiki.openmrs.org/display/docs/Radiology+Module
 
 ## Contributing
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -117,6 +117,13 @@
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       MYSQL_PASSWORD: &openmrs_db_password openmrs
       MYSQL_DATABASE: &openmrs_db openmrs
   openmrs:
-    image: openmrs/module-radiology
+    image: teleivo/openmrs-module-radiology
     ports:
       - "8080:8080"
     container_name: openmrs-module-radiology

--- a/docs/DEMO-DATA.md
+++ b/docs/DEMO-DATA.md
@@ -22,7 +22,7 @@ be used as radiology order reason
 * insert statements to assign necessary privileges to the radiology roles
 * a set of users/providers for every radiology roles
 
-*NOTE: users, providers, patients and their cases are purely fictional*
+**NOTE: users, providers, patients and their cases are purely fictional**
 
 Person related data has been generated using the awesome [Faker.js](https://github.com/marak/Faker.js/) project.
 
@@ -33,10 +33,11 @@ Person related data has been generated using the awesome [Faker.js](https://gith
 To import it in your database do:
 
 ```bash
-mysql -h 192.168.99.100 -uopenmrs -popenmrs openmrs < demo-data.sql
+mysql -h <IP ADDRESS> -uopenmrs -popenmrs openmrs < demo-data.sql
 ```
 
-NOTE: please update the mysql host, port ... for your setup
+**NOTE: please adjust the mysql connection details (host, port ...) according to
+your your setup!**
 
 ### Update Search Index
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,137 @@
+# Docker
+
+## Overview
+
+We are using maven plugin https://github.com/fabric8io/docker-maven-plugin
+to integrate creating and running a Docker image of the Radiology Module with
+its dependencies into the build process.
+
+If you are having trouble using the plugin or want to know more about its great
+features please checkout their documentation, it is extensive!
+
+## Background
+
+The Radiology Module needs OpenMRS (which itself needs an application server,
+we use Tomcat) and a database (we use MySQL).
+
+The Docker image of the Radiology Module is
+
+* built on top of a [Docker image for OpenMRS](https://hub.docker.com/r/teleivo/openmrs-platform/)
+* linked to a [Docker image for the database](https://hub.docker.com/r/teleivo/openmrs-platform-mysql/)
+
+If you want to get into the details please look at the omod/pom.xml
+
+## Create Image
+
+Build the Radiology Module and its Docker image:
+
+```bash
+cd openmrs-module-radiology
+mvn clean package docker:build
+```
+
+Only build the Docker image (assumes you already built the module):
+
+```bash
+cd openmrs-module-radiology/omod
+mvn package docker:build
+```
+
+NOTE: `package` is necessary otherwise the docker plugin wont find the created
+artifact. Thats a maven limitations which you can read about at the plugins
+documentation.
+
+### Skip tests
+
+If you want to skip tests at any stage add command line arg:
+
+```bash
+-DskipTests
+```
+
+### Build args
+
+You can specify build arguments on the command line.
+
+For example if you are behind a proxy add:
+
+```bash
+mvn package docker:build \
+  -Ddocker.buildArg.http_proxy=http://192.168.1.100:8080 \
+  -Ddocker.buildArg.https_proxy=http://192.168.1.100:8080
+```
+
+**NOTE: please use the IP and port of your proxy** :wink:
+
+## Create and Run Container
+
+```bash
+cd openmrs-module-radiology
+mvn docker:start
+```
+
+This will start a container for the database and one for the Radiology Module
+using the image you built at [Create Image](#create-image).
+
+You will see log outputs of both containers with a prefix
+
+* DB for the database container
+* TC for the tomcat container
+
+Logs will only show until a certain string in the log is found which we defined
+in the Docker plugin configuration and define as "the container is ready".
+
+So after that maven should show that the build succeeded and the Radiology
+Module will be available for login.
+
+From then on two new containers should be running.
+
+You can check with:
+
+```bash
+docker ps
+```
+
+## Stop and Remove Container
+
+```bash
+cd openmrs-module-radiology
+mvn docker:stop
+```
+
+This will only stop and remove the containers created via the Docker plugin.
+
+### Remove Volumes
+
+The database image is based on the Docker MySQL image which uses Docker volumes
+for storing the persistent data. You might need to remove the volume your self.
+
+After you started the Radiology Module using the Docker plugin you can check
+that there is a new volume with:
+
+```bash
+docker volume ls
+```
+
+If you want to remove the volume created by the plugin when stopping do:
+
+```bash
+cd openmrs-module-radiology
+mvn docker:stop -Ddocker.removeVolumes=true
+```
+
+If you want to manually remove a volume
+
+```bash
+docker volume rm <enter hash of volume you want to delete>
+```
+
+## I am busy :bowtie:
+
+So build the module, create the image and run it all at once!
+
+```bash
+cd openmrs-module-radiology
+mvn clean package docker:build docker:start
+```
+

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -144,7 +144,7 @@
 							<nonFilteredFileExtension>svg</nonFilteredFileExtension>
 							<nonFilteredFileExtension>eot</nonFilteredFileExtension>
 							<nonFilteredFileExtension>otf</nonFilteredFileExtension>
-    					</nonFilteredFileExtensions>
+						</nonFilteredFileExtensions>
 					</configuration>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings 
@@ -197,22 +197,6 @@
 								</pluginExecution>
 							</pluginExecutions>
 						</lifecycleMappingMetadata>
-					</configuration>
-				</plugin>
-				<plugin>
-					<groupId>com.spotify</groupId>
-					<artifactId>docker-maven-plugin</artifactId>
-					<version>${maven-docker-plugin-version}</version>
-					<configuration>
-						<imageName>${docker.image.prefix}/module-${project.parent.artifactId}</imageName>
-						<dockerDirectory>src/main/docker</dockerDirectory>
-						<resources>
-							<resource>
-								<targetPath>/</targetPath>
-								<directory>${project.build.directory}</directory>
-								<include>${project.build.finalName}.omod</include>
-							</resource>
-						</resources>
 					</configuration>
 				</plugin>
 			</plugins>
@@ -305,7 +289,7 @@
 						<checkSystemPath>true</checkSystemPath>
 						<enforceVersion>true</enforceVersion>
 						<source>REPOSITORY</source>
-						<baseUrl/>
+						<baseUrl />
 						<outputDirectory>target/phantomjs</outputDirectory>
 					</phantomjs>
 					<jsSrcDir>${project.basedir}/src/main/webapp/resources/scripts</jsSrcDir>
@@ -334,6 +318,79 @@
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<configuration>
+					<logDate>default</logDate>
+					<autoPull>true</autoPull>
+					<verbose>true</verbose>
+					<images>
+						<!-- DB Image is used 'as-is' and is linked into the openmrs image -->
+						<image>
+							<alias>db</alias>
+							<name>teleivo/openmrs-platform-mysql:latest</name>
+							<run>
+								<log>
+									<prefix>DB</prefix>
+									<color>yellow</color>
+								</log>
+								<ports>
+									<port>3306:3306</port>
+								</ports>
+								<env>
+									<MYSQL_ROOT_PASSWORD>openmrs</MYSQL_ROOT_PASSWORD>
+									<MYSQL_USER>openmrs</MYSQL_USER>
+									<MYSQL_PASSWORD>openmrs</MYSQL_PASSWORD>
+									<MYSQL_DATABASE>openmrs</MYSQL_DATABASE>
+								</env>
+								<wait>
+									<log>MySQL init process done. Ready for start up.</log>
+									<time>60000</time>
+								</wait>
+							</run>
+						</image>
+						<!-- Image holding the artifact of this build -->
+						<image>
+							<alias>openmrs</alias>
+							<name>teleivo/openmrs-module-${project.parent.artifactId}</name>
+							<build>
+								<dockerFile>Dockerfile</dockerFile>
+								<assembly>
+									<basedir>/</basedir>
+									<descriptor>${basedir}/src/main/assembly.xml</descriptor>
+								</assembly>
+								<ports>
+									<port>8080</port>
+								</ports>
+							</build>
+							<run>
+								<ports>
+									<port>8080:8080</port>
+								</ports>
+								<links>
+									<link>db:db</link>
+								</links>
+								<env>
+									<MYSQL_USER>openmrs</MYSQL_USER>
+									<MYSQL_PASSWORD>openmrs</MYSQL_PASSWORD>
+									<MYSQL_DATABASE>openmrs</MYSQL_DATABASE>
+									<MYSQL_HOST>db</MYSQL_HOST>
+									<MYSQL_PORT>3306</MYSQL_PORT>
+								</env>
+								<wait>
+									<log>Server startup in</log>
+									<time>300000</time>
+								</wait>
+								<log>
+									<prefix>TC</prefix>
+									<color>cyan</color>
+								</log>
+							</run>
+						</image>
+					</images>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/omod/src/main/assembly.xml
+++ b/omod/src/main/assembly.xml
@@ -1,0 +1,30 @@
+<!--
+
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+
+-->
+<assembly
+	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	<formats>
+		<format>dir</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>/</outputDirectory>
+			<outputFileNameMapping>${artifact.artifactId}-${project.parent.version}.omod</outputFileNameMapping>
+			<unpack>false</unpack>
+			<includes>
+				<include>${artifact}</include>
+			</includes>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/omod/src/main/docker/Dockerfile
+++ b/omod/src/main/docker/Dockerfile
@@ -8,4 +8,4 @@ RUN curl -L \
     "https://github.com/teleivo/tmp-dependencies-openmrs-module-radiology/raw/master/webservices.rest-2.15-SNAPSHOT.36ddda.omod" \
     -o "${OPENMRS_MODULES}/webservices.rest-2.15-SNAPSHOT.36dda.omod"
 
-COPY *.omod ${OPENMRS_MODULES}/
+COPY maven/*.omod ${OPENMRS_MODULES}/

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<maven-formatter-plugin-style-java>${project.parent.basedir}/tools/formatter/java.xml</maven-formatter-plugin-style-java>
 		<maven-formatter-plugin-style-javascript>${project.parent.basedir}/tools/formatter/javascript.xml</maven-formatter-plugin-style-javascript>
 		<maven-docker-plugin-version>0.4.11</maven-docker-plugin-version>
-		<docker.image.prefix>openmrs</docker.image.prefix>
+		<docker.maven.plugin.fabric8.version>0.15.11</docker.maven.plugin.fabric8.version>
 	</properties>
 
 	<dependencyManagement>
@@ -172,9 +172,9 @@
 					<version>4.0.0</version>
 				</plugin>
 				<plugin>
-					<groupId>com.spotify</groupId>
+					<groupId>io.fabric8</groupId>
 					<artifactId>docker-maven-plugin</artifactId>
-					<version>${maven-docker-plugin-version}</version>
+					<version>${docker.maven.plugin.fabric8.version}</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Use fabric8io docker plugin instead of spotify's since it allows to link
containers. This way we do not need docker-compose and can totally integrate
docker into the maven build process.

* use fabric8io docker plugin
* define it in api/pom.xml with skip=true so we can build docker from the root
dir
* configure omod/pom.xml to use the docker plugin
** define the db image (from docker hub) with run properties
** define the radiology image with a link to db
* update readme
* add DOCKER.md
* put DEMO-DATA.md and DOCKER.md into docs/

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-333


