### PR TITLE
Revert "RAD-249: Add unit-test and integration-test profile for maven…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,6 @@
 		<maven-formatter-plugin-style-javascript>${project.parent.basedir}/tools/formatter/javascript.xml</maven-formatter-plugin-style-javascript>
 		<maven-docker-plugin-version>0.4.11</maven-docker-plugin-version>
 		<docker.image.prefix>openmrs</docker.image.prefix>
-		<skip.integration.tests>false</skip.integration.tests>
-		<skip.unit.tests>false</skip.unit.tests>
 	</properties>
 
 	<dependencyManagement>
@@ -178,39 +176,6 @@
 					<artifactId>docker-maven-plugin</artifactId>
 					<version>${maven-docker-plugin-version}</version>
 				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.18.1</version>
-					<executions>
-						<execution>
-							<id>default-test</id>
-							<phase>test</phase>
-							<goals>
-								<goal>test</goal>
-							</goals>
-							<configuration>
-								<excludes>
-									<exclude>**/*ComponentTest.java</exclude>
-								</excludes>
-								<skipTests>${skip.unit.tests}</skipTests>
-							</configuration>
-						</execution>
-						<execution>
-							<id>integration-test</id>
-							<phase>test</phase>
-							<goals>
-								<goal>test</goal>
-							</goals>
-							<configuration>
-								<includes>
-									<include>**/*ComponentTest.java</include>
-								</includes>
-								<skipTests>${skip.integration.tests}</skipTests>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
 			</plugins>
 		</pluginManagement>
 		<plugins>
@@ -284,22 +249,5 @@
 			<url>http://mavenrepo.openmrs.org/nexus/content/repositories/snapshots</url>
 		</snapshotRepository>
 	</distributionManagement>
-
-	<profiles>
-		<profile>
-			<id>unit-test</id>
-			<properties>
-				<skip.integration.tests>true</skip.integration.tests>
-				<skip.unit.tests>false</skip.unit.tests>
-			</properties>
-		</profile>
-		<profile>
-			<id>integration-test</id>
-			<properties>
-				<skip.integration.tests>false</skip.integration.tests>
-				<skip.unit.tests>true</skip.unit.tests>
-			</properties>
-		</profile>
-	</profiles>
 
 </project>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
…. Running maven without profile will execute both test types."

This reverts commit 986c3aa1fe10a0ce70f71e520753c2f870d27fc3.

This change lead to

-DskipTests=true

being ignored, which in turn lead to travis CI executing tests twice since it
does

* mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
* mvn clean install --batch-mode

This needs to be tested beforehand if this feature is introduced again!

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-249

