### PR TITLE
RAD-344 Remove getRadiologyOrdersByPatients

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/HibernateRadiologyOrderDAO.java
@@ -112,42 +112,6 @@ class HibernateRadiologyOrderDAO implements RadiologyOrderDAO {
     }
     
     /**
-     * A utility method creating a criteria for RadiologyOrder
-     *
-     * @return criteria for RadiologyOrder
-     */
-    private Criteria createRadiologyOrderCriteria() {
-        return sessionFactory.getCurrentSession()
-                .createCriteria(RadiologyOrder.class);
-    }
-    
-    /**
-     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatients
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
-        
-        final Criteria radiologyOrderCriteria = createRadiologyOrderCriteria();
-        addRestrictionOnPatients(radiologyOrderCriteria, patients);
-        
-        final List<RadiologyOrder> result = (List<RadiologyOrder>) radiologyOrderCriteria.list();
-        return result == null ? new ArrayList<RadiologyOrder>() : result;
-    }
-    
-    /**
-     * Adds an in restriction for given patients on given criteria if patients is not empty
-     *
-     * @param criteria criteria on which in restriction is set if patients is not empty
-     * @param patients patient list for which in restriction will be set
-     */
-    private void addRestrictionOnPatients(Criteria criteria, List<Patient> patients) {
-        if (!patients.isEmpty()) {
-            criteria.add(Restrictions.in("patient", patients));
-        }
-    }
-    
-    /**
      * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrders(RadiologyOrderSearchCriteria)
      */
     @SuppressWarnings("unchecked")

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderDAO.java
@@ -38,11 +38,6 @@ interface RadiologyOrderDAO {
     public RadiologyOrder getRadiologyOrderByUuid(String uuid);
     
     /**
-     * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrdersByPatients
-     */
-    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients);
-    
-    /**
      * @see org.openmrs.module.radiology.order.RadiologyOrderService#getRadiologyOrders(RadiologyOrderSearchCriteria)
      */
     List<RadiologyOrder> getRadiologyOrders(RadiologyOrderSearchCriteria searchCriteria);

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -109,20 +109,6 @@ public interface RadiologyOrderService extends OpenmrsService {
     public RadiologyOrder getRadiologyOrderByUuid(String uuid);
     
     /**
-     * Get the {@code RadiologyOrder's} associated with a list of {@code Patient's}.
-     *
-     * @param patients the list of patients for which radiology orders should be returned
-     * @return the radiology orders associated with given patients
-     * @throws IllegalArgumentException if given null
-     * @should return all radiology orders associated with given patients
-     * @should return all radiology orders given empty patient list
-     * @should return empty list given patient list without associated radiology orders
-     * @should throw illegal argument exception if given null
-     */
-    @Authorized({ RadiologyPrivileges.GET_RADIOLOGY_ORDERS })
-    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients);
-    
-    /**
      * Get all {@code RadiologyOrder's} matching a variety of (nullable) criteria.
      * Each extra value for a parameter that is provided acts as an "and" and will reduce the number of results returned
      *

--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderServiceImpl.java
@@ -184,19 +184,6 @@ class RadiologyOrderServiceImpl extends BaseOpenmrsService implements RadiologyO
     }
     
     /**
-     * @see RadiologyOrderService#getRadiologyOrdersByPatients
-     */
-    @Override
-    public List<RadiologyOrder> getRadiologyOrdersByPatients(List<Patient> patients) {
-        
-        if (patients == null) {
-            throw new IllegalArgumentException("patients cannot be null");
-        }
-        
-        return radiologyOrderDAO.getRadiologyOrdersByPatients(patients);
-    }
-    
-    /**
      * @see AccessionNumberGenerator#getNewAccessionNumber()
      */
     @Override

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
@@ -65,11 +65,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     
     private static final int PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER = 70011;
     
-    private static final int PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER = 70021;
-    
     private static final int PATIENT_ID_WITH_TWO_RADIOLOGY_ORDERS = 70021;
-    
-    private static final int PATIENT_ID_WITH_FIVE_RADIOLOGY_ORDERS = 70022;
     
     private static final int PATIENT_ID_WITH_ONE_VOIDED_AND_ONE_NON_VOIDED_RADIOLOGY_ORDER = 70023;
     
@@ -568,80 +564,6 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("uuid cannot be null");
         radiologyOrderService.getRadiologyOrderByUuid(null);
-    }
-    
-    /**
-     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-     * @verifies should return all radiology orders associated with given patients
-     */
-    @Test
-    public void getRadiologyOrdersByPatients_shouldReturnAllRadiologyOrdersAssociatedWithGivenPatients() {
-        
-        Patient patientWithTwoRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_TWO_RADIOLOGY_ORDERS);
-        assertThat(orderService.getAllOrdersByPatient(patientWithTwoRadiologyOrders)
-                .size(),
-            is(2));
-        Patient patientWithFiveRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_FIVE_RADIOLOGY_ORDERS);
-        assertThat(orderService.getAllOrdersByPatient(patientWithFiveRadiologyOrders)
-                .size(),
-            is(1));
-        Patient patientWithTwoRadiologyOrdersOneVoidedOneNonVoided =
-                patientService.getPatient(PATIENT_ID_WITH_ONE_VOIDED_AND_ONE_NON_VOIDED_RADIOLOGY_ORDER);
-        assertThat(orderService.getAllOrdersByPatient(patientWithTwoRadiologyOrdersOneVoidedOneNonVoided)
-                .size(),
-            is(2));
-        
-        List<Patient> allPatientsWithRadiologyOrders = new ArrayList<Patient>();
-        allPatientsWithRadiologyOrders.add(patientWithTwoRadiologyOrders);
-        allPatientsWithRadiologyOrders.add(patientWithFiveRadiologyOrders);
-        allPatientsWithRadiologyOrders.add(patientWithTwoRadiologyOrdersOneVoidedOneNonVoided);
-        
-        List<RadiologyOrder> radiologyOrders =
-                radiologyOrderService.getRadiologyOrdersByPatients(allPatientsWithRadiologyOrders);
-        
-        assertThat(radiologyOrders.size(), is(TOTAL_NUMBER_OF_RADIOLOGY_ORDERS));
-    }
-    
-    /**
-     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-     * @verifies should return all radiology orders given empty patient list
-     */
-    @Test
-    public void getRadiologyOrdersByPatients_shouldReturnAllRadiologyOrdersGivenEmptyPatientList() {
-        
-        List<Patient> emptyPatientList = new ArrayList<Patient>();
-        
-        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrdersByPatients(emptyPatientList);
-        
-        assertThat(radiologyOrders.size(), is(TOTAL_NUMBER_OF_RADIOLOGY_ORDERS));
-    }
-    
-    /**
-     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List<Patient>)
-     * @verifies throw illegal argument exception if given null
-     */
-    @Test
-    public void getRadiologyOrdersByPatients_shouldThrowIllegalArgumentExceptionIfGivenNull() {
-        
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("patients cannot be null");
-        radiologyOrderService.getRadiologyOrdersByPatients(null);
-    }
-    
-    /**
-     * @see RadiologyOrderService#getRadiologyOrdersByPatients(List)
-     * @verifies return empty list given patient list without associated radiology orders
-     */
-    @Test
-    public void getRadiologyOrdersByPatients_shouldReturnEmptyListGivenPatientListWithoutAssociatedRadiologyOrders()
-            throws Exception {
-        
-        Patient patientWithoutRadiologyOrders = patientService.getPatient(PATIENT_ID_WITH_ONLY_ONE_NON_RADIOLOGY_ORDER);
-        
-        List<RadiologyOrder> radiologyOrders =
-                radiologyOrderService.getRadiologyOrdersByPatients(Arrays.asList(patientWithoutRadiologyOrders));
-        
-        assertThat(radiologyOrders.size(), is(0));
     }
     
     /**

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyOrderServiceComponentTestDataset.xml
@@ -68,19 +68,7 @@
   <test_order order_id="2002"/>
   <radiology_order order_id="2002" />
   <radiology_study study_id="2" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.2" order_id="2002" scheduled_status="SCHEDULED" performed_status="IN_PROGRESS" modality="MR" creator="1" date_created="2015-02-02 12:26:35.0" uuid="d1307f3e-a02a-4f1d-91cf-f9537c5cc93f"/>
-
-  <!-- patient with one radiology order with no associated study -->
-  <encounter encounter_id="2004" encounter_type="1001" patient_id="70022" location_id="1" form_id="1" encounter_datetime="2015-02-03 13:17:15.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" uuid="05715654-a566-4cb3-921f-2f7067eb119f"/>
-  <patient patient_id="70022" creator="1" date_created="2015-01-01 00:00:00.0" voided="false"/>
-  <patient_identifier patient_identifier_id="3" patient_id="70022" identifier="1236" identifier_type="1" preferred="1" location_id="1" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="4d529220-9864-4a95-a12c-eb2f81833076"/>
-  <person person_id="70022" gender="M" birthdate="1990-04-13" dead="false" creator="1" date_created="2015-01-01 00:00:00.0" voided="false"/>
-  <person_name person_name_id="3" preferred="true" person_id="70022" given_name="John" family_name="Doe" creator="1" date_created="2015-01-01 00:00:00.0" voided="false" uuid="6753aaa1-545d-44e2-9a9f-6c682f37a134"/>
-
-  <!-- radiology order with no associated study -->
-  <orders order_id="2004" order_number="2004" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="be24cb45-6ae2-4bf1-8aa1-4d95fd679e1f"/>
-  <test_order order_id="2004"/>
-  <radiology_order order_id="2004" />
-  
+ 
   <!-- patient with one voided and one non voided radiology order -->
   <encounter encounter_id="2005" encounter_type="1001" patient_id="70023" location_id="1" form_id="1" encounter_datetime="2015-02-03 13:17:15.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" uuid="4e0e172b-510e-4d35-b705-4b363540fc62"/>
   <patient patient_id="70023" creator="1" date_created="2016-01-01 00:00:00.0" voided="false"/>


### PR DESCRIPTION
## Description
* Remove unused method getRadiologyOrderByPatients from service and DAO

## Related Issue
see https://issues.openmrs.org/browse/RAD-344

