### PR TITLE
Execute license plugin format on build

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -53,9 +53,9 @@
 			<type>pom</type>
 		</dependency>
 		<dependency>
-	  		<groupId>org.jsoup</groupId>
-	  		<artifactId>jsoup</artifactId>
-	  		<version>1.9.2</version>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>1.9.2</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -105,18 +105,6 @@
 			<plugin>
 				<groupId>com.marvinformatics.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<configuration>
-					<includes>
-						<include>**/*.java</include>
-					</includes>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
@@ -265,8 +265,7 @@ public class MrrtReportTemplateServiceComponentTest extends BaseModuleContextSen
     * @verifies throw api exception if saving template that already exists
     */
     @Test
-    public void saveMrrtReportTemplate_shouldThrowApiExceptionIfSavingTemplateThatAlreadyExists()
-            throws Exception {
+    public void saveMrrtReportTemplate_shouldThrowApiExceptionIfSavingTemplateThatAlreadyExists() throws Exception {
         MrrtReportTemplate existing = mrrtReportTemplateService.getMrrtReportTemplate(EXISTING_TEMPLATE_ID);
         existing.setDcTermsTitle("modified");
         expectedException.expect(APIException.class);

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -220,13 +220,6 @@
 						<exclude>**/tinymce/**/*.*</exclude>
 					</excludes>
 				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.openmrs.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
 				<version>${openMRSVersion}</version>
 			</dependency>
 		</dependencies>
-
 	</dependencyManagement>
 
 	<build>
@@ -135,6 +134,9 @@
 						<overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
 						<configFile>${maven-formatter-plugin-style-java}</configFile>
 						<configJsFile>${maven-formatter-plugin-style-javascript}</configJsFile>
+						<includes>
+							<include>**/*.java</include>
+						</includes>
 					</configuration>
 				</plugin>
 				<plugin>
@@ -209,6 +211,7 @@
 				</configuration>
 				<executions>
 					<execution>
+						<id>check-license-header</id>
 						<goals>
 							<goal>check</goal>
 						</goals>
@@ -250,4 +253,40 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<profiles>
+		<profile>
+			<id>development</id>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>com.mycila</groupId>
+							<artifactId>license-maven-plugin</artifactId>
+							<executions>
+								<execution>
+									<id>format-license-header</id>
+									<phase>process-sources</phase>
+									<goals>
+										<goal>format</goal>
+									</goals>
+								</execution>
+							</executions>
+						</plugin>
+						<plugin>
+							<groupId>com.marvinformatics.formatter</groupId>
+							<artifactId>formatter-maven-plugin</artifactId>
+							<executions>
+								<execution>
+									<id>format-code</id>
+									<goals>
+										<goal>format</goal>
+									</goals>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
just testing the following on TRAVIS


* bind mycila maven license plugin goal format to phase process-sources so it executes on
mvn clean package automatically. ensures that when devs run this command their
code will be properly formatted including a correct license header.
* add id to formatter plugin execution in same style as mycila ids
* extract code formatter commons into root pom
* fix missed formatting in MrrtReportTemplateServiceComponentTest
* add development profile so only when this profile is active formatting of
license header and code will be done