### PR TITLE
RAD-345 Fail CI on missing license header and do not format

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -53,9 +53,9 @@
 			<type>pom</type>
 		</dependency>
 		<dependency>
-	  		<groupId>org.jsoup</groupId>
-	  		<artifactId>jsoup</artifactId>
-	  		<version>1.9.2</version>
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>1.9.2</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -105,18 +105,6 @@
 			<plugin>
 				<groupId>com.marvinformatics.formatter</groupId>
 				<artifactId>formatter-maven-plugin</artifactId>
-				<configuration>
-					<includes>
-						<include>**/*.java</include>
-					</includes>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.jacoco</groupId>

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
@@ -265,8 +265,7 @@ public class MrrtReportTemplateServiceComponentTest extends BaseModuleContextSen
     * @verifies throw api exception if saving template that already exists
     */
     @Test
-    public void saveMrrtReportTemplate_shouldThrowApiExceptionIfSavingTemplateThatAlreadyExists()
-            throws Exception {
+    public void saveMrrtReportTemplate_shouldThrowApiExceptionIfSavingTemplateThatAlreadyExists() throws Exception {
         MrrtReportTemplate existing = mrrtReportTemplateService.getMrrtReportTemplate(EXISTING_TEMPLATE_ID);
         existing.setDcTermsTitle("modified");
         expectedException.expect(APIException.class);

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -220,13 +220,6 @@
 						<exclude>**/tinymce/**/*.*</exclude>
 					</excludes>
 				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>format</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.openmrs.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,6 @@
 				<version>${openMRSVersion}</version>
 			</dependency>
 		</dependencies>
-
 	</dependencyManagement>
 
 	<build>
@@ -125,6 +124,44 @@
 					<version>2.4</version>
 				</plugin>
 				<plugin>
+					<groupId>com.mycila</groupId>
+					<artifactId>license-maven-plugin</artifactId>
+					<version>2.6</version>
+					<configuration>
+						<header>license-header.txt</header>
+						<includes>
+							<include>**/*.java</include>
+							<include>**/*.txt</include>
+							<include>**/*.xml</include>
+						</includes>
+						<excludes>
+							<exclude>acceptanceTest/**/build/**</exclude>
+							<exclude>license-header.txt</exclude>
+							<exclude>.git/**</exclude>
+							<exclude>tools/formatter/**</exclude>
+							<!-- From gitignore -->
+							<exclude>.idea/**</exclude>
+							<exclude>target/**</exclude>
+							<exclude>bin/**</exclude>
+							<exclude>tmp/**</exclude>
+							<exclude>.settings/**</exclude>
+							<exclude>.externalToolBuilders/</exclude>
+							<exclude>build/</exclude>
+							<exclude>bin/</exclude>
+							<exclude>dist/</exclude>
+						</excludes>
+					</configuration>
+					<executions>
+						<execution>
+							<id>format-license-header</id>
+							<phase>process-sources</phase>
+							<goals>
+								<goal>format</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
 					<groupId>com.marvinformatics.formatter</groupId>
 					<artifactId>formatter-maven-plugin</artifactId>
 					<version>${maven-formatter-plugin-version}</version>
@@ -135,7 +172,18 @@
 						<overrideConfigCompilerVersion>true</overrideConfigCompilerVersion>
 						<configFile>${maven-formatter-plugin-style-java}</configFile>
 						<configJsFile>${maven-formatter-plugin-style-javascript}</configJsFile>
+						<includes>
+							<include>**/*.java</include>
+						</includes>
 					</configuration>
+					<executions>
+						<execution>
+							<id>format-code</id>
+							<goals>
+								<goal>format</goal>
+							</goals>
+						</execution>
+					</executions>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -182,38 +230,6 @@
 			<plugin>
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
-				<version>2.6</version>
-				<configuration>
-					<header>license-header.txt</header>
-					<includes>
-						<include>**/*.java</include>
-						<include>**/*.txt</include>
-						<include>**/*.xml</include>
-					</includes>
-					<excludes>
-						<exclude>acceptanceTest/**/build/**</exclude>
-						<exclude>license-header.txt</exclude>
-						<exclude>.git/**</exclude>
-						<exclude>tools/formatter/**</exclude>
-						<!-- From gitignore -->
-						<exclude>.idea/**</exclude>
-						<exclude>target/**</exclude>
-						<exclude>bin/**</exclude>
-						<exclude>tmp/**</exclude>
-						<exclude>.settings/**</exclude>
-						<exclude>.externalToolBuilders/</exclude>
-						<exclude>build/</exclude>
-						<exclude>bin/</exclude>
-						<exclude>dist/</exclude>
-					</excludes>
-				</configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>
@@ -250,4 +266,48 @@
 		</snapshotRepository>
 	</distributionManagement>
 
+	<profiles>
+		<profile>
+			<id>ci</id>
+			<activation>
+				<property>
+					<name>env.CI</name>
+					<value>true</value>
+				</property>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>com.mycila</groupId>
+							<artifactId>license-maven-plugin</artifactId>
+							<executions>
+								<execution>
+									<id>format-license-header</id>
+									<phase>none</phase>
+								</execution>
+								<execution>
+									<id>validate-license-header</id>
+									<goals>
+										<goal>check</goal>
+									</goals>
+									<phase>initialize</phase>
+								</execution>
+							</executions>
+						</plugin>
+						<plugin>
+							<groupId>com.marvinformatics.formatter</groupId>
+							<artifactId>formatter-maven-plugin</artifactId>
+							<executions>
+								<execution>
+									<id>format-code</id>
+									<phase>none</phase>
+								</execution>
+							</executions>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
 </project>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
Ensure that when devs run mvn install/package the code and license headers are
formatted. Do not format on CI and fail on CI if license header is missing.

* bind mycila maven license plugin goal format to phase process-sources so it executes on
mvn install/package automatically.
* add ids to formatter plugins so we can override them easily
* extract common plugin configs for formatters into root pom in
pluginManagement
* fix missed formatting in MrrtReportTemplateServiceComponentTest
* add ci profile
  * activated with env var CI=true
  * license header will be checked and build will fail
  * code and license header will not be formatted

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-345
