### PR TITLE
Remove unused methods from RadiologyStudyService

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/HibernateRadiologyStudyDAO.java
@@ -9,13 +9,8 @@
  */
 package org.openmrs.module.radiology.study;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.hibernate.Criteria;
 import org.hibernate.SessionFactory;
 import org.hibernate.criterion.Restrictions;
-import org.openmrs.module.radiology.order.RadiologyOrder;
 
 /**
  * Hibernate specific RadiologyStudy related functions. This class should not be used directly. All calls
@@ -70,17 +65,6 @@ class HibernateRadiologyStudyDAO implements RadiologyStudyDAO {
     }
     
     /**
-     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getRadiologyStudyByOrderId(Integer)
-     */
-    @Override
-    public RadiologyStudy getRadiologyStudyByOrderId(Integer orderId) {
-        final String query = "from RadiologyStudy s where s.radiologyOrder.orderId = '" + orderId + "'";
-        return (RadiologyStudy) sessionFactory.getCurrentSession()
-                .createQuery(query)
-                .uniqueResult();
-    }
-    
-    /**
      * @see org.openmrs.module.radiology.study.RadiologyStudyService#getRadiologyStudyByStudyInstanceUid(String)
      */
     @Override
@@ -89,39 +73,5 @@ class HibernateRadiologyStudyDAO implements RadiologyStudyDAO {
                 .createCriteria(RadiologyStudy.class)
                 .add(Restrictions.eq("studyInstanceUid", studyInstanceUid))
                 .uniqueResult();
-    }
-    
-    /**
-     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getRadiologyStudiesByRadiologyOrders
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public List<RadiologyStudy> getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
-        List<RadiologyStudy> result = null;
-        if (!radiologyOrders.isEmpty()) {
-            final Criteria studyCriteria = sessionFactory.getCurrentSession()
-                    .createCriteria(RadiologyStudy.class);
-            addRestrictionOnRadiologyOrders(studyCriteria, radiologyOrders);
-            result = (List<RadiologyStudy>) studyCriteria.list();
-        }
-        
-        if (result == null) {
-            return new ArrayList<RadiologyStudy>();
-        } else {
-            return result;
-        }
-    }
-    
-    /**
-     * Adds an in restriction for given radiologyOrders on given criteria if radiologyOrders is not
-     * empty
-     *
-     * @param criteria criteria on which in restriction is set if radiologyOrders is not empty
-     * @param radiologyOrders radiology order list for which in restriction will be set
-     */
-    private void addRestrictionOnRadiologyOrders(Criteria criteria, List<RadiologyOrder> radiologyOrders) {
-        if (!radiologyOrders.isEmpty()) {
-            criteria.add(Restrictions.in("radiologyOrder", radiologyOrders));
-        }
     }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyDAO.java
@@ -9,10 +9,6 @@
  */
 package org.openmrs.module.radiology.study;
 
-import java.util.List;
-
-import org.openmrs.module.radiology.order.RadiologyOrder;
-
 /**
  * {@code RadiologyStudy} related database methods.
  * 
@@ -38,18 +34,7 @@ interface RadiologyStudyDAO {
     public RadiologyStudy getRadiologyStudyByUuid(String uuid);
     
     /**
-     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getRadiologyStudyByOrderId(Integer)
-     */
-    public RadiologyStudy getRadiologyStudyByOrderId(Integer orderId);
-    
-    /**
      * @see org.openmrs.module.radiology.study.RadiologyStudyService#getRadiologyStudyByStudyInstanceUid(String)
      */
     public RadiologyStudy getRadiologyStudyByStudyInstanceUid(String studyInstanceUid);
-    
-    /**
-     * @see org.openmrs.module.radiology.study.RadiologyStudyService#getStudiesByRadiologyOrders
-     */
-    public List<RadiologyStudy> getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders);
-    
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
@@ -9,13 +9,9 @@
  */
 package org.openmrs.module.radiology.study;
 
-import java.util.List;
-
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.OpenmrsService;
 import org.openmrs.module.radiology.RadiologyPrivileges;
-import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
-import org.openmrs.module.radiology.order.RadiologyOrder;
 
 /**
  * Service layer for {@code RadiologyStudy}.
@@ -46,21 +42,6 @@ public interface RadiologyStudyService extends OpenmrsService {
     public RadiologyStudy saveRadiologyStudy(RadiologyStudy radiologyStudy);
     
     /**
-     * Updates a {@code RadiologyStudy's} performed status in the database.
-     *
-     * @param studyInstanceUid the study instance uid of the study whos performed status should be updated
-     * @param performedStatus the performed procedure step status to which the study should be set to
-     * @return the radiology study whos performed status was updated
-     * @throws IllegalArgumentException if studyInstanceUid is null
-     * @throws IllegalArgumentException if performedStatus is null
-     * @should update performed status of radiology study associated with given study instance uid
-     * @should throw illegal argument exception if study instance uid is null
-     * @should throw illegal argument exception if performed status is null
-     */
-    @Authorized(RadiologyPrivileges.EDIT_RADIOLOGY_STUDIES)
-    public RadiologyStudy updateStudyPerformedStatus(String studyInstanceUid, PerformedProcedureStepStatus performedStatus);
-    
-    /**
      * Get the {@code RadiologyStudy} by its {@code studyId}.
      *
      * @param studyId the study id of the wanted study
@@ -87,19 +68,6 @@ public interface RadiologyStudyService extends OpenmrsService {
     public RadiologyStudy getRadiologyStudyByUuid(String uuid);
     
     /**
-     * Get the {@code RadiologyStudy} by its associated {@code RadiologyOrder's} {@code orderId}.
-     *
-     * @param orderId the order id of the wanted radiology studies associated radiology order
-     * @return the radiology study associated with a radiology order matching given order id
-     * @throws IllegalArgumentException if given null
-     * @should return radiology study associated with radiology order for which order id is given
-     * @should return null if no match was found
-     * @should throw illegal argument exception if given null
-     */
-    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_STUDIES)
-    public RadiologyStudy getRadiologyStudyByOrderId(Integer orderId);
-    
-    /**
      * Get the {@code RadiologyStudy} by its Study Instance UID.
      *
      * @param studyInstanceUid the study instance uid of wanted radiology study
@@ -111,18 +79,4 @@ public interface RadiologyStudyService extends OpenmrsService {
      */
     @Authorized(RadiologyPrivileges.GET_RADIOLOGY_STUDIES)
     public RadiologyStudy getRadiologyStudyByStudyInstanceUid(String studyInstanceUid);
-    
-    /**
-     * Get the {@code RadiologyStudy's} associated with a list of {@code RadiologyOrder's}.
-     *
-     * @param radiologyOrders the radiology orders for which radiology studies will be returned
-     * @return the radiology studies associated with given radiology orders
-     * @throws IllegalArgumentException given null
-     * @should return all radiology studies associated with given radiology orders
-     * @should return empty list given radiology orders without associated radiology studies
-     * @should return empty list given empty radiology order list
-     * @should throw illegal argument exception given null
-     */
-    @Authorized(RadiologyPrivileges.GET_RADIOLOGY_STUDIES)
-    public List<RadiologyStudy> getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders);
 }

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
@@ -9,16 +9,12 @@
  */
 package org.openmrs.module.radiology.study;
 
-import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.dicom.DicomUidGenerator;
-import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
-import org.openmrs.module.radiology.order.RadiologyOrder;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
@@ -82,26 +78,6 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     }
     
     /**
-     * @see RadiologyStudyService#updateStudyPerformedStatus(String, PerformedProcedureStepStatus)
-     */
-    @Override
-    @Transactional
-    public RadiologyStudy updateStudyPerformedStatus(String studyInstanceUid, PerformedProcedureStepStatus performedStatus) {
-        
-        if (studyInstanceUid == null) {
-            throw new IllegalArgumentException("studyInstanceUid cannot be null");
-        }
-        
-        if (performedStatus == null) {
-            throw new IllegalArgumentException("performedStatus cannot be null");
-        }
-        
-        final RadiologyStudy studyToBeUpdated = radiologyStudyDAO.getRadiologyStudyByStudyInstanceUid(studyInstanceUid);
-        studyToBeUpdated.setPerformedStatus(performedStatus);
-        return radiologyStudyDAO.saveRadiologyStudy(studyToBeUpdated);
-    }
-    
-    /**
      * @see RadiologyStudyService#getRadiologyStudy(Integer)
      */
     @Override
@@ -128,19 +104,6 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
     }
     
     /**
-     * @see RadiologyStudyService#getRadiologyStudyByOrderId(Integer)
-     */
-    @Override
-    public RadiologyStudy getRadiologyStudyByOrderId(Integer orderId) {
-        
-        if (orderId == null) {
-            throw new IllegalArgumentException("orderId cannot be null");
-        }
-        
-        return radiologyStudyDAO.getRadiologyStudyByOrderId(orderId);
-    }
-    
-    /**
      * @see RadiologyStudyService#getRadiologyStudyByStudyInstanceUid(String)
      */
     public RadiologyStudy getRadiologyStudyByStudyInstanceUid(String studyInstanceUid) {
@@ -149,19 +112,5 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
             throw new IllegalArgumentException("studyInstanceUid cannot be null");
         }
         return radiologyStudyDAO.getRadiologyStudyByStudyInstanceUid(studyInstanceUid);
-    }
-    
-    /**
-     * @see RadiologyStudyService#getStudiesByRadiologyOrders
-     */
-    @Override
-    public List<RadiologyStudy> getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder> radiologyOrders) {
-        
-        if (radiologyOrders == null) {
-            throw new IllegalArgumentException("radiologyOrders cannot be null");
-        }
-        
-        final List<RadiologyStudy> result = radiologyStudyDAO.getRadiologyStudiesByRadiologyOrders(radiologyOrders);
-        return result;
     }
 }

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
@@ -15,9 +15,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 
 import org.hibernate.cfg.Environment;
@@ -25,11 +22,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.openmrs.Patient;
-import org.openmrs.api.PatientService;
 import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
 import org.openmrs.module.radiology.order.RadiologyOrder;
-import org.openmrs.module.radiology.order.RadiologyOrderSearchCriteria;
 import org.openmrs.module.radiology.order.RadiologyOrderService;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,13 +37,7 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
     private static final String TEST_DATASET =
             "org/openmrs/module/radiology/include/RadiologyStudyServiceComponentTestDataset.xml";
     
-    private static final int PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER = 70021;
-    
     private static final int RADIOLOGY_ORDER_ID_WITHOUT_STUDY = 2004;
-    
-    private static final int EXISTING_RADIOLOGY_ORDER_ID = 2001;
-    
-    private static final int NON_EXISTING_RADIOLOGY_ORDER_ID = 99999;
     
     private static final String EXISTING_STUDY_UUID = "dde7399b-6092-4a3d-88a2-405b6b4499fc";
     
@@ -62,9 +50,6 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
     private static final int EXISTING_STUDY_ID = 1;
     
     private static final int NON_EXISTING_STUDY_ID = 99999;
-    
-    @Autowired
-    private PatientService patientService;
     
     @Autowired
     private RadiologyOrderService radiologyOrderService;
@@ -163,51 +148,6 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
     }
     
     /**
-     * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
-     * @verifies update performed status of radiology study associated with given study instance uid
-     */
-    @Test
-    public void updateStudyPerformedStatus_shouldUpdatePerformedStatusOfRadiologyStudyAssociatedWithGivenStudyInstanceUid()
-            throws Exception {
-        
-        RadiologyStudy existingStudy = radiologyStudyService.getRadiologyStudy(EXISTING_STUDY_ID);
-        PerformedProcedureStepStatus performedStatusPreUpdate = existingStudy.getPerformedStatus();
-        PerformedProcedureStepStatus performedStatusPostUpdate = PerformedProcedureStepStatus.COMPLETED;
-        
-        RadiologyStudy updatedStudy = radiologyStudyService.updateStudyPerformedStatus(existingStudy.getStudyInstanceUid(),
-            performedStatusPostUpdate);
-        
-        assertNotNull(updatedStudy);
-        assertThat(updatedStudy, is(existingStudy));
-        assertThat(performedStatusPreUpdate, is(not(performedStatusPostUpdate)));
-        assertThat(updatedStudy.getPerformedStatus(), is(performedStatusPostUpdate));
-    }
-    
-    /**
-     * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
-     * @verifies throw illegal argument exception if study instance uid is null
-     */
-    @Test
-    public void updateStudyPerformedStatus_shouldThrowIllegalArgumentExceptionIfStudyInstanceUidIsNull() throws Exception {
-        
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("studyInstanceUid cannot be null");
-        radiologyStudyService.updateStudyPerformedStatus(null, PerformedProcedureStepStatus.COMPLETED);
-    }
-    
-    /**
-     * @see RadiologyStudyService#updateStudyPerformedStatus(String,PerformedProcedureStepStatus)
-     * @verifies throw illegal argument exception if performed status is null
-     */
-    @Test
-    public void updateStudyPerformedStatus_shouldThrowIllegalArgumentExceptionIfPerformedStatusIsNull() throws Exception {
-        
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("performedStatus cannot be null");
-        radiologyStudyService.updateStudyPerformedStatus(EXISTING_STUDY_INSTANCE_UID, null);
-    }
-    
-    /**
      * @see RadiologyStudyService#getRadiologyStudy(Integer)
      * @verifies should return radiology study matching given study id
      */
@@ -217,9 +157,7 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
         RadiologyStudy radiologyStudy = radiologyStudyService.getRadiologyStudy(EXISTING_STUDY_ID);
         
         assertNotNull(radiologyStudy);
-        assertThat(radiologyStudy.getRadiologyOrder()
-                .getOrderId(),
-            is(EXISTING_RADIOLOGY_ORDER_ID));
+        assertThat(radiologyStudy.getStudyId(), is(EXISTING_STUDY_ID));
     }
     
     /**
@@ -280,44 +218,6 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
     }
     
     /**
-     * @see RadiologyStudyService#getRadiologyStudyByOrderId(Integer)
-     * @verifies return radiology study associated with radiology order for which order id is given
-     */
-    @Test
-    public void getRadiologyStudyByOrderId_shouldReturnRadiologyStudyAssociatedWithRadiologyOrderForWhichOrderIdIsGiven()
-            throws Exception {
-        
-        RadiologyStudy radiologyStudy = radiologyStudyService.getRadiologyStudyByOrderId(EXISTING_RADIOLOGY_ORDER_ID);
-        
-        assertNotNull(radiologyStudy);
-        assertThat(radiologyStudy.getRadiologyOrder()
-                .getOrderId(),
-            is(EXISTING_RADIOLOGY_ORDER_ID));
-    }
-    
-    /**
-     * @see RadiologyStudyService#getRadiologyStudyByOrderId(Integer)
-     * @verifies return null if no match was found
-     */
-    @Test
-    public void getRadiologyStudyByOrderId_shouldReturnNullIfNoMatchIsFound() {
-        
-        assertNull(radiologyStudyService.getRadiologyStudyByOrderId(NON_EXISTING_RADIOLOGY_ORDER_ID));
-    }
-    
-    /**
-     * @see RadiologyStudyService#getRadiologyStudyByOrderId(Integer)
-     * @verifies throw illegal argument exception if given null
-     */
-    @Test
-    public void getRadiologyStudyByOrderId_shouldThrowIllegalArgumentExceptionIfGivenNull() {
-        
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("orderId cannot be null");
-        assertNull(radiologyStudyService.getRadiologyStudyByOrderId(null));
-    }
-    
-    /**
      * @see RadiologyStudyService#getRadiologyStudyByStudyInstanceUid(String)
      * @verifies return radiology study exactly matching given study instance uid
      */
@@ -352,76 +252,5 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("studyInstanceUid cannot be null");
         assertNull(radiologyStudyService.getRadiologyStudyByStudyInstanceUid(null));
-    }
-    
-    /**
-     * @see RadiologyStudyService#getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder>)
-     * @verifies return all radiology studies associated with given radiology orders
-     */
-    @Test
-    public void getRadiologyStudiesByRadiologyOrders_shouldReturnAllRadiologyStudiesAssociatedWithGivenRadiologyOrders()
-            throws Exception {
-        
-        Patient patient = patientService.getPatient(PATIENT_ID_WITH_TWO_STUDIES_AND_NO_NON_RADIOLOGY_ORDER);
-        RadiologyOrderSearchCriteria radiologyOrderSearchCriteria =
-                new RadiologyOrderSearchCriteria.Builder().withPatient(patient)
-                        .build();
-        List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteria);
-        
-        List<RadiologyStudy> radiologyStudies = radiologyStudyService.getRadiologyStudiesByRadiologyOrders(radiologyOrders);
-        
-        assertThat(radiologyStudies.size(), is(radiologyOrders.size()));
-        assertThat(radiologyStudies.get(0)
-                .getRadiologyOrder(),
-            is(radiologyOrders.get(0)));
-        assertThat(radiologyStudies.get(1)
-                .getRadiologyOrder(),
-            is(radiologyOrders.get(1)));
-    }
-    
-    /**
-     * @see RadiologyStudyService#getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder>)
-     * @verifies return empty list given radiology orders without associated radiology studies
-     */
-    @Test
-    public void
-            getRadiologyStudiesByRadiologyOrders_shouldReturnEmptyListGivenRadiologyOrdersWithoutAssociatedRadiologyStudies()
-                    throws Exception {
-        
-        RadiologyOrder radiologyOrderWithoutStudy =
-                radiologyOrderService.getRadiologyOrder(RADIOLOGY_ORDER_ID_WITHOUT_STUDY);
-        List<RadiologyOrder> radiologyOrders = Arrays.asList(radiologyOrderWithoutStudy);
-        
-        List<RadiologyStudy> radiologyStudies = radiologyStudyService.getRadiologyStudiesByRadiologyOrders(radiologyOrders);
-        
-        assertThat(radiologyOrders.size(), is(1));
-        assertThat(radiologyStudies.size(), is(0));
-    }
-    
-    /**
-     * @see RadiologyStudyService#getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder>)
-     * @verifies return empty list given empty radiology order list
-     */
-    @Test
-    public void getRadiologyStudiesByRadiologyOrders_shouldReturnEmptyListGivenEmptyRadiologyOrderList() throws Exception {
-        
-        List<RadiologyOrder> orders = new ArrayList<RadiologyOrder>();
-        
-        List<RadiologyStudy> radiologyStudies = radiologyStudyService.getRadiologyStudiesByRadiologyOrders(orders);
-        
-        assertThat(orders.size(), is(0));
-        assertThat(radiologyStudies.size(), is(0));
-    }
-    
-    /**
-     * @see RadiologyStudyService#getRadiologyStudiesByRadiologyOrders(List<RadiologyOrder>)
-     * @should throw illegal argument exception if given null
-     */
-    @Test
-    public void getRadiologyStudiesByRadiologyOrders_shouldThrowIllegalArgumentExceptionGivenNull() throws Exception {
-        
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("radiologyOrders cannot be null");
-        radiologyStudyService.getRadiologyStudiesByRadiologyOrders(null);
     }
 }


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
Remove
* updateStudyPerformedStatus
* getRadiologyStudyByOrderId
* getRadiologyStudiesByRadiologyOrders

from RadiologyStudyService, since they are not used and RadiologyStudy will soon not be a member of RadiologyOrder.