### PR TITLE
Get Dockerfile dependencies from nexus

### DIFF
--- a/omod/src/main/docker/Dockerfile
+++ b/omod/src/main/docker/Dockerfile
@@ -2,10 +2,10 @@ FROM teleivo/openmrs-platform:2.0.0
 
 # Get radiology modules dependencies
 RUN curl -L \
-    "https://github.com/teleivo/tmp-dependencies-openmrs-module-radiology/raw/master/legacyui-0.3.1.omod" \
+    "http://mavenrepo.openmrs.org/nexus/service/local/repositories/modules/content/org/openmrs/module/legacyui-omod/0.3.1/legacyui-omod-0.3.1.jar" \
     -o "${OPENMRS_MODULES}/legacyui-0.3.1.omod"
 RUN curl -L \
-    "https://github.com/teleivo/tmp-dependencies-openmrs-module-radiology/raw/master/webservices.rest-2.15-SNAPSHOT.36ddda.omod" \
-    -o "${OPENMRS_MODULES}/webservices.rest-2.15-SNAPSHOT.36dda.omod"
+    "http://mavenrepo.openmrs.org/nexus/service/local/repositories/modules/content/org/openmrs/module/webservices.rest-omod/2.15/webservices.rest-omod-2.15.jar" \
+    -o "${OPENMRS_MODULES}/webservices.rest-2.15.omod"
 
 COPY maven/*.omod ${OPENMRS_MODULES}/


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
update Dockerfile URLs of module dependencies

* update webservices.rest module to 2.15 release
* get legacyui and webservices.rest from mavenrepo.openmrs.org