### PR TITLE
RAD-303 Rethink exceptions of API

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderService.java
@@ -42,15 +42,14 @@ public interface RadiologyOrderService extends OpenmrsService {
      * @param radiologyOrder the radiology order to be created
      * @return the created radiology order
      * @throws IllegalArgumentException if radiologyOrder is null
-     * @throws IllegalArgumentException if radiologyOrder.orderId is not null
      * @throws IllegalArgumentException if radiologyOrder.study is null
-     * @should create new radiology order and study from given radiology order object
+     * @throws APIException on saving an existing radiology order
+     * @should create new radiology order and study from given radiology order
      * @should create radiology order encounter
      * @should set the radiology order accession number
      * @should throw illegal argument exception given null
-     * @should throw illegal argument exception given existing radiology order
      * @should throw illegal argument exception if given radiology order has no study
-     * @should throw illegal argument exception if given study modality is null
+     * @should throw api exception on saving an existing radiology order
      */
     @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_ORDERS)
     public RadiologyOrder placeRadiologyOrder(RadiologyOrder radiologyOrder);
@@ -59,22 +58,24 @@ public interface RadiologyOrderService extends OpenmrsService {
      * Discontinues an existing {@code RadiologyOrder}.
      *
      * @param radiologyOrder the radiology order to be discontinued
+     * @param orderer the provider ordering the discontinuation of the radiology order
+     * @param discontinueReason the reason why the radiology order is discontinued
      * @return the discontinuation order
      * @throws Exception
      * @throws IllegalArgumentException if radiologyOrder is null
      * @throws IllegalArgumentException if radiologyOrder orderId is null
-     * @throws IllegalArgumentException if radiology order is discontinued
-     * @throws IllegalArgumentException if radiology order is in progress
-     * @throws IllegalArgumentException if radiology order is completed
      * @throws IllegalArgumentException if provider is null
+     * @throws APIException if radiology order is discontinued
+     * @throws APIException if radiology order is in progress
+     * @throws APIException if radiology order is completed
      * @should create discontinuation order which discontinues given radiology order that is not in progress or completed
      * @should create radiology order encounter
      * @should throw illegal argument exception if given radiology order is null
      * @should throw illegal argument exception if given radiology order with orderId null
-     * @should throw illegal argument exception if given radiology order is discontinued
-     * @should throw illegal argument exception if given radiology order is in progress
-     * @should throw illegal argument exception if given radiology order is completed
-     * @should throw illegal argument exception if given provider is null
+     * @should throw illegal argument exception if given orderer is null
+     * @should throw api exception if given radiology order is discontinued
+     * @should throw api exception if given radiology order is in progress
+     * @should throw api exception if given radiology order is completed
      */
     @Authorized({ RadiologyPrivileges.DELETE_RADIOLOGY_ORDERS })
     public Order discontinueRadiologyOrder(RadiologyOrder radiologyOrder, Provider orderer, String discontinueReason)
@@ -116,9 +117,12 @@ public interface RadiologyOrderService extends OpenmrsService {
      * @should return all radiology orders for given patient if patient is specified
      * @should return all radiology orders (including voided) matching the search query if include voided is set
      * @should return all radiology orders for given urgency
-     * @should return all radiology orders with effective order start date in given date range if to date and from date are specified
-     * @should return all radiology orders with effective order start date after or equal to from date if only from date is specified
-     * @should return all radiology orders with effective order start date before or equal to to date if only to date is specified
+     * @should return all radiology orders with effective order start date in given date range if to date and from date are
+     *         specified
+     * @should return all radiology orders with effective order start date after or equal to from date if only from date is
+     *         specified
+     * @should return all radiology orders with effective order start date before or equal to to date if only to date is
+     *         specified
      * @should return empty list if from date after to date
      * @should return empty search result if no effective order start is in date range
      * @should return all radiology orders for given accession number if accession number is specified

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyService.java
@@ -22,21 +22,22 @@ public interface RadiologyStudyService extends OpenmrsService {
     
     
     /**
-     * Saves a {@code RadiologyStudy} to the database.
+     * Saves a new {@code RadiologyStudy} to the database.
      * 
-     * @param radiologyStudy the radiology study to be created or updated
-     * @return the created or updated radiology study
+     * @param radiologyStudy the radiology study to be created
+     * @return the created radiology study
      * @throws IllegalArgumentException if given null
      * @throws IllegalArgumentException if global property DICOM UID org root cannot be found
      * @throws IllegalArgumentException if global property DICOM UID org root is empty
      * @throws IllegalArgumentException if global property DICOM UID org root is not a valid UID
      * @throws IllegalArgumentException if global property DICOM UID org root exceeds the maximum length
+     * @throws APIException on saving an existing radiology study
      * @should create new radiology study from given radiology study
      * @should set the study instance uid of given radiology study to a valid dicom uid if null
      * @should set the study instance uid of given radiology study to a valid dicom uid if only containing whitespaces
      * @should not set the study instance uid of given radiology study if contains non whitespace characters
-     * @should update existing radiology study
      * @should throw illegal argument exception if given null
+     * @should throw api exception on saving an existing radiology study
      */
     @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_STUDIES)
     public RadiologyStudy saveRadiologyStudy(RadiologyStudy radiologyStudy);

--- a/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/study/RadiologyStudyServiceImpl.java
@@ -12,6 +12,7 @@ package org.openmrs.module.radiology.study;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.APIException;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.radiology.RadiologyProperties;
 import org.openmrs.module.radiology.dicom.DicomUidGenerator;
@@ -50,6 +51,9 @@ class RadiologyStudyServiceImpl extends BaseOpenmrsService implements RadiologyS
         
         if (radiologyStudy == null) {
             throw new IllegalArgumentException("radiologyStudy cannot be null");
+        }
+        if (radiologyStudy.getStudyId() != null) {
+            throw new APIException("RadiologyStudy.cannot.edit.existing");
         }
         
         setStudyInstanceUidIfBlank(radiologyStudy);

--- a/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/study/RadiologyStudyServiceComponentTest.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.radiology.study;
 
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -22,7 +21,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.openmrs.module.radiology.dicom.code.PerformedProcedureStepStatus;
+import org.openmrs.api.APIException;
 import org.openmrs.module.radiology.order.RadiologyOrder;
 import org.openmrs.module.radiology.order.RadiologyOrderService;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
@@ -117,26 +116,6 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
     
     /**
      * @see RadiologyStudyService#saveRadiologyStudy(RadiologyStudy)
-     * @verifies update existing radiology study
-     */
-    @Test
-    public void saveRadiologyStudy_shouldUpdateExistingRadiologyStudy() throws Exception {
-        
-        RadiologyStudy existingStudy = radiologyStudyService.getRadiologyStudy(EXISTING_STUDY_ID);
-        PerformedProcedureStepStatus performedStatusPreUpdate = existingStudy.getPerformedStatus();
-        PerformedProcedureStepStatus performedStatusPostUpdate = PerformedProcedureStepStatus.COMPLETED;
-        existingStudy.setPerformedStatus(performedStatusPostUpdate);
-        
-        RadiologyStudy updatedStudy = radiologyStudyService.saveRadiologyStudy(existingStudy);
-        
-        assertNotNull(updatedStudy);
-        assertThat(updatedStudy, is(existingStudy));
-        assertThat(performedStatusPreUpdate, is(not(performedStatusPostUpdate)));
-        assertThat(updatedStudy.getPerformedStatus(), is(performedStatusPostUpdate));
-    }
-    
-    /**
-     * @see RadiologyStudyService#saveRadiologyStudy(RadiologyStudy)
      * @verifies throw illegal argument exception if given null
      */
     @Test
@@ -145,6 +124,20 @@ public class RadiologyStudyServiceComponentTest extends BaseModuleContextSensiti
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyStudy cannot be null");
         radiologyStudyService.saveRadiologyStudy(null);
+    }
+    
+    /**
+     * @see RadiologyStudyService#saveRadiologyStudy(RadiologyStudy)
+     * @verifies throw api exception on saving an existing radiology study
+     */
+    @Test
+    public void saveRadiologyStudy_shouldThrowApiExceptionOnSavingAnExistingRadiologyStudy() throws Exception {
+        
+        RadiologyStudy existingStudy = radiologyStudyService.getRadiologyStudy(EXISTING_STUDY_ID);
+        
+        expectedException.expect(APIException.class);
+        expectedException.expectMessage("RadiologyStudy.cannot.edit.existing");
+        radiologyStudyService.saveRadiologyStudy(existingStudy);
     }
     
     /**

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -117,6 +117,11 @@
 @MODULE_ID@.radiologyOrder.orderReasonNonCoded=Reason (Free Text)
 @MODULE_ID@.radiologyOrder.clinicalHistory=Clinical History
 
+@MODULE_ID@.RadiologyOrder.cannot.discontinue.discontinued=Cannot discontinue already discontinued radiology order
+@MODULE_ID@.RadiologyOrder.cannot.discontinue.inProgressOrcompleted=Cannot discontinue a radiology order that is already in progress or completed
+
+@MODULE_ID@.RadiologyStudy.cannot.edit.existing=Cannot edit an existing radiology study
+
 @MODULE_ID@.MrrtReportTemplate.imported=Report template imported
 @MODULE_ID@.MrrtReportTemplate.not.imported.empty=Failed to import report template because it was empty
 


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
throw openmrs APIException in service methods for cases violating business rules, and IllegalArgumentException for cases that are programming errors.
APIExceptions are thrown using message codes from the message properties files, so the client code can catch those and display the error message to the user.

* RadiologyStudyService.saveRadiologyStudy() does not allow saving existing
* use throw APIException in RadiologyOrderServie.placeRadiologyOrder() and
discontinueRadiologyOrder()
* catch APIException in RadiologyOrderFormController.saveRadiologyOrder()
* reduce code in catch block in
RadiologyOrderFormController.saveRadiologyOrder() only to the service call
* return in save/discontinueRadiologyOrder in controller after redirect since
model objects in model and view will not be used.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-303

