### PR TITLE
RAD-354 Overhaul ReportService

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -60,7 +60,7 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
     }
     
     /**
-     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReport(RadiologyReport)
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReportDraft(RadiologyReport)
      */
     @Override
     public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) {

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
@@ -33,7 +33,7 @@ interface RadiologyReportDAO {
     RadiologyReport getRadiologyReportByUuid(String radiologyReportUuid);
     
     /**
-     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReport(RadiologyReport)
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReportDraft(RadiologyReport)
      */
     RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport);
     

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -20,48 +20,64 @@ import org.openmrs.module.radiology.order.RadiologyOrder;
 
 /**
  * Service layer for {@code RadiologyReport}.
- * 
+ *
+ * <p>Typical usage involves:
+ * <ol>
+ * <li>Create a new {@code RadiologyReport} for a completed {@code RadiologyOrder}.
+ * <pre>{@code
+ * RadiologyReport radiologyReport = RadiologyReportService.createRadiologyReport(RadiologyOrder);
+ * }</pre>
+ * </li>
+ * <li>Set fields like for example {@code radiologyReport.setBody("Fracture of around 5mm visible in right tibia.")} through the setters of {@link RadiologyReport}.</li>
+ * <li>Optionally, save the {@code RadiologyReport} as a draft via {@link #saveRadiologyReportDraft(RadiologyReport)}.</li>
+ * <li>Optionally, void the {@code RadiologyReport} via {@link #unclaimRadiologyReport(RadiologyReport)}.</li>
+ * <li>Finally, complete the {@code RadiologyReport} via {@link #completeRadiologyReport(RadiologyReport, Provider)}.</li>
+ * </ol>
+ *
  * @see org.openmrs.module.radiology.report.RadiologyReport
  */
 public interface RadiologyReportService extends OpenmrsService {
     
     
     /**
-     * Saves a {@code RadiologyReport} to the database and sets its status to claimed.
+     * Saves a new {@code RadiologyReport} to the database and sets its status to claimed.
      *
-     * @param radiologyOrder the radiology order for which a radiology report will be created and claimed
-     * @return the created and claimed radiology report
+     * @param radiologyOrder the radiology order for which a radiology report will be created
+     * @return the created radiology report
      * @throws IllegalArgumentException if given null
-     * @throws IllegalArgumentException if Study of given radiologyOrder is null
      * @throws APIException if RadiologyStudy of given radiologyOrder is not completed
-     * @throws APIException if given radiologyOrder has a completed RadiologyReport
      * @throws APIException if given radiologyOrder has a claimed RadiologyReport
+     * @throws APIException if given radiologyOrder has a completed RadiologyReport
      * @should create a radiology order with report status claimed given a completed radiology order
      * @should throw illegal argument exception if given null
      * @should throw api exception if given radiology order is not completed
-     * @should throw api exception if given order has a completed radiology report
      * @should throw api exception if given order has a claimed radiology report
+     * @should throw api exception if given order has a completed radiology report
      */
     @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_REPORTS)
-    public RadiologyReport createAndClaimRadiologyReport(RadiologyOrder radiologyOrder);
+    public RadiologyReport createRadiologyReport(RadiologyOrder radiologyOrder);
     
     /**
-     * Saves a {@code RadiologyReport} to the database.
-     *
-     * @param radiologyReport the radiology report to be saved
+     * Saves an existing {@code RadiologyReport} which is in a draft state to the database.
+     * <p>
+     * A {@code RadiologyReport} is considered a draft as long as its status is {@code CLAIMED}.
+     * </p>
+     * @param radiologyReport the existing radiology report to be saved
      * @return the saved radiology report
      * @throws IllegalArgumentException if given null
-     * @throws IllegalArgumentException if radiologyReportStatus is null
-     * @throws APIException if radiologyReport is discontinued
+     * @throws IllegalArgumentException if radiologyReport reportId is null
      * @throws APIException if radiologyReport is completed
-     * @should save radiology report to the database and return it
+     * @throws APIException if radiologyReport is discontinued
+     * @throws APIException if radiologyReport.radiologyOrder has a completed RadiologyReport
+     * @should save existing radiology report to the database and return it
      * @should throw illegal argument exception if given null
-     * @should throw illegal argument exception if radiology report status is null
+     * @should throw illegal argument exception if given radiology report with reportId null
      * @should throw api exception if radiology report is completed
      * @should throw api exception if radiology report is discontinued
+     * @should throw api exception if given radiology reports order has a completed radiology report
      */
     @Authorized(RadiologyPrivileges.EDIT_RADIOLOGY_REPORTS)
-    public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport);
+    public RadiologyReport saveRadiologyReportDraft(RadiologyReport radiologyReport);
     
     /**
      * Unclaims a {@code RadiologyReport} and and sets its status to discontinued.
@@ -89,15 +105,17 @@ public interface RadiologyReportService extends OpenmrsService {
      * @return the completed radiology report
      *         principalResultsInterpreter
      * @throws IllegalArgumentException if radiologyReport is null
+     * @throws IllegalArgumentException if radiologyReport reportId is null
+     * @throws IllegalArgumentException if radiologyReport status is null
      * @throws IllegalArgumentException if principalResultsInterpreter is null
-     * @throws IllegalArgumentException if radiologyReportStatus is null
-     * @throws APIException if radiologyReport is discontinued
      * @throws APIException if radiologyReport is completed
+     * @throws APIException if radiologyReport is discontinued
      * @should set the report date of the radiology report to the day the radiology report was completed
      * @should set the radiology report status to complete
-     * @should throw illegal argument exception if principal results interpreter is null
-     * @should throw illegal argument exception if radiology report is null
-     * @should throw illegal argument exception if radiology report status is null
+     * @should throw illegal argument exception if given radiology report is null
+     * @should throw illegal argument exception if given radiology report with reportId null
+     * @should throw illegal argument exception if given radiology report with status null
+     * @should throw illegal argument exception if given principal results interpreter is null
      * @should throw api exception if radiology report is completed
      * @should throw api exception if radiology report is discontinued
      */

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -124,6 +124,17 @@
 
 @MODULE_ID@.RadiologyStudy.cannot.edit.existing=Cannot edit an existing radiology study
 
+@MODULE_ID@.RadiologyReport.cannot.create.for.not.completed.order=Cannot create a radiology report for an uncompleted order
+@MODULE_ID@.RadiologyReport.cannot.create.already.claimed=Cannot create a radiology report since this order has already been claimed for reporting
+@MODULE_ID@.RadiologyReport.cannot.create.already.completed=Cannot create a radiology report since this order has already been reported
+@MODULE_ID@.RadiologyReport.cannot.saveDraft.already.completed=Cannot save the radiology report as draft since the report is already completed
+@MODULE_ID@.RadiologyReport.cannot.saveDraft.already.discontinued=Cannot save the radiology report as draft since the report is already discontinued
+@MODULE_ID@.RadiologyReport.cannot.saveDraft.already.reported=Cannot save the radiology report draft since its order has already been reported
+@MODULE_ID@.RadiologyReport.savedDraft=Report draft saved
+@MODULE_ID@.RadiologyReport.cannot.complete.completed=Cannot complete this radiology report since its already completed
+@MODULE_ID@.RadiologyReport.cannot.complete.discontinued=Cannot complete this radiology report since its already discontinued
+@MODULE_ID@.RadiologyReport.completed=Report completed
+
 @MODULE_ID@.MrrtReportTemplate.imported=Report template imported
 @MODULE_ID@.MrrtReportTemplate.not.imported.empty=Failed to import report template because it was empty
 

--- a/omod/src/main/webapp/reports/radiologyReportForm.jsp
+++ b/omod/src/main/webapp/reports/radiologyReportForm.jsp
@@ -171,7 +171,7 @@
       <c:if test="${radiologyReport.status != 'DISCONTINUED'}">
         <input type="button" value="<spring:message code="radiology.radiologyReportUnclaim"/>"
           id="unclaimRadiologyReportButtonId" />
-        <input type="submit" value="<spring:message code="radiology.radiologyReportSave"/>" name="saveRadiologyReport" />
+        <input type="submit" value="<spring:message code="radiology.radiologyReportSave"/>" name="saveRadiologyReportDraft" />
         <input type="submit" value="<spring:message code="radiology.radiologyReportComplete"/>"
           name="completeRadiologyReport" />
       </c:if>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
* rename createAndClaimRadiologyReport to createRadiologyReport (in service and
controller)
* rename saveRadiologyReport to saveRadiologyReportDraft
* prevent saveRadiologyReportDraft if radiologyReport.reportId is null
* prevent saveRadiologyReportDraft if order already has a completed report
* harmonize tests and javadoc of Service methods
* make createRadiologyReport/saveDraft/complete synchronized
* add class javadoc to RadiologyReportService
* make tests cleaner
* throw APIExceptions using message property codes in RadiologyReportService
* catch APIExceptions in controller
* set session attribute on success/err in controller

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-354
