### PR TITLE
RAD-355 Turn unclaim into voidRadiologyReport

### DIFF
--- a/acceptanceTest/resources/demo-data.sql
+++ b/acceptanceTest/resources/demo-data.sql
@@ -453,7 +453,7 @@ INSERT INTO `orders` VALUES (1,4,161318,10,1,NULL,'2016-07-22 09:04:28',NULL,NUL
 INSERT INTO `test_order` VALUES (1,NULL,NULL,NULL,NULL,NULL);
 INSERT INTO `radiology_order` VALUES (1);
 INSERT INTO `radiology_study` VALUES (1,'2.25.246163855101151575419381898503875072573',1,'COMPLETED',10,'2016-07-22 09:04:29',NULL,NULL,'52cf158d-bd6b-4b60-b0ec-597dda94c372');
-INSERT INTO `radiology_report` VALUES (1,1,'COMPLETED',14,'2016-07-22','<p>Left&nbsp;wrist is broken, needs cask.</p>',14,'2016-07-22 09:06:00','022d45cc-ca76-49c0-8572-3c75a6f85e76');
+INSERT INTO `radiology_report` VALUES (1,1,'COMPLETED',14,'2016-07-22','<p>Left&nbsp;wrist is broken, needs cask.</p>',14,'2016-07-22 09:06:00','022d45cc-ca76-49c0-8572-3c75a6f85e76',false,NULL,NULL,NULL);
 COMMIT;
 
 -- Carlos Wilderman
@@ -488,7 +488,7 @@ INSERT INTO `orders` VALUES (6,4,161267,11,6,NULL,'2016-07-22 09:12:14',NULL,NUL
 INSERT INTO `test_order` VALUES (6,NULL,NULL,'already had broken her ankle once',NULL,NULL);
 INSERT INTO `radiology_order` VALUES (6);
 INSERT INTO `radiology_study` VALUES (5,'2.25.178890805958223695051050558077248903949',6,'COMPLETED',11,'2016-07-22 09:12:14',NULL,NULL,'07485517-d0dc-4a79-8e22-fd7d9326d055');
-INSERT INTO `radiology_report` VALUES (2,6,'CLAIMED',14,NULL,'<p>Old&nbsp;fracture visible, new one close to it.</p>',14,'2016-07-22 09:14:00','b56781de-7dad-4e25-b377-ebba7f3bf30c');
+INSERT INTO `radiology_report` VALUES (2,6,'CLAIMED',14,NULL,'<p>Old&nbsp;fracture visible, new one close to it.</p>',14,'2016-07-22 09:14:00','b56781de-7dad-4e25-b377-ebba7f3bf30c',false,NULL,NULL,NULL);
 COMMIT;
 
 BEGIN;
@@ -497,8 +497,8 @@ INSERT INTO `orders` VALUES (7,4,161291,11,7,NULL,'2016-07-22 09:14:28',NULL,NUL
 INSERT INTO `test_order` VALUES (7,NULL,NULL,'patient had several events of sharp abdominal pain for a few weeks',NULL,NULL);
 INSERT INTO `radiology_order` VALUES (7);
 INSERT INTO `radiology_study` VALUES (6,'2.25.195788626541510102066856864853818401349',7,'COMPLETED',11,'2016-07-22 09:14:28',NULL,NULL,'84feac4a-8954-4d0b-950b-e2b4ba1d4e9f');
-INSERT INTO `radiology_report` VALUES (3,7,'DISCONTINUED',14,NULL,'<p>Mhmm, not very firm with ultrasound. I\'ll ask Arden for help on this.</p>',14,'2016-07-22 09:16:00','d60338f6-27e0-4e69-bd91-fbc6e8f29660');
-INSERT INTO `radiology_report` VALUES (4,7,'CLAIMED',15,NULL,'<p>Ahh, clear to see that ...</p>',15,'2016-07-22 09:17:00','59ab79b5-15a0-40b2-a45e-57dba76bad25');
+INSERT INTO `radiology_report` VALUES (3,7,'CLAIMED',14,NULL,'<p>Mhmm, not very firm with ultrasound. I\'ll ask Arden for help on this.</p>',14,'2016-07-22 09:16:00','d60338f6-27e0-4e69-bd91-fbc6e8f29660',true,'2016-07-22 09:16:00',14,'Not firm enough with ultrasound, need Arden to help out here.');
+INSERT INTO `radiology_report` VALUES (4,7,'CLAIMED',15,NULL,'<p>Ahh, clear to see that ...</p>',15,'2016-07-22 09:17:00','59ab79b5-15a0-40b2-a45e-57dba76bad25',false,NULL,NULL,NULL);
 COMMIT;
 
 -- always update these values, they assure that the assigned order or accession numbers continue after the ones from the test data

--- a/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/HibernateRadiologyReportDAO.java
@@ -93,25 +93,9 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
                 .createCriteria(RadiologyReport.class)
                 .add(Restrictions.eq("radiologyOrder", radiologyOrder))
                 .add(Restrictions.eq("status", RadiologyReportStatus.CLAIMED))
+                .add(Restrictions.eq("voided", false))
                 .list();
         return radiologyReports.size() == 1;
-    }
-    
-    /**
-     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-     *      RadiologyReportStatus)
-     */
-    @SuppressWarnings("unchecked")
-    @Override
-    public List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(RadiologyOrder radiologyOrder,
-            RadiologyReportStatus radiologyReportStatus) {
-        
-        final List<RadiologyReport> result = sessionFactory.getCurrentSession()
-                .createCriteria(RadiologyReport.class)
-                .add(Restrictions.eq("radiologyOrder", radiologyOrder))
-                .add(Restrictions.eq("status", radiologyReportStatus))
-                .list();
-        return result == null ? new ArrayList<RadiologyReport>() : result;
     }
     
     /**
@@ -122,7 +106,7 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
         return (RadiologyReport) sessionFactory.getCurrentSession()
                 .createCriteria(RadiologyReport.class)
                 .add(Restrictions.eq("radiologyOrder", radiologyOrder))
-                .add(Restrictions.not(Restrictions.eq("status", RadiologyReportStatus.DISCONTINUED)))
+                .add(Restrictions.eq("voided", false))
                 .list()
                 .get(0);
     }
@@ -137,8 +121,8 @@ class HibernateRadiologyReportDAO implements RadiologyReportDAO {
         final Criteria crit = sessionFactory.getCurrentSession()
                 .createCriteria(RadiologyReport.class);
         
-        if (!searchCriteria.getIncludeDiscontinued()) {
-            crit.add(Restrictions.not(Restrictions.eq("status", RadiologyReportStatus.DISCONTINUED)));
+        if (!searchCriteria.getIncludeVoided()) {
+            crit.add(Restrictions.eq("voided", false));
         }
         if (searchCriteria.getFromDate() != null) {
             crit.add(Restrictions.ge("date", searchCriteria.getFromDate()));

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportDAO.java
@@ -23,6 +23,11 @@ interface RadiologyReportDAO {
     
     
     /**
+     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReportDraft(RadiologyReport)
+     */
+    RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport);
+    
+    /**
      * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReport(Integer)
      */
     RadiologyReport getRadiologyReport(Integer reportId);
@@ -33,11 +38,6 @@ interface RadiologyReportDAO {
     RadiologyReport getRadiologyReportByUuid(String radiologyReportUuid);
     
     /**
-     * @see org.openmrs.module.radiology.report.RadiologyReportService#saveRadiologyReportDraft(RadiologyReport)
-     */
-    RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport);
-    
-    /**
      * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder)
      */
     boolean hasRadiologyOrderClaimedRadiologyReport(RadiologyOrder radiologyOrder);
@@ -46,13 +46,6 @@ interface RadiologyReportDAO {
      * @see org.openmrs.module.radiology.report.RadiologyReportService#hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder)
      */
     boolean hasRadiologyOrderCompletedRadiologyReport(RadiologyOrder radiologyOrder);
-    
-    /**
-     * @see org.openmrs.module.radiology.report.RadiologyReportService#getRadiologyReportsByRadiologyOrderAndReportStatus(RadiologyOrder,
-     *      RadiologyReportStatus)
-     */
-    List<RadiologyReport> getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus(RadiologyOrder radiologyOrder,
-            RadiologyReportStatus radiologyReportStatus);
     
     /**
      * @see org.openmrs.module.radiology.report.RadiologyReportService#getActiveRadiologyReportByRadiologyOrder(RadiologyOrder)

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
@@ -25,7 +25,7 @@ public class RadiologyReportSearchCriteria {
     
     private final Provider principalResultsInterpreter;
     
-    private final Boolean includeDiscontinued;
+    private final Boolean includeVoided;
     
     private final RadiologyReportStatus status;
     
@@ -54,11 +54,11 @@ public class RadiologyReportSearchCriteria {
     }
     
     /**
-     * @return the {@code Boolean} specifying whether or not to include discontinued radiology reports
+     * @return the {@code Boolean} specifying whether or not to include voided radiology reports
      */
-    public Boolean getIncludeDiscontinued() {
+    public Boolean getIncludeVoided() {
         
-        return includeDiscontinued;
+        return includeVoided;
     }
     
     /**
@@ -78,7 +78,7 @@ public class RadiologyReportSearchCriteria {
         
         private Provider principalResultsInterpreter;
         
-        private Boolean includeDiscontinued = false;
+        private Boolean inludeVoided = false;
         
         private RadiologyReportStatus status;
         
@@ -113,18 +113,18 @@ public class RadiologyReportSearchCriteria {
         }
         
         /**
-         * Includes discontinued radiology reports.
+         * Includes voided radiology reports.
          * 
          * @return this builder instance
          */
-        public Builder includeDiscontinued() {
+        public Builder includeVoided() {
             
-            this.includeDiscontinued = true;
+            this.inludeVoided = true;
             return this;
         }
         
         /**
-         * Sets the criteria's report status and ensures {@code includeDiscontinued} is true if given status is discontinued.
+         * Sets the criteria's report status.
          * 
          * @param status the status of the report
          * @return this builder instance
@@ -132,9 +132,6 @@ public class RadiologyReportSearchCriteria {
         public Builder withStatus(RadiologyReportStatus status) {
             
             this.status = status;
-            if (status == RadiologyReportStatus.DISCONTINUED) {
-                this.includeDiscontinued = true;
-            }
             return this;
         }
         
@@ -144,9 +141,8 @@ public class RadiologyReportSearchCriteria {
          * @return a new search criteria instance
          * @should create a new radiology report search criteria instance with from and to date specified if date from and date to are set
          * @should create a new radiology report search criteria instance with principal results interpreter specified if principal results interpreter is set
-         * @should create a new radiology report search criteria instance with include discontinued set to true if discontinued reports should be included
+         * @should create a new radiology report search criteria instance with include voided set to true if voided reports should be included
          * @should create a new radiology report search criteria instance with report status specified if status is set to claimed or completed
-         * @should create a new radiology report search criteria instance with report status set to discontinued and include discontinued set to true if status is set to discontinued
          */
         public RadiologyReportSearchCriteria build() {
             
@@ -159,7 +155,7 @@ public class RadiologyReportSearchCriteria {
         this.fromDate = builder.fromDate;
         this.toDate = builder.toDate;
         this.principalResultsInterpreter = builder.principalResultsInterpreter;
-        this.includeDiscontinued = builder.includeDiscontinued;
+        this.includeVoided = builder.inludeVoided;
         this.status = builder.status;
     }
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportStatus.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportStatus.java
@@ -21,8 +21,4 @@ public enum RadiologyReportStatus {
      * The report is claimed by a physician and currently being worked on.
      */
     CLAIMED,
-    /**
-     * The report is discontinued and cannot be given to a patient.
-     */
-    DISCONTINUED
 }

--- a/api/src/main/resources/RadiologyReport.hbm.xml
+++ b/api/src/main/resources/RadiologyReport.hbm.xml
@@ -36,6 +36,10 @@
 		<property name="body" column="report_body" not-null="false" />
 		<many-to-one name="creator" unique="false" not-null="true" />
 		<property name="dateCreated" column="date_created" not-null="true" />
+		<property name="voided" type="java.lang.Boolean" column="voided" length="1" not-null="true"/>
+		<property name="dateVoided" type="java.util.Date" column="date_voided" length="19"/>
+		<many-to-one name="voidedBy" class="org.openmrs.User" column="voided_by" />
+		<property name="voidReason" type="java.lang.String" column="void_reason" length="255"/>
 		<property name="uuid" type="java.lang.String" column="uuid"
 			length="38" unique="true" />
 	</class>

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -458,4 +458,15 @@
 		<addNotNullConstraint tableName="radiology_study"
 			columnName="study_instance_uid" columnDataType="varchar(255)" />
 	</changeSet>
+	<changeSet id="radiology-37" author="teleivo">
+		<comment>Add columns to support voiding radiology_report</comment>
+		<addColumn tableName="radiology_report">
+			<column name="voided" type="BOOLEAN" defaultValueBoolean="false" >
+				<constraints nullable="false" />
+            </column>
+            <column name="date_voided" type="DATETIME"/>
+			<column name="voided_by" type="int"/>
+            <column name="void_reason" type="varchar(255)"/>
+		</addColumn>
+	</changeSet>
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteriaTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteriaTest.java
@@ -50,7 +50,7 @@ public class RadiologyReportSearchCriteriaTest {
                 .equals(fromDate));
         assertTrue(radiologyReportSearchCriteria.getToDate()
                 .equals(toDate));
-        assertFalse(radiologyReportSearchCriteria.getIncludeDiscontinued());
+        assertFalse(radiologyReportSearchCriteria.getIncludeVoided());
         assertNull(radiologyReportSearchCriteria.getPrincipalResultsInterpreter());
         assertNull(radiologyReportSearchCriteria.getStatus());
     }
@@ -72,7 +72,7 @@ public class RadiologyReportSearchCriteriaTest {
         assertThat(radiologyReportSearchCriteria.getPrincipalResultsInterpreter()
                 .getId(),
             is(1));
-        assertFalse(radiologyReportSearchCriteria.getIncludeDiscontinued());
+        assertFalse(radiologyReportSearchCriteria.getIncludeVoided());
         assertNull(radiologyReportSearchCriteria.getToDate());
         assertNull(radiologyReportSearchCriteria.getFromDate());
         assertNull(radiologyReportSearchCriteria.getStatus());
@@ -80,17 +80,17 @@ public class RadiologyReportSearchCriteriaTest {
     
     /**
      * @see RadiologyReportSearchCriteria.Builder#build()
-     * @verifies create a new radiology report search criteria instance with include discontinued set to true if discontinued reports should be included
+     * @verifies create a new radiology report search criteria instance with include voided set to true if voided reports should be included
      */
     @Test
     public void
             build_createANewRadiologyReportSearchCriteriaInstanceWithIncludeDiscontinuedSetToTrueIfDiscontinuedReportsShouldBeIncluded()
                     throws Exception {
         
-        radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().includeDiscontinued()
+        radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().includeVoided()
                 .build();
         
-        assertTrue(radiologyReportSearchCriteria.getIncludeDiscontinued());
+        assertTrue(radiologyReportSearchCriteria.getIncludeVoided());
         assertNull(radiologyReportSearchCriteria.getToDate());
         assertNull(radiologyReportSearchCriteria.getFromDate());
         assertNull(radiologyReportSearchCriteria.getPrincipalResultsInterpreter());
@@ -110,7 +110,7 @@ public class RadiologyReportSearchCriteriaTest {
                 .build();
         
         assertThat(radiologyReportSearchCriteria.getStatus(), is(RadiologyReportStatus.CLAIMED));
-        assertFalse(radiologyReportSearchCriteria.getIncludeDiscontinued());
+        assertFalse(radiologyReportSearchCriteria.getIncludeVoided());
         assertNull(radiologyReportSearchCriteria.getToDate());
         assertNull(radiologyReportSearchCriteria.getFromDate());
         assertNull(radiologyReportSearchCriteria.getPrincipalResultsInterpreter());
@@ -119,30 +119,9 @@ public class RadiologyReportSearchCriteriaTest {
                 new RadiologyReportSearchCriteria.Builder().withStatus(RadiologyReportStatus.COMPLETED)
                         .build();
         assertThat(radiologyReportSearchCriteria.getStatus(), is(RadiologyReportStatus.COMPLETED));
-        assertFalse(radiologyReportSearchCriteria.getIncludeDiscontinued());
+        assertFalse(radiologyReportSearchCriteria.getIncludeVoided());
         assertNull(radiologyReportSearchCriteria.getToDate());
         assertNull(radiologyReportSearchCriteria.getFromDate());
         assertNull(radiologyReportSearchCriteria.getPrincipalResultsInterpreter());
     }
-    
-    /**
-     * @see RadiologyReportSearchCriteria.Builder#build()
-     * @verifies create a new radiology report search criteria instance with report status set to discontinued and include discontinued set to true if status is set to discontinued
-     */
-    @Test
-    public void
-            build_createANewRadiologyReportSearchCriteriaInstanceWithReportStatusSetToDiscontinuedAndIncludeDiscontinuedSetToTrueIfStatusIsSetToDiscontinued()
-                    throws Exception {
-        
-        radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withStatus(RadiologyReportStatus.DISCONTINUED)
-                        .build();
-        
-        assertThat(radiologyReportSearchCriteria.getStatus(), is(RadiologyReportStatus.DISCONTINUED));
-        assertTrue(radiologyReportSearchCriteria.getIncludeDiscontinued());
-        assertNull(radiologyReportSearchCriteria.getToDate());
-        assertNull(radiologyReportSearchCriteria.getFromDate());
-        assertNull(radiologyReportSearchCriteria.getPrincipalResultsInterpreter());
-    }
-    
 }

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -74,26 +74,26 @@
   <test_order order_id="2006" />
   <radiology_order order_id="2006" />
   <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="58855a84-3c39-42d8-8d33-6c3f228c0936"/>
-  <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" uuid="e699d90d-e230-4762-8747-d2d0059394b0" report_date="2016-05-28" />
+  <radiology_report report_id="1" order_id="2006" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" voided="false" uuid="e699d90d-e230-4762-8747-d2d0059394b0" report_date="2016-05-28" />
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="5" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
-  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" voided="false" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
 
   <!-- radiology order with associated study and a discontinued report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="6" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="7ed51f0e-5351-4849-9ec3-9e87e18259c5"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="eb6dc805-e79f-4ca2-945b-5e9bdd9491c6"/>
-  <radiology_report report_id="3" order_id="2008" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
+  <radiology_report report_id="3" order_id="2008" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" voided="true" date_voided="2015-02-07 21:13:47.0" voided_by="1" void_reason="selected wrong order" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
   
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="7" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
   <test_order order_id="2009" />
   <radiology_order order_id="2009" />
   <radiology_study study_id="7" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.7" order_id="2009" performed_status="COMPLETED" creator="1" date_created="2016-07-01 13:17:15.0" uuid="7ffd5b5e-473f-11e6-beb8-9e71128cae77"/>
-  <radiology_report report_id="4" order_id="2009" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2016-07-01 13:17:15.0" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
+  <radiology_report report_id="4" order_id="2009" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/VoidRadiologyReportRequest.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/VoidRadiologyReportRequest.java
@@ -1,0 +1,37 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.web;
+
+/**
+ * Used as {@code ModelAttribute} when voiding a {@code RadiologyReport}.
+ */
+final class VoidRadiologyReportRequest {
+    
+    
+    /**
+     * Reason for voiding the {@code RadiologyReport}.
+     */
+    String voidReason;
+    
+    /**
+     * Create a new instance of {@code VoidRadiologyReportRequest}.
+     */
+    protected VoidRadiologyReportRequest() {
+        // shall only be used within this package
+    }
+    
+    public String getVoidReason() {
+        return voidReason;
+    }
+    
+    public void setVoidReason(String voidReason) {
+        this.voidReason = voidReason;
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/VoidRadiologyReportRequestValidator.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/VoidRadiologyReportRequestValidator.java
@@ -1,0 +1,57 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.web;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ValidationUtils;
+import org.springframework.validation.Validator;
+
+/**
+ * Validates {@link VoidRadiologyReportRequest}.
+ */
+@Component
+public class VoidRadiologyReportRequestValidator implements Validator {
+    
+    
+    /** Log for this class and subclasses */
+    protected final Log log = LogFactory.getLog(getClass());
+    
+    /**
+     * Determines if the command object being submitted is a valid type
+     *
+     * @see Validator#supports(Class)
+     * @should return true only for void radiology report request objects
+     * @should return false for other object types
+     */
+    @Override
+    public boolean supports(Class clazz) {
+        return VoidRadiologyReportRequest.class.equals(clazz);
+    }
+    
+    /**
+     * Checks the form object for any inconsistencies/errors
+     *
+     * @see Validator#validate(Object, Errors)
+     * @should fail validation if void reason is null or empty or whitespaces only
+     * @should pass validation if all fields are correct
+     */
+    @Override
+    public void validate(Object obj, Errors errors) {
+        final VoidRadiologyReportRequest voidRadiologyReportRequest = (VoidRadiologyReportRequest) obj;
+        if (voidRadiologyReportRequest == null) {
+            errors.reject("error.general");
+        } else {
+            ValidationUtils.rejectIfEmptyOrWhitespace(errors, "voidReason", "error.null");
+        }
+    }
+}

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResource.java
@@ -67,6 +67,7 @@ public class RadiologyReportResource extends DataDelegatingCrudResource<Radiolog
         description.addProperty("status");
         description.addProperty("body");
         description.addProperty("display");
+        description.addProperty("voided");
     }
     
     /**

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
@@ -79,7 +79,7 @@ public class RadiologyReportSearchHandler implements SearchHandler {
     /**
      * @see org.openmrs.module.webservices.rest.web.resource.api.SearchHandler#search()
      * @throws IllegalArgumentException if report status doesn't exist
-     * @should return all radiology reports (including discontinued) matching the search query if include all is set
+     * @should return all radiology reports (including voided) matching the search query if include all is set
      * @should return all radiology reports within given date range if date to and date from are specified
      * @should return all radiology reports with report date after or equal to from date if only date from is specified
      * @should return all radiology reports with report date before or equal to to date if only date to is specified
@@ -132,7 +132,7 @@ public class RadiologyReportSearchHandler implements SearchHandler {
             radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
                     .withToDate(toDate)
                     .withPrincipalResultsInterpreter(principalResultsInterpreter)
-                    .includeDiscontinued()
+                    .includeVoided()
                     .withStatus(status)
                     .build();
         } else {

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -51,6 +51,8 @@
 @MODULE_ID@.dashboard.tabs.reports.filters.date.to=to date
 @MODULE_ID@.dashboard.tabs.reports.filters.principalResultsInterpreter=Principal Results Interpreter
 @MODULE_ID@.dashboard.tabs.reports.filters.principalResultsInterpreter.title=Proposals after two characters
+@MODULE_ID@.dashboard.tabs.reports.filters.includeAll.title=Includes deleted reports
+@MODULE_ID@.dashboard.tabs.reports.filters.includeAll.description=Include deleted
 
 @MODULE_ID@.dashboard.tabs.reportTemplates=Report Templates
 @MODULE_ID@.dashboard.tabs.reportTemplates.filters.title=Title
@@ -105,15 +107,14 @@
 
 @MODULE_ID@.report.principalResultsInterpreter=Principal Results Interpreter
 
-@MODULE_ID@.report.form.unclaim.dialog.title=Unclaim Report
-@MODULE_ID@.report.form.unclaim.dialog.message=Are you sure you want to unclaim this report?
-@MODULE_ID@.report.form.unclaim.dialog.button.ok=Ok
-@MODULE_ID@.report.form.unclaim.dialog.button.cancel=Cancel
+@MODULE_ID@.report.form.void.dialog.title=Delete Report
+@MODULE_ID@.report.form.void.dialog.message=Are you sure you want to delete this report?
+@MODULE_ID@.report.form.void.dialog.button.ok=Ok
+@MODULE_ID@.report.form.void.dialog.button.cancel=Cancel
 
 @MODULE_ID@.report.status.selectStatus=Select status
 @MODULE_ID@.report.status.COMPLETED=Completed
 @MODULE_ID@.report.status.CLAIMED=Claimed
-@MODULE_ID@.report.status.DISCONTINUED=Discontinued
 
 @MODULE_ID@.radiologyOrder.orderReason=Reason (Coded)
 @MODULE_ID@.radiologyOrder.orderReasonNonCoded=Reason (Free Text)
@@ -128,12 +129,14 @@
 @MODULE_ID@.RadiologyReport.cannot.create.already.claimed=Cannot create a radiology report since this order has already been claimed for reporting
 @MODULE_ID@.RadiologyReport.cannot.create.already.completed=Cannot create a radiology report since this order has already been reported
 @MODULE_ID@.RadiologyReport.cannot.saveDraft.already.completed=Cannot save the radiology report as draft since the report is already completed
-@MODULE_ID@.RadiologyReport.cannot.saveDraft.already.discontinued=Cannot save the radiology report as draft since the report is already discontinued
+@MODULE_ID@.RadiologyReport.cannot.saveDraft.already.voided=Cannot save the radiology report as draft since the report is already voided
 @MODULE_ID@.RadiologyReport.cannot.saveDraft.already.reported=Cannot save the radiology report draft since its order has already been reported
 @MODULE_ID@.RadiologyReport.savedDraft=Report draft saved
 @MODULE_ID@.RadiologyReport.cannot.complete.completed=Cannot complete this radiology report since its already completed
-@MODULE_ID@.RadiologyReport.cannot.complete.discontinued=Cannot complete this radiology report since its already discontinued
+@MODULE_ID@.RadiologyReport.cannot.complete.voided=Cannot complete this radiology report since its already voided
 @MODULE_ID@.RadiologyReport.completed=Report completed
+@MODULE_ID@.RadiologyReport.cannot.void.completed=Cannot void this radiology report since its already completed
+@MODULE_ID@.RadiologyReport.voided=Report voided
 
 @MODULE_ID@.MrrtReportTemplate.imported=Report template imported
 @MODULE_ID@.MrrtReportTemplate.not.imported.empty=Failed to import report template because it was empty
@@ -188,7 +191,6 @@
 @MODULE_ID@.radiologyReportProvider=Results Interpreter
 @MODULE_ID@.radiologyReportDate=Completion Date
 @MODULE_ID@.radiologyReportClaim=Claim Report
-@MODULE_ID@.radiologyReportUnclaim=Unclaim
 @MODULE_ID@.radiologyReportSave=Save as Draft
 @MODULE_ID@.radiologyReportComplete=Save & Complete
 @MODULE_ID@.radiologyReportResume=Resume work on Report

--- a/omod/src/main/webapp/portlets/radiologyReportsTab.jsp
+++ b/omod/src/main/webapp/portlets/radiologyReportsTab.jsp
@@ -16,6 +16,7 @@
                     var toDate = $j('#reportsTabToDateFilter');
                     var principalResultsInterpreterUuid = $j('#reportsTabProviderFilter');
                     var status = $j('#reportsTabStatusSelect');
+                    var includeAll = $j('#reportsTabIncludeAllFilter');
                     var find = $j('#reportsTabFind');
                     var clearResults = $j('a#reportsTabClearFilters');
 
@@ -83,6 +84,7 @@
                                             principalResultsInterpreter: principalResultsInterpreterUuid
                                                     .val(),
                                             status: status.val(),
+                                            includeAll: includeAll.is(':checked'),
                                             totalCount: true,
                                           };
                                         },
@@ -155,6 +157,14 @@
                                             }
                                           },
                                           {
+                                            "name": "voided",
+                                            "responsivePriority": 11000,
+                                            "render": function(data, type,
+                                                    full, meta) {
+                                                return full.voided;
+                                            }
+                                          },
+                                          {
                                             "name": "status",
                                             "className": "dt-center",
                                             "render": function(data, type,
@@ -164,8 +174,6 @@
                                                 return '<i title="<spring:message code="radiology.report.status.COMPLETED"/>" class="fa fa-check-circle fa-lg"></i>';
                                               case "CLAIMED":
                                                 return '<i title="<spring:message code="radiology.report.status.CLAIMED"/>" class="fa fa-circle fa-lg"></i>';
-                                              case "DISCONTINUED":
-                                                return '<i title="<spring:message code="radiology.report.status.DISCONTINUED"/>" class="fa fa-times-circle fa-lg"></i>';
                                               }
                                             }
                                           },
@@ -238,7 +246,10 @@
                 </c:choose>
               </option>
             </c:forEach>
-        </select></td>
+        </select>
+        <input type="checkbox" id="reportsTabIncludeAllFilter" name="includeAllFilter" title="<spring:message code="radiology.dashboard.tabs.reports.filters.includeAll.title"/>" >
+        <spring:message code="radiology.dashboard.tabs.reports.filters.includeAll.description" />
+        </td>
         <td><input id="reportsTabFind" type="button"
           value="<spring:message code="radiology.dashboard.tabs.filters.filter"/>" /></td>
       </form>
@@ -255,6 +266,7 @@
           <th><spring:message code="radiology.datatables.column.report.date" /></th>
           <th><spring:message code="radiology.datatables.column.report.dateCreated" /></th>
           <th><spring:message code="radiology.datatables.column.report.createdBy" /></th>
+          <th><spring:message code="general.voided" /></th>
           <th><spring:message code="radiology.datatables.column.report.status" /></th>
           <th><spring:message code="radiology.datatables.column.action" /></th>
         </tr>

--- a/omod/src/main/webapp/reports/radiologyReportForm.jsp
+++ b/omod/src/main/webapp/reports/radiologyReportForm.jsp
@@ -11,34 +11,34 @@
 <script type="text/javascript">
   var $j = jQuery.noConflict();
  
-  function showUnclaimRadiologyReportDialog() {
+  function showVoidRadiologyReportDialog() {
     var dialogDiv = $j("<div></div>")
             .html(
-                    '<spring:message code="radiology.report.form.unclaim.dialog.message"/>');
+                    '<spring:message code="radiology.report.form.void.dialog.message"/>');
     dialogDiv
             .dialog({
               resizable: false,
               width: 'auto',
               height: 'auto',
-              title: '<spring:message code="radiology.report.form.unclaim.dialog.title"/>',
+              title: '<spring:message code="radiology.report.form.void.dialog.title"/>',
               modal: true,
               buttons: {
-                '<spring:message code="radiology.report.form.unclaim.dialog.button.ok"/>': function() {
+                '<spring:message code="radiology.report.form.void.dialog.button.ok"/>': function() {
                   $j(this).dialog("close");
-                  submitUnclaimRadiologyReport();
+                  submitVoidRadiologyReport();
                 },
-                '<spring:message code="radiology.report.form.unclaim.dialog.button.cancel"/>': function() {
+                '<spring:message code="radiology.report.form.void.dialog.button.cancel"/>': function() {
                   $j(this).dialog("close");
                 }
               }
             });
   }
 
-  function submitUnclaimRadiologyReport() {
-    var unclaimRadiologyReport = $j("<input>").attr("type", "hidden").attr(
-            "name", "unclaimRadiologyReport").val("Unclaim");
-    $j("#radiologyReportFormId").append(unclaimRadiologyReport);
-    $j("#radiologyReportFormId").submit()
+  function submitVoidRadiologyReport() {
+    var voidRadiologyReport = $j("<input>").attr("type", "hidden").attr(
+            "name", "voidRadiologyReport").val('<spring:message code="general.void"/>');
+    $j("#voidRadiologyReportForm").append(voidRadiologyReport);
+    $j("#voidRadiologyReportForm").submit()
   }
 
   $j(document).ready(function() {
@@ -57,11 +57,11 @@
       elementpath: false,
     });
 
-    $j("#unclaimRadiologyReportButtonId").click(function() {
+    $j("#voidRadiologyReportButtonId").click(function() {
       if (tinymce.activeEditor.getContent() != "") {
-        showUnclaimRadiologyReportDialog();
+        showVoidRadiologyReportDialog();
       } else {
-        submitUnclaimRadiologyReport();
+        submitVoidRadiologyReport();
       }
     });
 
@@ -91,6 +91,13 @@
   </div>
   <br>
 </spring:hasBindErrors>
+<c:if test="${radiologyReport.voided}">
+  <div class="retiredMessage">
+    <div>
+      <spring:message code="general.voided"/>
+    </div>
+  </div>
+</c:if>
 <span class="boxHeader"> <b><spring:message code="radiology.radiologyReportTitle" /></b>
 </span>
 <form:form id="radiologyReportFormId" modelAttribute="radiologyReport" method="post">
@@ -165,17 +172,46 @@
 					<form:hidden path="dateCreated" />
             </spring:bind></span></td>
       </tr>
+      <c:if test="${radiologyReport.voided}">
+          <form:hidden path="voided" />
+          <tr>
+            <td><spring:message code="general.voidedBy" /></td>
+            <td><spring:bind path="voidedBy.personName">
+                        ${status.value}
+                        <form:hidden path="voidedBy" />
+              </spring:bind> - <span class="datetime"><spring:bind path="dateVoided">
+                        ${status.value}
+                        <form:hidden path="dateVoided" />
+                </spring:bind></span></td>
+          </tr>
+          <tr>
+            <td><spring:message code="general.voidReason" /></td>
+            <td><spring:bind path="voidReason">${status.value}</spring:bind></td>
+          </tr>
+      </c:if>
     </table>
     <br>
-    <c:if test="${radiologyReport.status != 'COMPLETED'}">
-      <c:if test="${radiologyReport.status != 'DISCONTINUED'}">
-        <input type="button" value="<spring:message code="radiology.radiologyReportUnclaim"/>"
-          id="unclaimRadiologyReportButtonId" />
+    <c:if test="${(radiologyReport.status == 'CLAIMED') && (not radiologyReport.voided)}">
         <input type="submit" value="<spring:message code="radiology.radiologyReportSave"/>" name="saveRadiologyReportDraft" />
         <input type="submit" value="<spring:message code="radiology.radiologyReportComplete"/>"
           name="completeRadiologyReport" />
-      </c:if>
     </c:if>
   </div>
 </form:form>
+<c:if test="${(radiologyReport.status == 'CLAIMED') && (not radiologyReport.voided)}">
+  </br>
+  <form:form method="post" id="voidRadiologyReportForm" modelAttribute="voidRadiologyReportRequest" cssClass="box">
+    <table>
+        <td><spring:message code="general.voidReason" /></td>
+        <td><spring:bind path="voidReason">
+            <textarea name="${status.expression}">${status.value}</textarea>
+            <c:if test="${not empty status.errorMessage}">
+              <span class="error">${status.errorMessage}</span>
+            </c:if>
+          </spring:bind></td>
+      </tr>
+    </table>
+    <input type="button" value="<spring:message code="general.void"/>" id="voidRadiologyReportButtonId" />
+  </form:form>
+</c:if>
 <%@ include file="/WEB-INF/template/footer.jsp"%>

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/VoidRadiologyReportRequestValidatorTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/VoidRadiologyReportRequestValidatorTest.java
@@ -1,0 +1,133 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.web;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.validation.BindException;
+import org.springframework.validation.Errors;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests {@link VoidRadiologyReportRequest}.
+ */
+public class VoidRadiologyReportRequestValidatorTest {
+    
+    
+    VoidRadiologyReportRequestValidator voidRadiologyReportRequestValidator;
+    
+    VoidRadiologyReportRequest voidRadiologyReportRequest;
+    
+    @Before
+    public void setUp() {
+        
+        voidRadiologyReportRequestValidator = new VoidRadiologyReportRequestValidator();
+        
+        voidRadiologyReportRequest = new VoidRadiologyReportRequest();
+        voidRadiologyReportRequest.setVoidReason("wrong order selected");
+    }
+    
+    /**
+     * @see VoidRadiologyReportRequestValidator#supports(Class)
+     * @verifies return true only for void radiology report request objects
+     */
+    @Test
+    public void supports_shouldReturnTrueOnlyForVoidRadiologyReportRequestObjects() throws Exception {
+        
+        assertTrue(voidRadiologyReportRequestValidator.supports(VoidRadiologyReportRequest.class));
+    }
+    
+    /**
+     * @see VoidRadiologyReportRequestValidator#supports(Class)
+     * @verifies return false for other object types
+     */
+    @Test
+    public void supports_shouldReturnFalseForOtherObjectTypes() throws Exception {
+        
+        assertFalse(voidRadiologyReportRequestValidator.supports(Object.class));
+    }
+    
+    /**
+     * @see VoidRadiologyReportRequestValidator#validate(Object, Errors)
+     * @verifies fail validation if void radiology report request is null
+     */
+    @Test
+    public void validate_shouldFailValidationIfDiscontinuationOrderRequestIsNull() throws Exception {
+        
+        Errors errors = new BindException(voidRadiologyReportRequest, "voidRadiologyReportRequest");
+        voidRadiologyReportRequestValidator.validate(null, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(),
+            is("error.general"));
+    }
+    
+    /**
+     * @see VoidRadiologyReportRequestValidator#validate(Object, Errors)
+     * @verifies fail validation if void reason is null or empty or whitespaces only
+     */
+    @Test
+    public void validate_shouldFailValidationIfVoidReasonNonCodedIsNull() throws Exception {
+        
+        voidRadiologyReportRequest.setVoidReason(null);
+        
+        Errors errors = new BindException(voidRadiologyReportRequest, "voidRadiologyReportRequest");
+        voidRadiologyReportRequestValidator.validate(voidRadiologyReportRequest, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertTrue(errors.hasFieldErrors("voidReason"));
+        
+        voidRadiologyReportRequest.setVoidReason("");
+        
+        errors = new BindException(voidRadiologyReportRequest, "voidRadiologyReportRequest");
+        voidRadiologyReportRequestValidator.validate(voidRadiologyReportRequest, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertTrue(errors.hasFieldErrors("voidReason"));
+        
+        voidRadiologyReportRequest.setVoidReason("   ");
+        
+        errors = new BindException(voidRadiologyReportRequest, "voidRadiologyReportRequest");
+        voidRadiologyReportRequestValidator.validate(voidRadiologyReportRequest, errors);
+        
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertTrue(errors.hasFieldErrors("voidReason"));
+    }
+    
+    /**
+     * @see VoidRadiologyReportRequestValidator#validate(Object, Errors)
+     * @verifies pass validation if all fields are correct
+     */
+    @Test
+    public void validate_shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
+        
+        Errors errors = new BindException(voidRadiologyReportRequest, "voidRadiologyReportRequest");
+        voidRadiologyReportRequestValidator.validate(voidRadiologyReportRequest, errors);
+        
+        assertFalse(errors.hasErrors());
+    }
+}

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceComponentTest.java
@@ -72,6 +72,7 @@ public class RadiologyReportResourceComponentTest
         assertPropPresent("status");
         assertPropPresent("body");
         assertPropPresent("display");
+        assertPropPresent("voided");
     }
     
     /**
@@ -87,6 +88,7 @@ public class RadiologyReportResourceComponentTest
         assertPropPresent("status");
         assertPropPresent("body");
         assertPropPresent("display");
+        assertPropPresent("voided");
         assertPropPresent("auditInfo");
     }
 }

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/resource/RadiologyReportResourceTest.java
@@ -101,7 +101,8 @@ public class RadiologyReportResourceTest {
                 radiologyReportResource.getRepresentationDescription(defaultRepresentation);
         assertThat(resourceDescription.getProperties()
                 .keySet(),
-            contains("uuid", "radiologyOrder", "date", "principalResultsInterpreter", "status", "body", "display"));
+            contains("uuid", "radiologyOrder", "date", "principalResultsInterpreter", "status", "body", "display",
+                "voided"));
         assertThat(resourceDescription.getProperties()
                 .get("radiologyOrder")
                 .getRep(),
@@ -122,7 +123,7 @@ public class RadiologyReportResourceTest {
                 radiologyReportResource.getRepresentationDescription(fullRepresentation);
         assertThat(resourceDescription.getProperties()
                 .keySet(),
-            contains("uuid", "radiologyOrder", "date", "principalResultsInterpreter", "status", "body", "display",
+            contains("uuid", "radiologyOrder", "date", "principalResultsInterpreter", "status", "body", "display", "voided",
                 "auditInfo"));
         assertThat(resourceDescription.getProperties()
                 .get("radiologyOrder")

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerComponentTest.java
@@ -48,7 +48,7 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
     
     protected static final String TEST_DATASET = "RadiologyReportSearchHandlerComponentTestDataset.xml";
     
-    private static final String RADIOLOGY_REPORT_UUID_OF_DISCONTINUED = "90765170-473f-11e6-beb8-9e71128cae77";
+    private static final String RADIOLOGY_REPORT_UUID_OF_VOIDED = "90765170-473f-11e6-beb8-9e71128cae77";
     
     private static final String DATE_AFTER_REPORT_DATES = "2016-07-02";
     
@@ -120,7 +120,7 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
     
     /**
      * @see RadiologyReportSearchHandler#search(RequestContext)
-     * @verifies return all radiology reports (including discontinued) matching the search query if include all is set
+     * @verifies return all radiology reports (including voided) matching the search query if include all is set
      */
     @Test
     public void search_shouldReturnAllRadiologyReportsIncludingDiscontinuedMatchingTheSearchQueryIfIncludeAllIsSet()
@@ -137,8 +137,8 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
         assertNotNull(result);
         List<Object> hits = (List<Object>) result.get("results");
         assertThat(hits.size(), is(3));
-        assertThat(PropertyUtils.getProperty(hits.get(2), "uuid"), is(RADIOLOGY_REPORT_UUID_OF_DISCONTINUED));
-        assertThat(PropertyUtils.getProperty(hits.get(2), "status"), is(RadiologyReportStatus.DISCONTINUED.toString()));
+        assertThat(PropertyUtils.getProperty(hits.get(2), "uuid"), is(RADIOLOGY_REPORT_UUID_OF_VOIDED));
+        assertThat(PropertyUtils.getProperty(hits.get(2), "voided"), is(true));
     }
     
     /**
@@ -168,7 +168,7 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
             is(resultFormat.format(radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria)
                     .get(0)
                     .getDate())));
-        assertThat(PropertyUtils.getProperty(hits.get(0), "status"), is(not(RadiologyReportStatus.DISCONTINUED.toString())));
+        assertThat(PropertyUtils.getProperty(hits.get(0), "voided"), is(false));
     }
     
     /**
@@ -198,7 +198,7 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
             is(resultFormat.format(radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria)
                     .get(0)
                     .getDate())));
-        assertThat(PropertyUtils.getProperty(hits.get(0), "status"), is(not(RadiologyReportStatus.DISCONTINUED.toString())));
+        assertThat(PropertyUtils.getProperty(hits.get(0), "voided"), is(false));
     }
     
     /**
@@ -232,8 +232,8 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
                 .getDate())));
         assertThat(PropertyUtils.getProperty(hits.get(1), "date"), is(resultFormat.format(radiologyReports.get(1)
                 .getDate())));
-        assertThat(PropertyUtils.getProperty(hits.get(0), "status"), is(not(RadiologyReportStatus.DISCONTINUED.toString())));
-        assertThat(PropertyUtils.getProperty(hits.get(1), "status"), is(not(RadiologyReportStatus.DISCONTINUED.toString())));
+        assertThat(PropertyUtils.getProperty(hits.get(0), "voided"), is(false));
+        assertThat(PropertyUtils.getProperty(hits.get(1), "voided"), is(false));
     }
     
     /**
@@ -270,8 +270,8 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
         assertNotNull(result);
         List<Object> hits = (List<Object>) result.get("results");
         assertThat(hits.size(), is(2));
-        assertThat(PropertyUtils.getProperty(hits.get(0), "status"), is(not(RadiologyReportStatus.DISCONTINUED.toString())));
-        assertThat(PropertyUtils.getProperty(hits.get(1), "status"), is(not(RadiologyReportStatus.DISCONTINUED.toString())));
+        assertThat(PropertyUtils.getProperty(hits.get(0), "voided"), is(false));
+        assertThat(PropertyUtils.getProperty(hits.get(1), "voided"), is(false));
     }
     
     /**

--- a/omod/src/test/resources/RadiologyReportResourceComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyReportResourceComponentTestDataset.xml
@@ -51,5 +51,5 @@
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
-  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810"/>
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" voided="false" uuid="82d3fb80-e403-4b9b-982c-22161ec29810"/>
 </dataset>

--- a/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
+++ b/omod/src/test/resources/RadiologyReportSearchHandlerComponentTestDataset.xml
@@ -52,19 +52,19 @@
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
-  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-30"/>
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" voided="false" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-30"/>
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="2" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:18:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:18:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79656"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:18:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5ca"/>
-  <radiology_report report_id="3" order_id="2008" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" uuid="82d3fb80-e403-4b9b-982c-22161ec29811" report_date="2016-06-01"/>
+  <radiology_report report_id="3" order_id="2008" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" voided="false" uuid="82d3fb80-e403-4b9b-982c-22161ec29811" report_date="2016-06-01"/>
 
   <!-- radiology order with associated study and a discontinued report -->
   <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="3" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
   <test_order order_id="2009" />
   <radiology_order order_id="2009" />
   <radiology_study study_id="7" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.7" order_id="2009" performed_status="COMPLETED" creator="1" date_created="2016-07-01 13:17:15.0" uuid="7ffd5b5e-473f-11e6-beb8-9e71128cae77"/>
-  <radiology_report report_id="4" order_id="2009" report_status="DISCONTINUED" principal_results_interpreter="1" creator="1" date_created="2016-07-01 13:17:15.0" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
+  <radiology_report report_id="4" order_id="2009" report_status="CLAIMED" principal_results_interpreter="1" creator="1" date_created="2016-07-01 13:17:15.0" voided="true" date_voided="2016-07-02 10:13:47.0" voided_by="1"  void_reason="wrong order selected" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
 </dataset>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
* rename unclaimRadiologyReport to voidRadiologyReport
* add liquibase changeset
* adapt hibernate mapping file
* adapt xml test datasets and demo-data.sql
* add messages properties entries and use them in APIException
* add try/catch to controller of voidRadiologyReport
* create tests of controller for redirect/not redirect and session attribute
* remove radiology report status DISCONTINUED, thus from service/dao/rest layers
* remove unused getRadiologyReportsByRadiologyOrderAndRadiologyReportStatus
* adapt SearchCriteria
* adapt REST
* add voided property to RadiologyReportResource
* adapt UI report list filter
* add voidReason to radiologyReportForm and handle its validity in controller
* add VoidRadiologyReportRequest with Validator to ensure voidReason isnt empty
* exclude voided reports hasRadiologyOrderClaimedReport

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-355

