### PR TITLE
Rename completeRadiologyReport to saveRadiologyReport

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportService.java
@@ -11,7 +11,6 @@ package org.openmrs.module.radiology.report;
 
 import java.util.List;
 
-import org.openmrs.Provider;
 import org.openmrs.annotation.Authorized;
 import org.openmrs.api.APIException;
 import org.openmrs.api.OpenmrsService;
@@ -31,7 +30,7 @@ import org.openmrs.module.radiology.order.RadiologyOrder;
  * <li>Set fields like for example {@code radiologyReport.setBody("Fracture of around 5mm visible in right tibia.")} through the setters of {@link RadiologyReport}.</li>
  * <li>Optionally, save the {@code RadiologyReport} as a draft via {@link #saveRadiologyReportDraft(RadiologyReport)}.</li>
  * <li>Optionally, void the {@code RadiologyReport} via {@link #voidRadiologyReport(RadiologyReport, String)}.</li>
- * <li>Finally, complete the {@code RadiologyReport} via {@link #completeRadiologyReport(RadiologyReport, Provider)}.</li>
+ * <li>Finally, complete the {@code RadiologyReport} via {@link #saveRadiologyReport(RadiologyReport)}.</li>
  * </ol>
  *
  * @see org.openmrs.module.radiology.report.RadiologyReport
@@ -99,29 +98,27 @@ public interface RadiologyReportService extends OpenmrsService {
     public RadiologyReport voidRadiologyReport(RadiologyReport radiologyReport, String voidReason);
     
     /**
-     * Completes a {@code radiologyReport} and and sets its status to completed.
+     * Saves an existing {@code RadiologyReport} and and sets its status to completed.
      *
-     * @param radiologyReport the radiology report to be completed
-     * @param principalResultsInterpreter the provider which completed the radiology report
-     * @return the completed radiology report
-     *         principalResultsInterpreter
+     * @param radiologyReport the radiology report to be saved and completed
+     * @return the saved radiology report
      * @throws IllegalArgumentException if radiologyReport is null
      * @throws IllegalArgumentException if radiologyReport reportId is null
      * @throws IllegalArgumentException if radiologyReport status is null
-     * @throws IllegalArgumentException if principalResultsInterpreter is null
      * @throws APIException if radiologyReport is completed
      * @throws APIException if radiologyReport is voided
+     * @throws APIException if radiologyReport is not valid
      * @should set the report date of the radiology report to the day the radiology report was completed
      * @should set the radiology report status to complete
      * @should throw illegal argument exception if given radiology report is null
      * @should throw illegal argument exception if given radiology report with reportId null
      * @should throw illegal argument exception if given radiology report with status null
-     * @should throw illegal argument exception if given principal results interpreter is null
      * @should throw api exception if radiology report is completed
      * @should throw api exception if radiology report is voided
+     * @should throw api exception if radiology report is not valid
      */
     @Authorized(RadiologyPrivileges.EDIT_RADIOLOGY_REPORTS)
-    public RadiologyReport completeRadiologyReport(RadiologyReport radiologyReport, Provider principalResultsInterpreter);
+    public RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport);
     
     /**
      * Get the {@code RadiologyReport} by its {@code reportId}.

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportServiceImpl.java
@@ -15,7 +15,6 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.openmrs.Provider;
 import org.openmrs.api.APIException;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.radiology.order.RadiologyOrder;
@@ -104,21 +103,17 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      */
     @Override
     @Transactional
-    public synchronized RadiologyReport completeRadiologyReport(RadiologyReport radiologyReport,
-            Provider principalResultsInterpreter) {
+    public synchronized RadiologyReport saveRadiologyReport(RadiologyReport radiologyReport) {
         
         if (radiologyReport == null) {
             throw new IllegalArgumentException("radiologyReport cannot be null");
         }
         if (radiologyReport.getReportId() == null) {
             throw new IllegalArgumentException("radiologyReport.reportId cannot be null");
-        }
-        if (principalResultsInterpreter == null) {
-            throw new IllegalArgumentException("principalResultsInterpreter cannot be null");
         }
         if (radiologyReport.getStatus() == null) {
             throw new IllegalArgumentException("radiologyReport.status cannot be null");
@@ -130,7 +125,6 @@ class RadiologyReportServiceImpl extends BaseOpenmrsService implements Radiology
             throw new APIException("radiology.RadiologyReport.cannot.complete.voided");
         }
         radiologyReport.setDate(new Date());
-        radiologyReport.setPrincipalResultsInterpreter(principalResultsInterpreter);
         radiologyReport.setStatus(RadiologyReportStatus.COMPLETED);
         return radiologyReportDAO.saveRadiologyReport(radiologyReport);
     }

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportValidator.java
@@ -11,6 +11,7 @@ package org.openmrs.module.radiology.report;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.openmrs.annotation.Handler;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
@@ -20,6 +21,7 @@ import org.springframework.validation.Validator;
  * Validates {@link RadiologyReport}.
  */
 @Component
+@Handler(supports = { RadiologyReport.class })
 public class RadiologyReportValidator implements Validator {
     
     

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -373,58 +373,54 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      * @verifies set the report date of the radiology report to the day the radiology report was completed
      */
     @Test
-    public void completeRadiologyReport_shouldSetTheReportDateOfTheRadiologyReportToTheDayTheRadiologyReportWasCompleted()
+    public void saveRadiologyReport_shouldSetTheReportDateOfTheRadiologyReportToTheDayTheRadiologyReportWasCompleted()
             throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
         
-        RadiologyReport completedRadiologyReport = radiologyReportService.completeRadiologyReport(radiologyReport,
-            radiologyReport.getPrincipalResultsInterpreter());
+        RadiologyReport completedRadiologyReport = radiologyReportService.saveRadiologyReport(radiologyReport);
         
         assertNotNull(completedRadiologyReport);
         assertNotNull(completedRadiologyReport.getDate());
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      * @verifies set the radiology report status to complete
      */
     @Test
-    public void completeRadiologyReport_shouldSetTheRadiologyReportStatusToComplete() throws Exception {
+    public void saveRadiologyReport_shouldSetTheRadiologyReportStatusToComplete() throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
         
-        RadiologyReport completedRadiologyReport = radiologyReportService.completeRadiologyReport(radiologyReport,
-            radiologyReport.getPrincipalResultsInterpreter());
+        RadiologyReport completedRadiologyReport = radiologyReportService.saveRadiologyReport(radiologyReport);
         
         assertNotNull(completedRadiologyReport);
         assertThat(completedRadiologyReport.getStatus(), is(RadiologyReportStatus.COMPLETED));
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      * @verifies throw illegal argument exception if given radiology report is null
      */
     @Test
-    public void completeRadiologyReport_shouldThrowIllegalArgumentExceptionIfGivenRadiologyReportIsNull() throws Exception {
-        
-        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
+    public void saveRadiologyReport_shouldThrowIllegalArgumentExceptionIfGivenRadiologyReportIsNull() throws Exception {
         
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyReport cannot be null");
-        radiologyReportService.completeRadiologyReport(null, radiologyReport.getPrincipalResultsInterpreter());
+        radiologyReportService.saveRadiologyReport(null);
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      * @verifies throw illegal argument exception if given radiology report with reportId null
      */
     @Test
-    public void completeRadiologyReport_shouldThrowIllegalArgumentExceptionIfGivenRadiologyReportWithReportIdNull()
+    public void saveRadiologyReport_shouldThrowIllegalArgumentExceptionIfGivenRadiologyReportWithReportIdNull()
             throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
@@ -432,15 +428,15 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyReport.reportId cannot be null");
-        radiologyReportService.completeRadiologyReport(radiologyReport, radiologyReport.getPrincipalResultsInterpreter());
+        radiologyReportService.saveRadiologyReport(radiologyReport);
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      * @verifies throw illegal argument exception if given radiology report with status null
      */
     @Test
-    public void completeRadiologyReport_shouldThrowIllegalArgumentExceptionIfGivenRadiologyReportWithStatusNull()
+    public void saveRadiologyReport_shouldThrowIllegalArgumentExceptionIfGivenRadiologyReportWithStatusNull()
             throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
@@ -448,51 +444,57 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("radiologyReport.status cannot be null");
-        radiologyReportService.completeRadiologyReport(radiologyReport, radiologyReport.getPrincipalResultsInterpreter());
+        radiologyReportService.saveRadiologyReport(radiologyReport);
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
-     * @verifies throw illegal argument exception if given principal results interpreter is null
-     */
-    @Test
-    public void completeRadiologyReport_shouldThrowIllegalArgumentExceptionIfGivenPrincipalResultsInterpreterIsNull()
-            throws Exception {
-        
-        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
-        radiologyReport.setPrincipalResultsInterpreter(null);
-        
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("principalResultsInterpreter cannot be null");
-        radiologyReportService.completeRadiologyReport(radiologyReport, null);
-    }
-    
-    /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      * @verifies throw api exception if radiology report is completed
      */
     @Test
-    public void completeRadiologyReport_shouldThrowAPIExceptionIfRadiologyReportIsCompleted() throws Exception {
+    public void saveRadiologyReport_shouldThrowAPIExceptionIfRadiologyReportIsCompleted() throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(COMPLETED_RADIOLOGY_REPORT);
         
         expectedException.expect(APIException.class);
         expectedException.expectMessage("radiology.RadiologyReport.cannot.complete.completed");
-        radiologyReportService.completeRadiologyReport(radiologyReport, radiologyReport.getPrincipalResultsInterpreter());
+        radiologyReportService.saveRadiologyReport(radiologyReport);
     }
     
     /**
-     * @see RadiologyReportService#completeRadiologyReport(RadiologyReport, Provider)
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
      * @verifies throw api exception if radiology report is voided
      */
     @Test
-    public void completeRadiologyReport_shouldThrowAPIExceptionIfRadiologyReportIsVoided() throws Exception {
+    public void saveRadiologyReport_shouldThrowAPIExceptionIfRadiologyReportIsVoided() throws Exception {
         
         RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(VOIDED_RADIOLOGY_REPORT);
         
         expectedException.expect(APIException.class);
         expectedException.expectMessage("radiology.RadiologyReport.cannot.complete.voided");
-        radiologyReportService.completeRadiologyReport(radiologyReport, radiologyReport.getPrincipalResultsInterpreter());
+        radiologyReportService.saveRadiologyReport(radiologyReport);
+    }
+    
+    /**
+     * @see RadiologyReportService#saveRadiologyReport(RadiologyReport)
+     * @verifies throw api exception if radiology report is not valid
+     */
+    @Test
+    public void saveRadiologyReport_shouldThrowAPIExceptionIfRadiologyReportIsNotValid() throws Exception {
+        
+        RadiologyReport radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
+        radiologyReport.setPrincipalResultsInterpreter(null);
+        
+        expectedException.expect(APIException.class);
+        expectedException.expectMessage("failed to validate with reason:");
+        radiologyReportService.saveRadiologyReport(radiologyReport);
+        
+        radiologyReport = radiologyReportService.getRadiologyReport(DRAFT_RADIOLOGY_REPORT);
+        radiologyReport.setBody(null);
+        
+        expectedException.expect(APIException.class);
+        expectedException.expectMessage("failed to validate with reason:");
+        radiologyReportService.saveRadiologyReport(radiologyReport);
     }
     
     /**

--- a/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
+++ b/api/src/test/resources/org/openmrs/module/radiology/include/RadiologyReportServiceComponentTestDataset.xml
@@ -74,26 +74,26 @@
   <test_order order_id="2006" />
   <radiology_order order_id="2006" />
   <radiology_study study_id="4" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.4" order_id="2006" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="58855a84-3c39-42d8-8d33-6c3f228c0936"/>
-  <radiology_report report_id="1" order_id="2006" report_status="DRAFT" principal_results_interpreter="1" creator="1" date_created="2015-02-15 13:17:15.0" voided="false" uuid="e699d90d-e230-4762-8747-d2d0059394b0" report_date="2016-05-28" />
+  <radiology_report report_id="1" order_id="2006" report_status="DRAFT" principal_results_interpreter="1" report_body="some diagnosis" creator="1" date_created="2015-02-15 13:17:15.0" voided="false" uuid="e699d90d-e230-4762-8747-d2d0059394b0" report_date="2016-05-28" />
 
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2007" order_number="2007" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="5" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="ed994ec5-4a6a-4c77-96a2-59fcfab79655"/>
   <test_order order_id="2007" />
   <radiology_order order_id="2007" />
   <radiology_study study_id="5" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.5" order_id="2007" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="486f9e2b-844c-4f3b-8fcf-9a543414a5cf"/>
-  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2015-02-14 09:25:16.0" voided="false" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
+  <radiology_report report_id="2" order_id="2007" report_status="COMPLETED" principal_results_interpreter="1" report_body="some diagnosis" creator="1" date_created="2015-02-14 09:25:16.0" voided="false" uuid="82d3fb80-e403-4b9b-982c-22161ec29810" report_date="2016-06-02" />
 
   <!-- radiology order with associated study and a discontinued report -->
   <orders order_id="2008" order_number="2008" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="6" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2015-02-03 13:17:15.0" auto_expire_date="2015-02-14 00:00:00.0" creator="1" date_created="2015-02-03 13:17:15.0" voided="false" patient_id="70022" uuid="7ed51f0e-5351-4849-9ec3-9e87e18259c5"/>
   <test_order order_id="2008" />
   <radiology_order order_id="2008" />
   <radiology_study study_id="6" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.6" order_id="2008" performed_status="COMPLETED" creator="1" date_created="2015-02-03 13:17:15.0" uuid="eb6dc805-e79f-4ca2-945b-5e9bdd9491c6"/>
-  <radiology_report report_id="3" order_id="2008" report_status="DRAFT" principal_results_interpreter="1" creator="1" date_created="2015-02-07 18:20:12.0" voided="true" date_voided="2015-02-07 21:13:47.0" voided_by="1" void_reason="selected wrong order" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
+  <radiology_report report_id="3" order_id="2008" report_status="DRAFT" principal_results_interpreter="1" report_body="some diagnosis" creator="1" date_created="2015-02-07 18:20:12.0" voided="true" date_voided="2015-02-07 21:13:47.0" voided_by="1" void_reason="selected wrong order" uuid="7b2b9619-a6b2-4fb7-bf6b-fc7917d6dd59" report_date="2016-07-01"/>
   
   <!-- radiology order with associated study and a completed report -->
   <orders order_id="2009" order_number="2009" order_type_id="5" order_action="NEW" care_setting="1" encounter_id="2004" urgency="ROUTINE" orderer="1" concept_id="178" accession_number="7" instructions="CT ABDOMEN PANCREAS WITH IV CONTRAST" date_activated="2016-07-01 13:17:15.0" auto_expire_date="2016-07-20 00:00:00.0" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" patient_id="70022" uuid="71b92000-473f-11e6-beb8-9e71128cae77"/>
   <test_order order_id="2009" />
   <radiology_order order_id="2009" />
   <radiology_study study_id="7" study_instance_uid="1.2.826.0.1.3680043.8.2186.1.7" order_id="2009" performed_status="COMPLETED" creator="1" date_created="2016-07-01 13:17:15.0" uuid="7ffd5b5e-473f-11e6-beb8-9e71128cae77"/>
-  <radiology_report report_id="4" order_id="2009" report_status="COMPLETED" principal_results_interpreter="1" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
+  <radiology_report report_id="4" order_id="2009" report_status="COMPLETED" principal_results_interpreter="1" report_body="some diagnosis" creator="1" date_created="2016-07-01 13:17:15.0" voided="false" uuid="90765170-473f-11e6-beb8-9e71128cae77" report_date="2016-07-01"/>
 </dataset>

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/RadiologyReportFormController.java
@@ -31,8 +31,6 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
-import static org.openmrs.module.radiology.order.web.RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_REQUEST_MAPPING;
-
 /**
  * Controller for the form handling entry, display, saving, unclaiming of {@code RadiologyReport's}.
  */
@@ -205,8 +203,7 @@ public class RadiologyReportFormController {
         }
         
         try {
-            radiologyReportService.completeRadiologyReport(radiologyReport,
-                radiologyReport.getPrincipalResultsInterpreter());
+            radiologyReportService.saveRadiologyReport(radiologyReport);
             request.getSession()
                     .setAttribute(WebConstants.OPENMRS_MSG_ATTR, "radiology.RadiologyReport.completed");
             modelAndView.setViewName(

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/RadiologyReportFormControllerTest.java
@@ -363,8 +363,7 @@ public class RadiologyReportFormControllerTest extends BaseContextMockTest {
         mockCompletedRadiologyReport.setStatus(RadiologyReportStatus.COMPLETED);
         BindingResult reportErrors = mock(BindingResult.class);
         
-        when(radiologyReportService.completeRadiologyReport(mockRadiologyReport,
-            mockRadiologyReport.getPrincipalResultsInterpreter())).thenReturn(mockCompletedRadiologyReport);
+        when(radiologyReportService.saveRadiologyReport(mockRadiologyReport)).thenReturn(mockCompletedRadiologyReport);
         
         MockHttpServletRequest mockRequest = new MockHttpServletRequest();
         mockRequest.addParameter("completeRadiologyReport", "completeRadiologyReport");
@@ -462,9 +461,8 @@ public class RadiologyReportFormControllerTest extends BaseContextMockTest {
         when(dicomWebViewer.getDicomViewerUrl(mockRadiologyReport.getRadiologyOrder()
                 .getStudy())).thenReturn(
                     "http://localhost:8081/weasis-pacs-connector/viewer?studyUID=1.2.826.0.1.3680043.8.2186.1.1");
-        when(radiologyReportService.completeRadiologyReport(mockRadiologyReport,
-            mockRadiologyReport.getPrincipalResultsInterpreter()))
-                    .thenThrow(new APIException("RadiologyReport.cannot.complete.reported"));
+        when(radiologyReportService.saveRadiologyReport(mockRadiologyReport))
+                .thenThrow(new APIException("RadiologyReport.cannot.complete.reported"));
         
         ModelAndView modelAndView =
                 radiologyReportFormController.completeRadiologyReport(mockRequest, mockRadiologyReport, reportErrors);


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
* add Handler annotation to RadiologyReportValidator so AOP kicks in on
saveRadiologyReport
* add test for it
* adapt test dataset since report_body cannot be null
* since now RadiologyReport is ensured to be valid according to our Validator (via
AOP), we dont need param principalResultsInterpreter anymore. delete it

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-353


