### PR TITLE
Rename date methods in SearchCriteriaBuilders

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/order/RadiologyOrderSearchCriteria.java
@@ -16,7 +16,17 @@ import org.openmrs.Patient;
 import org.openmrs.Provider;
 
 /**
- * The search parameter object for {@code RadiologyOrder's}.
+ * Search parameter object for {@link RadiologyOrder}'s.
+ *
+ * <p>Typical usage involves:
+ * <ol>
+ * <li>Set the various search criteria parameters through the respective methods of the static builder class
+ * ({@link Builder#withPatient(Patient)}, {@link Builder#includeVoided()}, {@link Builder#withUrgency(Urgency)}, 
+ * {@link Builder#fromEffectiveStartDate(Date)}, {@link Builder#toEffectiveStartDate(Date)},
+ * {@link Builder#withAccessionNumber(String)} and {@link Builder#withOrderer(Provider)}).</li>
+ * <li>Build the {@link RadiolologyOrderSearchCriteria} instance with the {@link Builder#build()} method.</li>
+ * <li>Get the search parameters through the getter methods (such as {@link #getPatient()} or {@link #getUrgency()}).</li>
+ * </ol>
  */
 public class RadiologyOrderSearchCriteria {
     
@@ -143,7 +153,7 @@ public class RadiologyOrderSearchCriteria {
          * @param fromEffectiveStartDate the minimum effective start date
          * @return this builder instance
          */
-        public Builder withFromEffectiveStartDate(Date fromEffectiveStartDate) {
+        public Builder fromEffectiveStartDate(Date fromEffectiveStartDate) {
             
             this.fromEffectiveStartDate = fromEffectiveStartDate;
             return this;
@@ -153,7 +163,7 @@ public class RadiologyOrderSearchCriteria {
          * @param toEffectiveStartDate the maximum effective start date
          * @return this builder instance
          */
-        public Builder withToEffectiveStartDate(Date toEffectiveStartDate) {
+        public Builder toEffectiveStartDate(Date toEffectiveStartDate) {
             
             this.toEffectiveStartDate = toEffectiveStartDate;
             return this;

--- a/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteria.java
@@ -14,7 +14,16 @@ import java.util.Date;
 import org.openmrs.Provider;
 
 /**
- * The search parameter object for {@code RadiologyReport's}.
+ * Search parameter object for {@link RadiologyReport}'s.
+ *
+ * <p>Typical usage involves:
+ * <ol>
+ * <li>Set the various search criteria parameters through the respective methods of the static builder class
+ * ({@link Builder#fromDate(Date)}, {@link Builder#toDate(Date)}, {@link Builder#withPrincipalResultsInterpreter(Provider)}, 
+ * {@link Builder#includeVoided()} and {@link Builder#withStatus(RadiologyReportStatus)}).</li>
+ * <li>Build the {@link RadiolologyReportSearchCriteria} instance with the {@link Builder#build()} method.</li>
+ * <li>Get the search parameters through the getter methods (such as {@link #getFromDate()} or {@link #getStatus()}).</li>
+ * </ol>
  */
 public class RadiologyReportSearchCriteria {
     
@@ -86,7 +95,7 @@ public class RadiologyReportSearchCriteria {
          * @param fromDate the minimum date (inclusive) the report date
          * @return this builder instance
          */
-        public Builder withFromDate(Date fromDate) {
+        public Builder fromDate(Date fromDate) {
             
             this.fromDate = fromDate;
             return this;
@@ -96,7 +105,7 @@ public class RadiologyReportSearchCriteria {
          * @param toDate the maximum date (inclusive) the report date
          * @return this builder instance
          */
-        public Builder withToDate(Date toDate) {
+        public Builder toDate(Date toDate) {
             
             this.toDate = toDate;
             return this;

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderSearchCriteriaTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderSearchCriteriaTest.java
@@ -105,7 +105,7 @@ public class RadiologyOrderSearchCriteriaTest {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date fromEffectiveStartDate = format.parse("2016-05-01");
         radiologyOrderSearchCriteria =
-                new RadiologyOrderSearchCriteria.Builder().withFromEffectiveStartDate(fromEffectiveStartDate)
+                new RadiologyOrderSearchCriteria.Builder().fromEffectiveStartDate(fromEffectiveStartDate)
                         .build();
         
         assertThat(radiologyOrderSearchCriteria.getFromEffectiveStartDate(), is(fromEffectiveStartDate));
@@ -127,9 +127,8 @@ public class RadiologyOrderSearchCriteriaTest {
         
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date toEffectiveStartDate = format.parse("2016-05-01");
-        radiologyOrderSearchCriteria =
-                new RadiologyOrderSearchCriteria.Builder().withToEffectiveStartDate(toEffectiveStartDate)
-                        .build();
+        radiologyOrderSearchCriteria = new RadiologyOrderSearchCriteria.Builder().toEffectiveStartDate(toEffectiveStartDate)
+                .build();
         
         assertThat(radiologyOrderSearchCriteria.getToEffectiveStartDate(), is(toEffectiveStartDate));
         assertNull(radiologyOrderSearchCriteria.getPatient());

--- a/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/order/RadiologyOrderServiceComponentTest.java
@@ -621,8 +621,8 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteriaDateRange =
                 new RadiologyOrderSearchCriteria.Builder().includeVoided()
                         .withPatient(patient)
-                        .withFromEffectiveStartDate(fromDate)
-                        .withToEffectiveStartDate(toDate)
+                        .fromEffectiveStartDate(fromDate)
+                        .toEffectiveStartDate(toDate)
                         .build();
         List<RadiologyOrder> radiologyOrders =
                 radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteriaDateRange);
@@ -663,7 +663,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteriaDateRange =
                 new RadiologyOrderSearchCriteria.Builder().includeVoided()
                         .withPatient(patient)
-                        .withFromEffectiveStartDate(fromDate)
+                        .fromEffectiveStartDate(fromDate)
                         .build();
         List<RadiologyOrder> radiologyOrders =
                 radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteriaDateRange);
@@ -703,7 +703,7 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteriaDateRange =
                 new RadiologyOrderSearchCriteria.Builder().includeVoided()
                         .withPatient(patient)
-                        .withToEffectiveStartDate(toDate)
+                        .toEffectiveStartDate(toDate)
                         .build();
         List<RadiologyOrder> radiologyOrders =
                 radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteriaDateRange);
@@ -736,8 +736,8 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
         Date fromDate = format.parse("2016-06-30");
         Date toDate = format.parse("2016-05-29");
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteria =
-                new RadiologyOrderSearchCriteria.Builder().withFromEffectiveStartDate(fromDate)
-                        .withToEffectiveStartDate(toDate)
+                new RadiologyOrderSearchCriteria.Builder().fromEffectiveStartDate(fromDate)
+                        .toEffectiveStartDate(toDate)
                         .build();
         
         List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteria);
@@ -752,8 +752,8 @@ public class RadiologyOrderServiceComponentTest extends BaseModuleContextSensiti
     public void getRadiologyOrders_shouldReturnEmptySearchResultIfNoEffectiveOrderStartIsInDateRange() throws Exception {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteriaDateRange =
-                new RadiologyOrderSearchCriteria.Builder().withFromEffectiveStartDate(format.parse("2016-06-06"))
-                        .withToEffectiveStartDate(format.parse("2016-07-07"))
+                new RadiologyOrderSearchCriteria.Builder().fromEffectiveStartDate(format.parse("2016-06-06"))
+                        .toEffectiveStartDate(format.parse("2016-07-07"))
                         .build();
         
         List<RadiologyOrder> radiologyOrdersWithDateRange =

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteriaTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportSearchCriteriaTest.java
@@ -42,8 +42,8 @@ public class RadiologyReportSearchCriteriaTest {
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date fromDate = format.parse("2016-05-01");
         Date toDate = format.parse("2016-05-01");
-        radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
-                .withToDate(toDate)
+        radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().fromDate(fromDate)
+                .toDate(toDate)
                 .build();
         
         assertTrue(radiologyReportSearchCriteria.getFromDate()

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportServiceComponentTest.java
@@ -732,8 +732,8 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         Date fromDate = format.parse("2016-05-28");
         Date toDate = format.parse("2016-07-01");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
-                        .withToDate(toDate)
+                new RadiologyReportSearchCriteria.Builder().fromDate(fromDate)
+                        .toDate(toDate)
                         .build();
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
@@ -759,7 +759,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date fromDate = format.parse("2016-05-29");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
+                new RadiologyReportSearchCriteria.Builder().fromDate(fromDate)
                         .build();
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
@@ -783,7 +783,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         Date toDate = format.parse("2016-06-30");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withToDate(toDate)
+                new RadiologyReportSearchCriteria.Builder().toDate(toDate)
                         .build();
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
@@ -806,8 +806,8 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         Date fromDate = format.parse("2016-06-30");
         Date toDate = format.parse("2016-05-29");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
-                        .withToDate(toDate)
+                new RadiologyReportSearchCriteria.Builder().fromDate(fromDate)
+                        .toDate(toDate)
                         .build();
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
@@ -823,8 +823,8 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         RadiologyReportSearchCriteria radiologyReportSearchCriteriaDateRange =
-                new RadiologyReportSearchCriteria.Builder().withFromDate(format.parse("2016-04-25"))
-                        .withToDate(format.parse("2016-05-27"))
+                new RadiologyReportSearchCriteria.Builder().fromDate(format.parse("2016-04-25"))
+                        .toDate(format.parse("2016-05-27"))
                         .build();
         
         List<RadiologyReport> radiologyReportsWithDateRange =
@@ -910,7 +910,7 @@ public class RadiologyReportServiceComponentTest extends BaseModuleContextSensit
         
         DateFormat format = new SimpleDateFormat("yyyy-MM-dd");
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withToDate(format.parse("2016-05-01"))
+                new RadiologyReportSearchCriteria.Builder().toDate(format.parse("2016-05-01"))
                         .withStatus(RadiologyReportStatus.DRAFT)
                         .build();
         

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandler.java
@@ -133,8 +133,8 @@ public class RadiologyOrderSearchHandler implements SearchHandler {
         final RadiologyOrderSearchCriteria radiologyOrderSearchCriteria =
                 new RadiologyOrderSearchCriteria.Builder().withAccessionNumber(accessionNumber)
                         .withPatient(patient)
-                        .withFromEffectiveStartDate(fromEffectiveStartDate)
-                        .withToEffectiveStartDate(toEffectiveStartDate)
+                        .fromEffectiveStartDate(fromEffectiveStartDate)
+                        .toEffectiveStartDate(toEffectiveStartDate)
                         .withUrgency(urgency)
                         .build();
         

--- a/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandler.java
@@ -127,21 +127,16 @@ public class RadiologyReportSearchHandler implements SearchHandler {
             status = RadiologyReportStatus.valueOf(statusString);
         }
         
-        RadiologyReportSearchCriteria radiologyReportSearchCriteria;
+        RadiologyReportSearchCriteria.Builder radiologyReportSearchCriteriaBuilder =
+                new RadiologyReportSearchCriteria.Builder();
         if (context.getIncludeAll()) {
-            radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
-                    .withToDate(toDate)
-                    .withPrincipalResultsInterpreter(principalResultsInterpreter)
-                    .includeVoided()
-                    .withStatus(status)
-                    .build();
-        } else {
-            radiologyReportSearchCriteria = new RadiologyReportSearchCriteria.Builder().withFromDate(fromDate)
-                    .withToDate(toDate)
-                    .withPrincipalResultsInterpreter(principalResultsInterpreter)
-                    .withStatus(status)
-                    .build();
+            radiologyReportSearchCriteriaBuilder.includeVoided();
         }
+        RadiologyReportSearchCriteria radiologyReportSearchCriteria = radiologyReportSearchCriteriaBuilder.fromDate(fromDate)
+                .toDate(toDate)
+                .withPrincipalResultsInterpreter(principalResultsInterpreter)
+                .withStatus(status)
+                .build();
         
         final List<RadiologyReport> result = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);
         

--- a/omod/src/main/webapp/radiologyDashboardReportsTab.jsp
+++ b/omod/src/main/webapp/radiologyDashboardReportsTab.jsp
@@ -75,12 +75,12 @@
                                                     : moment(fromDate.val(),
                                                             "L")
                                                             .format(
-                                                                    "YYYY-MM-DDTHH:mm:ss.SSSZ"),
+                                                                    "YYYY-MM-DD"),
                                             todate: toDate.val() === ""
                                                     ? ""
                                                     : moment(toDate.val(), "L")
                                                             .format(
-                                                                    "YYYY-MM-DDTHH:mm:ss.SSSZ"),
+                                                                    "YYYY-MM-DD"),
                                             principalResultsInterpreter: principalResultsInterpreterUuid
                                                     .val(),
                                             status: status.val(),

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/search/RadiologyOrderSearchHandlerComponentTest.java
@@ -255,7 +255,7 @@ public class RadiologyOrderSearchHandlerComponentTest extends MainResourceContro
         assertNull(PropertyUtils.getProperty(result, "totalCount"));
         
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteria = new RadiologyOrderSearchCriteria.Builder()
-                .withFromEffectiveStartDate(format.parse(DATE_BETWEEN_ORDER_EFFECTIVE_START_DATES))
+                .fromEffectiveStartDate(format.parse(DATE_BETWEEN_ORDER_EFFECTIVE_START_DATES))
                 .build();
         List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteria);
         
@@ -297,7 +297,7 @@ public class RadiologyOrderSearchHandlerComponentTest extends MainResourceContro
         assertNull(PropertyUtils.getProperty(result, "totalCount"));
         
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteria = new RadiologyOrderSearchCriteria.Builder()
-                .withToEffectiveStartDate(format.parse(DATE_BETWEEN_ORDER_EFFECTIVE_START_DATES))
+                .toEffectiveStartDate(format.parse(DATE_BETWEEN_ORDER_EFFECTIVE_START_DATES))
                 .build();
         List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteria);
         
@@ -340,8 +340,8 @@ public class RadiologyOrderSearchHandlerComponentTest extends MainResourceContro
         assertNull(PropertyUtils.getProperty(result, "totalCount"));
         
         RadiologyOrderSearchCriteria radiologyOrderSearchCriteria = new RadiologyOrderSearchCriteria.Builder()
-                .withFromEffectiveStartDate(format.parse(DATE_BEFORE_ORDER_EFFECTIVE_START_DATES))
-                .withToEffectiveStartDate(format.parse(DATE_AFTER_ORDER_EFFECTIVE_START_DATES))
+                .fromEffectiveStartDate(format.parse(DATE_BEFORE_ORDER_EFFECTIVE_START_DATES))
+                .toEffectiveStartDate(format.parse(DATE_AFTER_ORDER_EFFECTIVE_START_DATES))
                 .build();
         List<RadiologyOrder> radiologyOrders = radiologyOrderService.getRadiologyOrders(radiologyOrderSearchCriteria);
         

--- a/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerComponentTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/report/web/search/RadiologyReportSearchHandlerComponentTest.java
@@ -161,7 +161,7 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
         assertNull(PropertyUtils.getProperty(result, "totalCount"));
         
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withFromDate(format.parse(DATE_BETWEEN_REPORT_DATES))
+                new RadiologyReportSearchCriteria.Builder().fromDate(format.parse(DATE_BETWEEN_REPORT_DATES))
                         .build();
         
         assertThat(PropertyUtils.getProperty(hits.get(0), "date"),
@@ -191,7 +191,7 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
         assertNull(PropertyUtils.getProperty(result, "totalCount"));
         
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withToDate(format.parse(DATE_BETWEEN_REPORT_DATES))
+                new RadiologyReportSearchCriteria.Builder().toDate(format.parse(DATE_BETWEEN_REPORT_DATES))
                         .build();
         
         assertThat(PropertyUtils.getProperty(hits.get(0), "date"),
@@ -222,8 +222,8 @@ public class RadiologyReportSearchHandlerComponentTest extends MainResourceContr
         assertNull(PropertyUtils.getProperty(result, "totalCount"));
         
         RadiologyReportSearchCriteria radiologyReportSearchCriteria =
-                new RadiologyReportSearchCriteria.Builder().withFromDate(format.parse(DATE_BEFORE_REPORT_DATES))
-                        .withToDate(format.parse(DATE_AFTER_REPORT_DATES))
+                new RadiologyReportSearchCriteria.Builder().fromDate(format.parse(DATE_BEFORE_REPORT_DATES))
+                        .toDate(format.parse(DATE_AFTER_REPORT_DATES))
                         .build();
         
         List<RadiologyReport> radiologyReports = radiologyReportService.getRadiologyReports(radiologyReportSearchCriteria);


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
* rename withFromEffectiveStartDate to fromEffectiveStartDate,
  withToEffectiveStartDate to toEffectiveStartDate in
  RadiologyOrderSearchCriteria.java
* rename withFromDate to fromDate, withToDate to toDate in
  RadiologyReportSearchCriteria.java
* modify construction of RadiologyReportSearchCriteria
