### PR TITLE
RAD-364 Fix radiology dashboard tab bug

### DIFF
--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardOrdersTabController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyDashboardOrdersTabController.java
@@ -41,8 +41,8 @@ public class RadiologyDashboardOrdersTabController {
      * 
      * @return model and view of the radiology orders tab page
      * @should return model and view of the radiology orders tab page and set tab session attribute to radiology orders tab page if not already set
-     * @should redirect to dashboard tab page given from tab session attribute if change tab is not set
-     * @should not redirect to dashboard tab page given from tab session attribute if change tab is set
+     * @should not redirect to dashboard tab page given from tab session attribute and set tab session attribute to radiology orders tab page if switch tab is set
+     * @should redirect to dashboard tab page given from tab session attribute if switch tab is not set
      */
     @RequestMapping(method = RequestMethod.GET)
     protected ModelAndView getRadiologyOrdersTab(HttpServletRequest request,
@@ -52,12 +52,12 @@ public class RadiologyDashboardOrdersTabController {
         
         String tabLink = (String) request.getSession()
                 .getAttribute(RadiologyWebConstants.RADIOLOGY_DASHBOARD_TAB_SESSION_ATTRIBUTE);
-        if (StringUtils.isBlank(tabLink)) {
+        if (StringUtils.isBlank(tabLink) || StringUtils.isNotBlank(switchTab)) {
             request.getSession()
                     .setAttribute(RadiologyWebConstants.RADIOLOGY_DASHBOARD_TAB_SESSION_ATTRIBUTE,
                         RADIOLOGY_ORDERS_TAB_REQUEST_MAPPING);
         } else {
-            if (!RADIOLOGY_ORDERS_TAB_REQUEST_MAPPING.equals(tabLink) && StringUtils.isBlank(switchTab)) {
+            if (!RADIOLOGY_ORDERS_TAB_REQUEST_MAPPING.equals(tabLink)) {
                 modelAndView.setViewName("redirect:" + tabLink);
             }
         }

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyDashboardOrdersTabControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyDashboardOrdersTabControllerTest.java
@@ -56,10 +56,10 @@ public class RadiologyDashboardOrdersTabControllerTest {
     
     /**
      * @see RadiologyDashboardOrdersTabController#getRadiologyOrdersTab(HttpServletRequest,String)
-     * @verifies redirect to dashboard tab page given from tab session attribute if change tab is not set
+     * @verifies redirect to dashboard tab page given from tab session attribute if switch tab is not set
      */
     @Test
-    public void getRadiologyOrdersTab_shouldRedirectToDashboardTabPageGivenFromTabSessionAttributeIfChangeTabIsNotSet()
+    public void getRadiologyOrdersTab_shouldRedirectToDashboardTabPageGivenFromTabSessionAttributeIfSwitchTabIsNotSet()
             throws Exception {
         
         MockHttpServletRequest mockRequest = new MockHttpServletRequest();
@@ -79,11 +79,12 @@ public class RadiologyDashboardOrdersTabControllerTest {
     
     /**
      * @see RadiologyDashboardOrdersTabController#getRadiologyOrdersTab(HttpServletRequest,String)
-     * @verifies not redirect to dashboard tab page given from tab session attribute if change tab is set
+     * @verifies not redirect to dashboard tab page given from tab session attribute and set tab session attribute to radiology orders tab page if switch tab is set
      */
     @Test
-    public void getRadiologyOrdersTab_shouldNotRedirectToDashboardTabPageGivenFromTabSessionAttributeIfChangeTabIsSet()
-            throws Exception {
+    public void
+            getRadiologyOrdersTab_shouldNotRedirectToDashboardTabPageGivenFromTabSessionAttributeAndSetTabSessionAttributeToRadiologyOrdersTabPageIfSwitchTabIsSet()
+                    throws Exception {
         
         MockHttpServletRequest mockRequest = new MockHttpServletRequest();
         MockHttpSession mockSession = new MockHttpSession();
@@ -96,7 +97,7 @@ public class RadiologyDashboardOrdersTabControllerTest {
         assertNotNull(modelAndView);
         assertThat(modelAndView.getViewName(), is(RadiologyDashboardOrdersTabController.RADIOLOGY_ORDERS_TAB_VIEW));
         assertThat((String) mockSession.getAttribute(RadiologyWebConstants.RADIOLOGY_DASHBOARD_TAB_SESSION_ATTRIBUTE),
-            is(RadiologyDashboardReportsTabController.RADIOLOGY_REPORTS_TAB_REQUEST_MAPPING));
+            is(RadiologyDashboardOrdersTabController.RADIOLOGY_ORDERS_TAB_REQUEST_MAPPING));
     }
     
     /**


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
If orders tab gets selected through tab click and afterwards radiology gutter list link gets clicked
the orders tab controller redirects to previous active tab

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-364