### PR TITLE
RAD-295 Filter coded reason on ordering

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyConstants.java
@@ -63,6 +63,11 @@ public class RadiologyConstants {
     public static final String GP_RADIOLOGY_CONCEPT_CLASSES = "radiology.radiologyConceptClasses";
     
     /**
+     * {@code GlobalProperty} property for the comma separated list of concept class UUIDs which define the reasons for {@code RadiologyOrder's}.
+     */
+    public static final String GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES = "radiology.radiologyOrderReasonConceptClasses";
+    
+    /**
      * {@code GlobalProperty} property for the UUID of the {@code OrderType} which is used when creating a {@code RadiologyOrder}.
      */
     public static final String GP_RADIOLOGY_TEST_ORDER_TYPE = "radiology.radiologyTestOrderType";

--- a/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
+++ b/api/src/main/java/org/openmrs/module/radiology/RadiologyProperties.java
@@ -181,26 +181,31 @@ public class RadiologyProperties {
     }
     
     /**
-     * Gets the Name of the ConceptClass for the UUID from the config
+     * Gets the names of the concept classes for the UUIDs from the config
      *
-     * @return a String that contains the Names of the ConceptClasses seperated by a comma
-     * @should throw illegal state exception if global property radiologyConceptClasses is null
-     * @should throw illegal state exception if global property radiologyConceptClasses is an empty
+     * @return a string that contains the names of the concept classes seperated by a comma
+     * @throws IllegalStateException if global property radiologyConceptClasses is null
+     * @throws IllegalStateException if global property radiologyConceptClasses is an empty string
+     * @throws IllegalStateException if global property radiologyConceptClasses is badly formatted
+     * @throws IllegalStateException if global property radiologyConceptClasses contains a UUID not found among concept
+     *         classes
+     * @should throw illegal state exception if global property radiology concept classes is null
+     * @should throw illegal state exception if global property radiology concept classes is an empty
      *         string
-     * @should throw illegal state exception if global property radiologyConceptClasses is badly
+     * @should throw illegal state exception if global property radiology concept classes is badly
      *         formatted
-     * @should throw illegal state exception if global property radiologyConceptClasses contains a
-     *         UUID not found among ConceptClasses
-     * @should returns comma separated list of ConceptClass names configured via ConceptClass UUIDs
-     *         in global property radiologyConceptClasses
+     * @should throw illegal state exception if global property radiology concept classes contains a
+     *         UUID not found among concept classes
+     * @should return comma separated list of concept class names configured via concept class UUIDs
+     *         in global property radiology concept classes
      */
     public String getRadiologyConceptClassNames() {
         
         String radiologyConceptClassUuidSetting = getGlobalProperty(RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES, true);
         radiologyConceptClassUuidSetting = radiologyConceptClassUuidSetting.replace(" ", "");
         if (!radiologyConceptClassUuidSetting.matches("^[0-9a-fA-f,-]+$")) {
-            throw new IllegalStateException(
-                    "Property radiology.radiologyConcepts needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
+            throw new IllegalStateException("Property " + RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES
+                    + " needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
         }
         
         final String[] radiologyConceptClassUuids = radiologyConceptClassUuidSetting.split(",");
@@ -209,8 +214,61 @@ public class RadiologyProperties {
         for (final String radiologyConceptClassUuid : radiologyConceptClassUuids) {
             final ConceptClass fetchedConceptClass = conceptService.getConceptClassByUuid(radiologyConceptClassUuid);
             if (fetchedConceptClass == null) {
-                throw new IllegalStateException("Property radiology.radiologyConceptClasses contains UUID "
-                        + radiologyConceptClassUuid + " which cannot be found as ConceptClass in the database.");
+                throw new IllegalStateException(
+                        "Property " + RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES + " contains UUID "
+                                + radiologyConceptClassUuid + " which cannot be found as ConceptClass in the database.");
+            }
+            result = result + fetchedConceptClass.getName() + ",";
+        }
+        result = result.substring(0, result.length() - 1);
+        return result;
+    }
+    
+    /**
+     * Gets the names of the concept classes for the UUIDs from the global property radiologyOrderReasonConceptClasses
+     *
+     * @return a string that contains the names of the concept classes for radiology order reason seperated by a comma
+     * @throws IllegalStateException if global property radiologyOrderReasonConceptClasses is badly formatted
+     * @throws IllegalStateException if global property radiologyOrderReasonConceptClasses contains a UUID not found among
+     *         concept classes
+     * @should throw illegal state exception if global property radiology order reason concept classes is badly formatted
+     * @should throw illegal state exception if global property radiology order reason concept classes contains a UUID not
+     *         found among concept classes
+     * @should return the name of the diagnosis concept class if global property radiology order reason concept classes is
+     *         null
+     * @should return the name of the diagnosis concept class if global property radiology order reason concept classes is an
+     *         empty string
+     * @should return an empty string if global property radiology order reason concept classes is null or an empty string
+     *         and no diagnosis concept class is present
+     * @should return comma separated list of concept class names configured via concept class UUIDs in global property
+     *         radiology order reason concept classes
+     */
+    public String getRadiologyOrderReasonConceptClassNames() {
+        
+        String radiologyReasonConceptClassUuidSetting =
+                getGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES, false);
+        if (StringUtils.isBlank(radiologyReasonConceptClassUuidSetting)) {
+            final ConceptClass diagnosisConceptClass = conceptService.getConceptClassByName("Diagnosis");
+            if (diagnosisConceptClass == null) {
+                return "";
+            }
+            return diagnosisConceptClass.getName();
+        }
+        
+        radiologyReasonConceptClassUuidSetting = radiologyReasonConceptClassUuidSetting.replace(" ", "");
+        if (!radiologyReasonConceptClassUuidSetting.matches("^[0-9a-fA-f,-]*$")) {
+            throw new IllegalStateException("Property " + RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES
+                    + " needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
+        }
+        final String[] radiologyReasonConceptClassUuids = radiologyReasonConceptClassUuidSetting.split(",");
+        
+        String result = "";
+        for (final String radiologyReasonConceptClassUuid : radiologyReasonConceptClassUuids) {
+            final ConceptClass fetchedConceptClass = conceptService.getConceptClassByUuid(radiologyReasonConceptClassUuid);
+            if (fetchedConceptClass == null) {
+                throw new IllegalStateException("Property " + RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES
+                        + " contains UUID " + radiologyReasonConceptClassUuid
+                        + " which cannot be found as ConceptClass in the database.");
             }
             result = result + fetchedConceptClass.getName() + ",";
         }

--- a/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/RadiologyPropertiesComponentTest.java
@@ -409,12 +409,12 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     
     /**
      * @see RadiologyProperties#getRadiologyConceptClassNames()
-     * @verifies returns comma separated list of ConceptClass names configured via ConceptClass
-     *           UUIDs in global property radiologyConceptClasses
+     * @verifies return comma separated list of concept class names configured via concept class
+     *           UUIDs in global property radiology concept classes
      */
     @Test
     public void
-            getRadiologyConceptClassNames_shouldReturnsCommaSeparatedListOfConceptClassNamesConfiguredViaConceptClassUUIDsInGlobalPropertyRadiologyConceptClasses()
+            getRadiologyConceptClassNames_shouldReturnCommaSeparatedListOfConceptClassNamesConfiguredViaConceptClassUUIDsInGlobalPropertyRadiologyConceptClasses()
                     throws Exception {
         List<ConceptClass> conceptClasses = new LinkedList<ConceptClass>();
         conceptClasses.add(conceptService.getConceptClassByName("Drug"));
@@ -437,7 +437,7 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     
     /**
      * @see RadiologyProperties#getRadiologyConceptClassNames()
-     * @verifies throw illegal state exception if global property radiologyConceptClasses is null
+     * @verifies throw illegal state exception if global property radiology concept classes is null
      */
     @Test
     public void getRadiologyConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyConceptClassesIsNull()
@@ -452,7 +452,7 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     
     /**
      * @see RadiologyProperties#getRadiologyConceptClassNames()
-     * @verifies throw illegal state exception if global property radiologyConceptClasses is an
+     * @verifies throw illegal state exception if global property radiology concept classes is an
      *           empty String
      */
     @Test
@@ -469,7 +469,7 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     
     /**
      * @see RadiologyProperties#getRadiologyConceptClassNames()
-     * @verifies throw illegal state exception if global property radiologyConceptClasses is badly
+     * @verifies throw illegal state exception if global property radiology concept classes is badly
      *           formatted
      */
     @Test
@@ -480,16 +480,16 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
             "AAAA-bbbbb-1111-2222/AAAA-BBBB-2222-3333");
         
         expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage(
-            "Property radiology.radiologyConcepts needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
+        expectedException.expectMessage("Property " + RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES
+                + " needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
         
         radiologyProperties.getRadiologyConceptClassNames();
     }
     
     /**
      * @see RadiologyProperties#getRadiologyConceptClassNames()
-     * @verifies throw illegal state exception if global property radiologyConceptClasses contains a
-     *           UUID not found among ConceptClasses
+     * @verifies throw illegal state exception if global property radiology concept classes contains a
+     *           UUID not found among concept classes
      */
     @Test
     public void
@@ -501,9 +501,111 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
                     .getUuid() + "5");
         
         expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Property radiology.radiologyConceptClasses contains UUID");
+        expectedException.expectMessage("Property " + RadiologyConstants.GP_RADIOLOGY_CONCEPT_CLASSES + " contains UUID");
         
         radiologyProperties.getRadiologyConceptClassNames();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderReasonConceptClassNames()
+     * @verifies throw illegal state exception if global property radiology order reason concept classes is badly formatted
+     */
+    @Test
+    public void
+            getRadiologyOrderReasonConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyOrderReasonConceptClassesIsBadlyFormatted()
+                    throws Exception {
+        
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES,
+            "AAAA-bbbbb-1111-2222/AAAA-BBBB-2222-3333");
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage("Property " + RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES
+                + " needs to be a comma separated list of concept class UUIDs (allowed characters [a-z][A-Z][0-9][,][-][ ])");
+        
+        radiologyProperties.getRadiologyOrderReasonConceptClassNames();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderReasonConceptClassNames()
+     * @verifies throw illegal state exception if global property radiology order reason concept classes contains a UUID not
+     *           found among concept classes
+     */
+    @Test
+    public void
+            getRadiologyOrderReasonConceptClassNames_shouldThrowIllegalStateExceptionIfGlobalPropertyRadiologyOrderReasonConceptClassesContainsAUUIDNotFoundAmongConceptClasses()
+                    throws Exception {
+        
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES,
+            conceptService.getConceptClassByName("Drug")
+                    .getUuid() + "5");
+        
+        expectedException.expect(IllegalStateException.class);
+        expectedException.expectMessage(
+            "Property " + RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES + " contains UUID");
+        
+        radiologyProperties.getRadiologyOrderReasonConceptClassNames();
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderReasonConceptClassNames()
+     * @verifies return the name of the diagnosis concept class if global property radiology order reason concept classes is
+     *           null
+     */
+    @Test
+    public void
+            getRadiologyOrderReasonConceptClassNames_shouldReturnTheNameOfTheDiagnosisConceptClassIfGlobalPropertyRadiologyOrderReasonConceptClassesIsNull()
+                    throws Exception {
+        
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES, null);
+        
+        ConceptClass diagnosisConceptClass = conceptService.getConceptClassByName("Diagnosis");
+        assertThat(radiologyProperties.getRadiologyOrderReasonConceptClassNames(), is(diagnosisConceptClass.getName()));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderReasonConceptClassNames()
+     * @verifies return the name of the diagnosis concept class if global property radiology order reason concept classes is
+     *           an empty string
+     */
+    @Test
+    public void
+            getRadiologyOrderReasonConceptClassNames_shouldReturnTheNameOfTheDiagnosisConceptClassIfGlobalPropertyRadiologyOrderReasonConceptClassesIsAnEmptyString()
+                    throws Exception {
+        
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES, "");
+        
+        ConceptClass diagnosisConceptClass = conceptService.getConceptClassByName("Diagnosis");
+        assertThat(radiologyProperties.getRadiologyOrderReasonConceptClassNames(), is(diagnosisConceptClass.getName()));
+    }
+    
+    /**
+     * @see RadiologyProperties#getRadiologyOrderReasonConceptClassNames()
+     * @verifies return comma separated list of concept class names configured via concept class UUIDs in global property
+     *           radiology order reason concept classes
+     */
+    @Test
+    public void
+            getRadiologyOrderReasonConceptClassNames_shouldReturnCommaSeparatedListOfConceptClassNamesConfiguredViaConceptClassUUIDsInGlobalPropertyRadiologyOrderReasonConceptClasses()
+                    throws Exception {
+        
+        List<ConceptClass> conceptClasses = new LinkedList<ConceptClass>();
+        conceptClasses.add(conceptService.getConceptClassByName("Drug"));
+        conceptClasses.add(conceptService.getConceptClassByName("Test"));
+        conceptClasses.add(conceptService.getConceptClassByName("Anatomy"));
+        conceptClasses.add(conceptService.getConceptClassByName("Diagnosis"));
+        String uuidFromConceptClasses = "";
+        String expectedNames = "";
+        for (ConceptClass conceptClass : conceptClasses) {
+            if (expectedNames.equals("")) {
+                uuidFromConceptClasses = conceptClass.getUuid();
+                expectedNames = conceptClass.getName();
+            }
+            uuidFromConceptClasses = uuidFromConceptClasses + "," + conceptClass.getUuid();
+            expectedNames = expectedNames + "," + conceptClass.getName();
+        }
+        administrationService.setGlobalProperty(RadiologyConstants.GP_RADIOLOGY_ORDER_REASON_CONCEPT_CLASSES,
+            uuidFromConceptClasses);
+        assertThat(radiologyProperties.getRadiologyOrderReasonConceptClassNames(), is(expectedNames));
     }
     
     /**
@@ -545,9 +647,9 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     }
     
     /**
-    * @see RadiologyProperties#getReportTemplateHome()
-    * @verifies create a directory under the openmrs application data directory if GP value is relative
-    */
+     * @see RadiologyProperties#getReportTemplateHome()
+     * @verifies create a directory under the openmrs application data directory if GP value is relative
+     */
     @Test
     public void getReportTemplateHome_shouldCreateADirectoryUnderTheOpenmrsApplicationDataDirectoryIfGPValueIsRelative()
             throws Exception {
@@ -567,9 +669,9 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     }
     
     /**
-    * @see RadiologyProperties#getReportTemplateHome()
-    * @verifies create a directory at GP value if it is an absolute path
-    */
+     * @see RadiologyProperties#getReportTemplateHome()
+     * @verifies create a directory at GP value if it is an absolute path
+     */
     @Test
     public void getReportTemplateHome_shouldCreateADirectoryAtGPValueIfItIsAnAbsolutePath() throws Exception {
         File tempFolder = temporaryFolder.newFolder("/mrrt_templates");
@@ -587,9 +689,9 @@ public class RadiologyPropertiesComponentTest extends BaseModuleContextSensitive
     }
     
     /**
-    * @see RadiologyProperties#getReportTemplateHome()
-    * @verifies throw illegal state exception if global property cannot be found
-    */
+     * @see RadiologyProperties#getReportTemplateHome()
+     * @verifies throw illegal state exception if global property cannot be found
+     */
     @Test
     public void getReportTemplateHome_shouldThrowIllegalStateExceptionIfGlobalPropertyCannotBeFound() throws Exception {
         expectedException.expect(IllegalStateException.class);

--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
@@ -310,12 +310,22 @@ public class RadiologyOrderFormController {
     }
     
     /**
-     * Gets the Name of the ConceptClasses that should be filtered
+     * Gets the names of the concept classes that should be filtered
      *
-     * @return Name of ConceptClasses
+     * @return names of concept classes
      */
     @ModelAttribute("radiologyConceptClassNames")
     private String getRadiologyConceptClassNames() {
         return radiologyProperties.getRadiologyConceptClassNames();
+    }
+    
+    /**
+     * Gets the names of the concept classes that should be filtered for the order reason field
+     *
+     * @return names of concept classes containing concepts for the order reason field
+     */
+    @ModelAttribute("radiologyOrderReasonConceptClassNames")
+    private String getRadiologyOrderReasonConceptClassNames() {
+        return radiologyProperties.getRadiologyOrderReasonConceptClassNames();
     }
 }

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -140,6 +140,13 @@
 		</description>
 	</globalProperty>
 	<globalProperty>
+		<property>@MODULE_ID@.radiologyOrderReasonConceptClasses</property>
+		<defaultValue>8d4918b0-c2cc-11de-8d13-0010c6dffd0f</defaultValue>
+		<description>Comma separated list of concept class UUIDs which define
+			concepts that are reasons for radiology orders
+		</description>
+	</globalProperty>
+	<globalProperty>
 		<property>@MODULE_ID@.radiologyOrderingProviderEncounterRole
 		</property>
 		<defaultValue>13fc9b4a-49ed-429c-9dde-ca005b387a3d</defaultValue>

--- a/omod/src/main/webapp/orders/radiologyOrderCreationSegment.jsp
+++ b/omod/src/main/webapp/orders/radiologyOrderCreationSegment.jsp
@@ -4,10 +4,13 @@
   var $j = jQuery.noConflict();
 
   function onQuestionSelect(concept) {
-    $j("#conceptDescription").show();
     $j("#conceptDescription").html(concept.description);
   }
 
+  function onReasonSelect(concept) {
+    $j("#reasonDescription").html(concept.description);
+  }
+  
   $j(document).ready(
           function() {
             var scheduledDate = $j("#scheduledDateId");
@@ -89,10 +92,7 @@
         <td><spring:message code="Order.patient" /><span class="required">*</span></td>
         <td><spring:bind path="patient">
             <openmrs:fieldGen type="org.openmrs.Patient" formFieldName="${status.expression}" val="${status.editor.value}" />
-            <c:if test="${status.errorMessage != ''}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+          </spring:bind> <form:errors path="patient" cssClass="error" /></td>
       </tr>
       <tr>
         <td><spring:message code="radiology.imagingProcedure" /><span class="required">*</span></td>
@@ -100,39 +100,27 @@
             <openmrs_tag:conceptField formFieldName="concept" formFieldId="conceptId"
               initialValue="${status.editor.value.conceptId}" onSelectFunction="onQuestionSelect"
               includeClasses="${radiologyConceptClassNames}" />
-            <c:if test="${status.errorMessage != ''}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-            <div class="description" id="conceptDescription"></div>
-          </spring:bind></td>
+          </spring:bind> <form:errors path="concept" cssClass="error" />
+          <div class="description" id="conceptDescription"></div></td>
       </tr>
       <tr>
         <td><spring:message code="radiology.radiologyOrder.orderReason" /></td>
         <td><spring:bind path="orderReason">
             <openmrs_tag:conceptField formFieldName="orderReason" formFieldId="orderReasonId"
-              initialValue="${status.editor.value.conceptId}" />
-            <c:if test="${status.errorMessage != ''}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+              initialValue="${status.editor.value.conceptId}" onSelectFunction="onReasonSelect" 
+              includeClasses="${radiologyOrderReasonConceptClassNames}" />
+          </spring:bind> <form:errors path="orderReason" cssClass="error" />
+          <div class="description" id="reasonDescription"></div></td>
       </tr>
       <tr>
         <td><spring:message code="radiology.radiologyOrder.orderReasonNonCoded" /></td>
-        <td><spring:bind path="orderReasonNonCoded">
-            <textarea name="${status.expression}">${status.value}</textarea>
-            <c:if test="${status.errorMessage != ''}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+        <td><form:textarea path="orderReasonNonCoded" id="orderReasonNonCodedId" /> <form:errors
+            path="orderReasonNonCoded" cssClass="error" /></td>
       </tr>
       <tr>
         <td><spring:message code="radiology.radiologyOrder.clinicalHistory" /></td>
-        <td><spring:bind path="clinicalHistory">
-            <textarea name="${status.expression}">${status.value}</textarea>
-            <c:if test="${not empty status.errorMessage}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+        <td><form:textarea path="clinicalHistory" id="clinicalHistoryId" /> <form:errors path="clinicalHistory"
+            cssClass="error" /></td>
       </tr>
       <tr>
         <td><spring:message code="radiology.urgency" /><span class="required">*</span></td>
@@ -148,10 +136,7 @@
             <input name="${status.expression}Input" id="${status.expression}InputId" type="text"
               style="display: none; width: 150px;" value=""
               placeholder="<spring:message code="radiology.order.creation.scheduledDate.placeholder"/>">
-            <c:if test="${status.errorMessage != ''}">
-              <span id="scheduledDateErrorSpan" class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+          </spring:bind> <form:errors path="scheduledDate" cssClass="error" /></td>
       </tr>
       <tr>
         <td><spring:message code="radiology.performedStatus" /></td>
@@ -162,28 +147,17 @@
                     code="radiology.${performedStatus.key}" text="${performedStatus.value}" /></option>
               </c:forEach>
             </select>
-            <c:if test="${status.errorMessage != ''}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+          </spring:bind> <form:errors path="study.performedStatus" cssClass="error" /></td>
       </tr>
       <tr>
         <td><spring:message code="general.instructions" /></td>
-        <td><spring:bind path="instructions">
-            <textarea name="${status.expression}">${status.value}</textarea>
-            <c:if test="${status.errorMessage != ''}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+        <td><form:textarea path="instructions" id="instructionsId" /> <form:errors path="instructions" cssClass="error" /></td>
       </tr>
       <tr>
         <td><spring:message code="Order.orderer" /><span class="required">*</span></td>
         <td><spring:bind path="orderer">
             <openmrs:fieldGen type="org.openmrs.Provider" formFieldName="${status.expression}" val="${status.editor.value}" />
-            <c:if test="${status.errorMessage != ''}">
-              <span class="error">${status.errorMessage}</span>
-            </c:if>
-          </spring:bind></td>
+          </spring:bind> <form:errors path="orderer" cssClass="error" /></td>
       </tr>
       <tr>
         <td></td>

--- a/omod/src/main/webapp/orders/radiologyOrderDiscontinuationSegment.jsp
+++ b/omod/src/main/webapp/orders/radiologyOrderDiscontinuationSegment.jsp
@@ -6,19 +6,13 @@
       <td><spring:message code="Order.orderer" /><span class="required">*</span></td>
       <td><spring:bind path="orderer">
           <openmrs:fieldGen type="org.openmrs.Provider" formFieldName="${status.expression}" val="${status.editor.value}" />
-          <c:if test="${not empty status.errorMessage}">
-            <span class="error">${status.errorMessage}</span>
-          </c:if>
-        </spring:bind></td>
+        </spring:bind> <form:errors path="orderer" cssClass="error" /></td>
     </tr>
     <tr>
       <td><spring:message code="general.discontinuedReason" /><span class="required">*</span></td>
       <td><spring:bind path="reasonNonCoded">
           <textarea name="${status.expression}">${status.value}</textarea>
-          <c:if test="${not empty status.errorMessage}">
-            <span class="error">${status.errorMessage}</span>
-          </c:if>
-        </spring:bind></td>
+        </spring:bind> <form:errors path="reasonNonCoded" cssClass="error" /></td>
     </tr>
   </table>
   <input type="submit" name="discontinueOrder" value='<spring:message code="Order.discontinueOrder"/>' />


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
A global property should enable the admin to configure a list of
concept classes for reason coded from which an ordering clinician
can choose from when creating radiology orders.

* add new global property to RadiologyConstants.java
* add gloabl property to config.xml
* add method to get concept class names from specified uuids in
  RadiologyProperties.java
* add tests for new method
* add model attribute for reason concept classes to radiology order
  form controller
* add description to reason coded field in
  radiologyOrderCreationSegment.jsp
* use spring form tags

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-295
