### PR TITLE
Remove radiology_order.order_id autoIncrement

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -182,7 +182,7 @@
 		</preConditions>
 		<comment>Create radiology_order table for new class RadiologyOrder</comment>
 		<createTable tableName="radiology_order">
-			<column name="order_id" type="int" autoIncrement="true">
+			<column name="order_id" type="int" autoIncrement="false">
 				<constraints primaryKey="true" nullable="false" />
 			</column>
 		</createTable>


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
the radiology_order.order_id primary key was set to autoIncrement which makes
it possible to insert a new radiology_order using

"insert into radiology_order values (NULL);"

if there is a test_order matching the current auto_increment value of the
radiology_order. This should not be possible as this can cause a
radiology_order being attached to a test_order which is in fact not a
radiology_order.

Not-null constraint on radiology_order.order_id and Foreign key constraint to test_order.order_id
together ensure integrity of radiology_order data.