### PR TITLE
Move radiologyOrderCreationSegment to own Form

### DIFF
--- a/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormController.java
@@ -54,6 +54,8 @@ public class RadiologyOrderFormController {
     
     public static final String RADIOLOGY_ORDER_FORM_REQUEST_MAPPING = "/module/radiology/radiologyOrder.form";
     
+    static final String RADIOLOGY_ORDER_CREATION_FORM_VIEW = "/module/radiology/orders/radiologyOrderCreationForm";
+    
     static final String RADIOLOGY_ORDER_FORM_VIEW = "/module/radiology/orders/radiologyOrderForm";
     
     @Autowired
@@ -88,7 +90,7 @@ public class RadiologyOrderFormController {
     @RequestMapping(method = RequestMethod.GET)
     protected ModelAndView getRadiologyOrderFormWithNewRadiologyOrder() {
         
-        final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
+        final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_CREATION_FORM_VIEW);
         modelAndView.addObject("order", new Order());
         modelAndView.addObject("radiologyReport", null);
         final RadiologyOrder radiologyOrder = new RadiologyOrder();
@@ -170,7 +172,7 @@ public class RadiologyOrderFormController {
     protected ModelAndView saveRadiologyOrder(HttpServletRequest request, @ModelAttribute RadiologyOrder radiologyOrder,
             BindingResult resultRadiologyOrder) {
         
-        final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_FORM_VIEW);
+        final ModelAndView modelAndView = new ModelAndView(RADIOLOGY_ORDER_CREATION_FORM_VIEW);
         
         radiologyOrderValidator.validate(radiologyOrder, resultRadiologyOrder);
         if (resultRadiologyOrder.hasErrors()) {

--- a/omod/src/main/webapp/orders/radiologyOrderCreationForm.jsp
+++ b/omod/src/main/webapp/orders/radiologyOrderCreationForm.jsp
@@ -1,5 +1,18 @@
+<%@ include file="/WEB-INF/template/include.jsp"%>
+<c:set var="DO_NOT_INCLUDE_JQUERY" value="true" />
+<%@ include file="/WEB-INF/template/header.jsp"%>
+<c:set var="INCLUDE_TIME_ADJUSTMENT" value="true" />
+<%@ include file="/WEB-INF/view/module/radiology/template/includeScripts.jsp"%>
+
 <openmrs:htmlInclude file="/moduleResources/radiology/scripts/jquery/daterangepicker/css/daterangepicker.min.css" />
 <openmrs:htmlInclude file="/moduleResources/radiology/scripts/jquery/daterangepicker/js/jquery.daterangepicker.min.js" />
+
+<openmrs:require
+  allPrivileges="Add Encounters,Add Orders,Add Radiology Orders,Add Visits,Edit Encounters,Edit Visits,Get Care Settings,Get Concepts,Get Encounter Roles,Get Encounters,Get Orders,Get Patients,Get Providers,Get Radiology Orders,Get Users,Get Visit Attribute Types,Get Visit Types,Get Visits,View Orders"
+  otherwise="/login.htm" redirect="/module/radiology/radiologyOrder.form" />
+
+<!--  This form is for creating new RadiologyOrders -->
+
 <script type="text/javascript">
   var $j = jQuery.noConflict();
 
@@ -184,3 +197,4 @@
     </table>
   </form:form>
 </div>
+<%@ include file="/WEB-INF/template/footer.jsp"%>

--- a/omod/src/main/webapp/orders/radiologyOrderForm.jsp
+++ b/omod/src/main/webapp/orders/radiologyOrderForm.jsp
@@ -10,62 +10,40 @@
   allPrivileges="Get Care Settings,Get Concepts,Get Encounter Roles,Get Encounters,Get Orders,Get Patients,Get Providers,Get Radiology Orders,Get Users,Get Visit Attribute Types,Get Visit Types,Get Visits,View Orders"
   otherwise="/login.htm" redirect="/module/radiology/radiologyOrder.form" />
 
+<!--  This form shows existing RadiologyOrder/discontinued Order -->
+
+<openmrs:hasPrivilege privilege="View Patients">
+  <openmrs:portlet url="patientHeader" id="patientDashboardHeader" patientId="${order.patient.patientId}" />
+  <br>
+</openmrs:hasPrivilege>
 <c:choose>
-  <c:when test="${not empty radiologyOrder && empty radiologyOrder.orderId}">
-    <!--  Create a new RadiologyOrder -->
-    <openmrs:hasPrivilege privilege="Add Encounters">
-      <openmrs:hasPrivilege privilege="Add Orders">
-        <openmrs:hasPrivilege privilege="Add Radiology Orders">
-          <openmrs:hasPrivilege privilege="Add Visits">
-            <openmrs:hasPrivilege privilege="Edit Encounters">
-              <openmrs:hasPrivilege privilege="Edit Visits">
-                <%@ include file="radiologyOrderCreationSegment.jsp"%>
-              </openmrs:hasPrivilege>
+  <c:when test="${not empty radiologyOrder}">
+    <!--  Show existing RadiologyOrder -->
+    <%@ include file="radiologyOrderDisplaySegment.jsp"%>
+    <c:if test="${radiologyOrder.completed}">
+      <!--  Show form for radiology report -->
+      <openmrs:hasPrivilege privilege="Add Radiology Reports">
+        <openmrs:hasPrivilege privilege="Delete Radiology Reports">
+          <openmrs:hasPrivilege privilege="Edit Radiology Reports">
+            <openmrs:hasPrivilege privilege="Get Radiology Reports">
+              <%@ include file="radiologyReportSegment.jsp"%>
             </openmrs:hasPrivilege>
           </openmrs:hasPrivilege>
         </openmrs:hasPrivilege>
       </openmrs:hasPrivilege>
-    </openmrs:hasPrivilege>
-
+    </c:if>
+    <c:if test="${radiologyOrder.discontinuationAllowed}">
+      <!--  Show form to discontinue an active non in progress/completed RadiologyOrder -->
+      <openmrs:hasPrivilege privilege="Delete Radiology Orders">
+        <openmrs:hasPrivilege privilege="Edit Orders">
+          <%@ include file="radiologyOrderDiscontinuationSegment.jsp"%>
+        </openmrs:hasPrivilege>
+      </openmrs:hasPrivilege>
+    </c:if>
   </c:when>
-
   <c:otherwise>
-    <!--  Show existing RadiologyOrder/discontinued Order -->
-    <openmrs:hasPrivilege privilege="View Patients">
-      <openmrs:portlet url="patientHeader" id="patientDashboardHeader" patientId="${order.patient.patientId}" />
-      <br>
-    </openmrs:hasPrivilege>
-    <c:choose>
-      <c:when test="${not empty radiologyOrder}">
-        <!--  Show existing RadiologyOrder -->
-        <%@ include file="radiologyOrderDisplaySegment.jsp"%>
-        <c:if test="${radiologyOrder.completed}">
-          <!--  Show form for radiology report -->
-          <openmrs:hasPrivilege privilege="Add Radiology Reports">
-            <openmrs:hasPrivilege privilege="Delete Radiology Reports">
-              <openmrs:hasPrivilege privilege="Edit Radiology Reports">
-                <openmrs:hasPrivilege privilege="Get Radiology Reports">
-                  <%@ include file="radiologyReportSegment.jsp"%>
-                </openmrs:hasPrivilege>
-              </openmrs:hasPrivilege>
-            </openmrs:hasPrivilege>
-          </openmrs:hasPrivilege>
-
-        </c:if>
-        <c:if test="${radiologyOrder.discontinuationAllowed}">
-          <!--  Show form to discontinue an active non in progress/completed RadiologyOrder -->
-          <openmrs:hasPrivilege privilege="Delete Radiology Orders">
-            <openmrs:hasPrivilege privilege="Edit Orders">
-              <%@ include file="radiologyOrderDiscontinuationSegment.jsp"%>
-            </openmrs:hasPrivilege>
-          </openmrs:hasPrivilege>
-        </c:if>
-      </c:when>
-      <c:otherwise>
-        <!--  Show read-only view of discontinuation Order -->
-        <%@ include file="discontinuationOrderDisplaySegment.jsp"%>
-      </c:otherwise>
-    </c:choose>
+    <!--  Show read-only view of discontinuation Order -->
+    <%@ include file="discontinuationOrderDisplaySegment.jsp"%>
   </c:otherwise>
 </c:choose>
 <%@ include file="/WEB-INF/template/footer.jsp"%>

--- a/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/radiology/order/web/RadiologyOrderFormControllerTest.java
@@ -103,7 +103,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
         ModelAndView modelAndView = radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrder();
         
         assertNotNull(modelAndView);
-        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW));
+        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_CREATION_FORM_VIEW));
         
         assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
         RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
@@ -134,7 +134,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
                 radiologyOrderFormController.getRadiologyOrderFormWithNewRadiologyOrderAndPrefilledPatient(mockPatient);
         
         assertNotNull(modelAndView);
-        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW));
+        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_CREATION_FORM_VIEW));
         
         assertThat(modelAndView.getModelMap(), hasKey("radiologyOrder"));
         RadiologyOrder order = (RadiologyOrder) modelAndView.getModelMap()
@@ -320,7 +320,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
                 radiologyOrderFormController.saveRadiologyOrder(mockRequest, mockRadiologyOrder, orderErrors);
         
         assertNotNull(modelAndView);
-        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW));
+        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_CREATION_FORM_VIEW));
         
         assertThat(modelAndView.getModelMap(), hasKey("order"));
         Order order = (Order) modelAndView.getModelMap()
@@ -360,7 +360,7 @@ public class RadiologyOrderFormControllerTest extends BaseContextMockTest {
                 radiologyOrderFormController.saveRadiologyOrder(mockRequest, mockRadiologyOrder, orderErrors);
         
         assertNotNull(modelAndView);
-        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_FORM_VIEW));
+        assertThat(modelAndView.getViewName(), is(RadiologyOrderFormController.RADIOLOGY_ORDER_CREATION_FORM_VIEW));
         
         assertThat(modelAndView.getModelMap(), hasKey("order"));
         Order order = (Order) modelAndView.getModelMap()


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
the radiologyOrderCreationSegment.jsp was included into the
radiologyOrderForm.jsp and surrounded by hasPrivilege tag to not display it
when the user is not allowed to create a report. Doesnt really make sense,
since if the user doesnt have the permission he is allowed on the page and the
page is blank.

* rename the jsp to radiologyOrderCreationForm.jsp
* add necessary header includes/footer
* adapt RadiologyOrderFormController to return the page for GET/POST requests
of new RadiologyOrder's

now when the user is missing a privilege he will be redirected via the
require tag and see what privileges he is missing.