### PR TITLE
Update legacyui snapshot link in Dockerfile

### DIFF
--- a/omod/src/main/docker/Dockerfile
+++ b/omod/src/main/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM teleivo/openmrs-platform:2.0.0-1
 
 # Get radiology modules dependencies
 RUN curl -L \
-    "http://mavenrepo.openmrs.org/nexus/service/local/repositories/snapshots/content/org/openmrs/module/legacyui-omod/1.1-SNAPSHOT/legacyui-omod-1.1-20160912.201607-48.jar" \
+    "http://mavenrepo.openmrs.org/nexus/service/local/repositories/snapshots/content/org/openmrs/module/legacyui-omod/1.1-SNAPSHOT/legacyui-omod-1.1-20160916.121155-57.jar" \
     -o "${OPENMRS_MODULES}/legacyui-1.1-SNAPSHOT.omod"
 RUN curl -L \
     "http://mavenrepo.openmrs.org/nexus/service/local/repositories/modules/content/org/openmrs/module/webservices.rest-omod/2.15/webservices.rest-omod-2.15.jar" \


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
since we currently depend on a legacyui snapshot we need to update the
Dockerfile's url to get the snapshot as snapshots are not keept for ever
on nexus

will be resolved once we depend on 1.1 which has features/fixes we currently
need