### PR TITLE
RAD-359 Improve validation error messages on mrrt import

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/template/ElementsExpressionValidationRule.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/ElementsExpressionValidationRule.java
@@ -1,0 +1,48 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import org.jsoup.select.Elements;
+
+import java.util.function.Predicate;
+
+/**
+ * Checks a condition on a subset of elements matching a selector.
+ */
+class ElementsExpressionValidationRule implements ValidationRule<Elements> {
+    
+    
+    private final String description;
+    
+    private final String messageCode;
+    
+    private final String elementsSelector;
+    
+    private final Predicate<Elements> condition;
+    
+    public ElementsExpressionValidationRule(String description, String messageCode, String elementsSelector,
+        Predicate<Elements> condition) {
+        this.description = description;
+        this.messageCode = messageCode;
+        this.elementsSelector = elementsSelector;
+        this.condition = condition;
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.ValidationRule#check(ValidationResult, Object)
+     */
+    @Override
+    public void check(ValidationResult validationResult, Elements subject) {
+        Elements elements = subject.select(elementsSelector);
+        if (condition.test(elements)) {
+            validationResult.addError(description, messageCode);
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MetaTagsValidationEngine.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MetaTagsValidationEngine.java
@@ -1,0 +1,56 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validates <meta> tags of an Mrrt Report Template.
+ */
+class MetaTagsValidationEngine implements ValidationEngine<Elements> {
+    
+    
+    static String SELECTOR_QUERY_META_ATTRIBUTE_CHARSET = "meta[charset]";
+    
+    static String SELECTOR_QUERY_META_ATTRIBUTE_NAME = "meta[name]";
+    
+    private List<ValidationRule<Elements>> rules;
+    
+    public MetaTagsValidationEngine() {
+        rules = new ArrayList<>();
+        rules.add(new ElementsExpressionValidationRule("One 'meta' element with attribute 'charset' expected",
+                "radiology.MrrtReportTemplate.validation.error.meta.charset.occurence",
+                SELECTOR_QUERY_META_ATTRIBUTE_CHARSET, subject -> subject.isEmpty() || subject.size() > 1));
+        rules.add(
+            new ElementsExpressionValidationRule("At least one 'meta' element encoding dublin core attributes expected",
+                    "radiology.MrrtReportTemplate.validation.error.meta.dublinCore.missing",
+                    SELECTOR_QUERY_META_ATTRIBUTE_NAME, subject -> subject.isEmpty()));
+    }
+    
+    /**
+     * @see org.openmrs.module.radiology.report.template.ValidationEngine#run(Object)
+     * @should return validation result with no errors if subject passes all checks
+     * @should return validation result with error for meta element charset attribute if not present in subject
+     * @should return validation result with error for meta element charset attribute if present more than once in subject
+     * @should return validation result with error for meta element dublin core if no meta element with name attribute is present in subject
+     */
+    @Override
+    public ValidationResult run(Elements subject) {
+        
+        final ValidationResult validationResult = new ValidationResult();
+        for (ValidationRule rule : rules) {
+            rule.check(validationResult, subject);
+        }
+        return validationResult;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidationException.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidationException.java
@@ -1,0 +1,26 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import org.openmrs.api.APIException;
+
+public class MrrtReportTemplateValidationException extends APIException {
+    
+    
+    private final ValidationResult validationResult;
+    
+    public ValidationResult getValidationResult() {
+        return validationResult;
+    }
+    
+    public MrrtReportTemplateValidationException(ValidationResult validationResult) {
+        this.validationResult = validationResult;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationEngine.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationEngine.java
@@ -1,0 +1,29 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+/**
+ * Runs a set of rules on a subject and returns collected errors in the result.
+ *
+ * @param <T> the type of subject the engine should validate
+ * @see ValidationRule
+ * @see ValidationResult
+ */
+public interface ValidationEngine<T> {
+    
+    
+    /**
+     * Validates a subject collecting the errors in validation result.
+     *
+     * @param subject the subject to be validated
+     * @return the validation result containing found errors
+     */
+    public ValidationResult run(T subject);
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationError.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationError.java
@@ -1,0 +1,58 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+/**
+ * Represents an error found during validation of the IHE Management of Radiology Report Templates (MRRT).
+ */
+public class ValidationError {
+    
+    
+    private final String description;
+    
+    private final String messageCode;
+    
+    /**
+     * Get this description.
+     *
+     * @return the description
+     */
+    public String getDescription() {
+        return description;
+    }
+    
+    /**
+     * Get this message code.
+     *
+     * @return the message code
+     */
+    public String getMessageCode() {
+        return messageCode;
+    }
+    
+    /**
+     * Creates a new instance of {@link ValidationError}.
+     *
+     * @param description the description of the error
+     * @param messageCode the message code of the error
+     */
+    public ValidationError(String description, String messageCode) {
+        this.description = description;
+        this.messageCode = messageCode;
+    }
+    
+    /**
+     * @see Object#toString()
+     */
+    @Override
+    public String toString() {
+        return description;
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationResult.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationResult.java
@@ -1,0 +1,107 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Container collecting errors found during validation of the IHE Management of Radiology Report Templates (MRRT).
+ *
+ */
+public class ValidationResult {
+    
+    
+    private List<ValidationError> errors;
+    
+    /**
+     * Get the errors of this validation result.
+     *
+     * @return the errors
+     */
+    public List<ValidationError> getErrors() {
+        return errors;
+    }
+    
+    /**
+     * Creates a new instance of {@link ValidationResult}.
+     * @should create a new validation result initializing errors
+     */
+    public ValidationResult() {
+        errors = new ArrayList<>();
+    }
+    
+    /**
+     * Add an error to this validation result.
+     *
+     * @param description the error description
+     * @param messageCode the message code of the error
+     * @should add new error with given parameters
+     */
+    public void addError(String description, String messageCode) {
+        ValidationError error = new ValidationError(description, messageCode);
+        errors.add(error);
+    }
+    
+    /**
+     * Add an error to this validation result.
+     *
+     * @param validationError the validation error
+     * @should add given validation error to errors
+     */
+    public void addError(ValidationError validationError) {
+        errors.add(validationError);
+    }
+    
+    /**
+     * Assert that this validation result has no errors and throw an exception if it does.
+     *
+     * @see MrrtReportTemplateValidationException
+     * @should throw a validation exception if validation has errors
+     * @should not throw a validation exception if validation has errors
+     */
+    public void assertOk() {
+        if (hasErrors()) {
+            throw new MrrtReportTemplateValidationException(this);
+        }
+    }
+    
+    /**
+     * Check if this validation result has errors.
+     *
+     * @return true if this result has errors and false otherwise
+     * @should return true if validation has errors
+     * @should return false if validation has no errors
+     */
+    public boolean hasErrors() {
+        return !errors.isEmpty();
+    }
+    
+    /**
+     * @see Object#toString()
+     * @should return ok if validation has no errors
+     * @should return error strings if validation has errors
+     */
+    @Override
+    public String toString() {
+        
+        if (hasErrors()) {
+            final StringBuilder result = new StringBuilder();
+            result.append("Validation failed due to:\n");
+            for (ValidationError error : getErrors()) {
+                result.append(error);
+                result.append("\n");
+            }
+            return result.toString();
+        } else {
+            return "OK";
+        }
+    }
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationRule.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/ValidationRule.java
@@ -1,0 +1,25 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+/**
+ * Represents a rule which can be checked during validation.
+ */
+public interface ValidationRule<T> {
+    
+    
+    /**
+     * Checks given subject and populates validation results.
+     *
+     * @param validationResult the validation result to be populated
+     * @param subject the subject to be checked
+     */
+    public void check(ValidationResult validationResult, T subject);
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/XsdMrrtReportTemplateValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/XsdMrrtReportTemplateValidator.java
@@ -36,37 +36,38 @@ public class XsdMrrtReportTemplateValidator implements MrrtReportTemplateValidat
     
     private static final String MRRT_REPORT_TEMPLATE_SCHEMA_FILE = "MrrtReportTemplateSchema.xsd";
     
+    MetaTagsValidationEngine metaTagsValidationEngine;
+    
+    public MetaTagsValidationEngine getMetaTagsValidationEngine() {
+        return metaTagsValidationEngine;
+    }
+    
+    public void setMetaTagsValidationEngine(MetaTagsValidationEngine metaTagsValidationEngine) {
+        this.metaTagsValidationEngine = metaTagsValidationEngine;
+    }
+    
     /**
      * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateValidator#validate(File)
      */
     @Override
     public void validate(File templateFile) throws IOException {
+        
+        final Document document = Jsoup.parse(templateFile, null, "");
+        final Elements metatags = document.getElementsByTag("meta");
+        ValidationResult metaTagsValidationResult = metaTagsValidationEngine.run(metatags);
+        metaTagsValidationResult.assertOk();
+        
         final SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         final Schema schema;
         final Validator validator;
         try {
             schema = factory.newSchema(getSchemaFile());
             validator = schema.newValidator();
-            validateMetatags(templateFile);
             validator.validate(new StreamSource(templateFile));
         }
         catch (SAXException e) {
             log.error(e.getMessage(), e);
             throw new APIException("radiology.report.template.validation.error", null, e);
-        }
-    }
-    
-    private void validateMetatags(File templateFile) throws IOException {
-        final Document doc = Jsoup.parse(templateFile, null, "");
-        final Elements metatagsWithCharsetAttribute = doc.select("meta[charset]");
-        
-        if (metatagsWithCharsetAttribute.isEmpty() || metatagsWithCharsetAttribute.size() > 1) {
-            throw new APIException("radiology.report.template.validation.error.meta.charset");
-        }
-        
-        final Elements dublinAttributes = doc.select("meta[name]");
-        if (dublinAttributes.isEmpty()) {
-            throw new APIException("radiology.report.template.validation.error.meta.dublinCore");
         }
     }
     

--- a/api/src/main/resources/moduleApplicationContext.xml
+++ b/api/src/main/resources/moduleApplicationContext.xml
@@ -215,7 +215,12 @@
 	</bean>
 	<bean id="mrrtReportTemplateFileParser" class="org.openmrs.module.radiology.report.template.DefaultMrrtReportTemplateFileParser">
 		<property name="validator">
-			<bean class="org.openmrs.module.radiology.report.template.XsdMrrtReportTemplateValidator"></bean>
+			<ref bean="mrrtReportTemplateValidator" />
+		</property>
+	</bean>
+	<bean id="mrrtReportTemplateValidator" class="org.openmrs.module.radiology.report.template.XsdMrrtReportTemplateValidator">
+		<property name="metaTagsValidationEngine">
+			<bean class="org.openmrs.module.radiology.report.template.MetaTagsValidationEngine"></bean>
 		</property>
 	</bean>
 </beans>

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MetaTagsValidationEngineTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MetaTagsValidationEngineTest.java
@@ -1,0 +1,126 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import org.jsoup.nodes.Attributes;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Tag;
+import org.jsoup.select.Elements;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link MetaTagsValidationEngine}.
+ */
+public class MetaTagsValidationEngineTest {
+    
+    
+    Attributes charsetAttributes;
+    
+    Attributes dublinElementAttributes;
+    
+    Element charsetElement;
+    
+    Element dublinElement;
+    
+    @Before
+    public void setUp() {
+        charsetAttributes = new Attributes();
+        charsetAttributes.put("charset", "UTF-8");
+        charsetElement = new Element(Tag.valueOf("meta"), "", charsetAttributes);
+        
+        dublinElementAttributes = new Attributes();
+        dublinElementAttributes.put("name", "dcterms.title");
+        dublinElementAttributes.put("content", "CT Abdomen");
+        dublinElement = new Element(Tag.valueOf("meta"), "", dublinElementAttributes);
+    }
+    
+    /**
+     * @verifies return validation result with no errors if subject passes all checks
+     * @see MetaTagsValidationEngine#run(org.jsoup.select.Elements)
+     */
+    @Test
+    public void run_shouldReturnValidationResultWithNoErrorsIfSubjectPassesAllChecks() throws Exception {
+        
+        Elements elements = new Elements(charsetElement, dublinElement);
+        
+        MetaTagsValidationEngine validationEngine = new MetaTagsValidationEngine();
+        
+        ValidationResult validationResult = validationEngine.run(elements);
+        assertFalse(validationResult.hasErrors());
+    }
+    
+    /**
+     * @verifies return validation result with error for meta element charset attribute if not present in subject
+     * @see MetaTagsValidationEngine#run(org.jsoup.select.Elements)
+     */
+    @Test
+    public void run_shouldReturnValidationResultWithErrorForMetaElementCharsetAttributeIfNotPresentInSubject()
+            throws Exception {
+        
+        Elements elements = new Elements(dublinElement);
+        
+        MetaTagsValidationEngine validationEngine = new MetaTagsValidationEngine();
+        
+        ValidationResult validationResult = validationEngine.run(elements);
+        assertTrue(validationResult.hasErrors());
+        assertThat(validationResult.getErrors()
+                .get(0)
+                .getMessageCode(),
+            is("radiology.MrrtReportTemplate.validation.error.meta.charset.occurence"));
+    }
+    
+    /**
+     * @verifies return validation result with error for meta element charset attribute if present more than once in subject
+     * @see MetaTagsValidationEngine#run(org.jsoup.select.Elements)
+     */
+    @Test
+    public void run_shouldReturnValidationResultWithErrorForMetaElementCharsetAttributeIfPresentMoreThanOnceInSubject()
+            throws Exception {
+        
+        Element otherCharsetElement = new Element(Tag.valueOf("meta"), "", charsetAttributes);
+        Elements elements = new Elements(charsetElement, otherCharsetElement, dublinElement);
+        
+        MetaTagsValidationEngine validationEngine = new MetaTagsValidationEngine();
+        
+        ValidationResult validationResult = validationEngine.run(elements);
+        assertTrue(validationResult.hasErrors());
+        assertThat(validationResult.getErrors()
+                .get(0)
+                .getMessageCode(),
+            is("radiology.MrrtReportTemplate.validation.error.meta.charset.occurence"));
+    }
+    
+    /**
+     * @verifies return validation result with error for meta element dublin core if no meta element with name attribute is present in subject
+     * @see MetaTagsValidationEngine#run(org.jsoup.select.Elements)
+     */
+    @Test
+    public void
+            run_shouldReturnValidationResultWithErrorForMetaElementDublinCoreIfNoMetaElementWithNameAttributeIsPresentInSubject()
+                    throws Exception {
+        
+        Elements elements = new Elements(charsetElement);
+        
+        MetaTagsValidationEngine validationEngine = new MetaTagsValidationEngine();
+        
+        ValidationResult validationResult = validationEngine.run(elements);
+        assertTrue(validationResult.hasErrors());
+        assertThat(validationResult.getErrors()
+                .get(0)
+                .getMessageCode(),
+            is("radiology.MrrtReportTemplate.validation.error.meta.dublinCore.missing"));
+    }
+}

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidatorTest.java
@@ -15,14 +15,17 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.openmrs.api.APIException;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Tests {@code MrrtReportTemplateValidator}
+ * Tests {@link MrrtReportTemplateValidator}.
  */
-public class MrrtReportTemplateValidatorTest {
+public class MrrtReportTemplateValidatorTest extends BaseModuleContextSensitiveTest {
     
     
-    MrrtReportTemplateValidator validator = new XsdMrrtReportTemplateValidator();
+    @Autowired
+    MrrtReportTemplateValidator validator;
     
     @Rule
     public ExpectedException expectedException = ExpectedException.none();

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/ValidationResultTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/ValidationResultTest.java
@@ -1,0 +1,159 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link ValidationResult}.
+ */
+public class ValidationResultTest {
+    
+    
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+    
+    ValidationResult validationResultWithoutErrors;
+    
+    ValidationResult validationResultWithErrors;
+    
+    @Before
+    public void setUp() {
+        
+        validationResultWithoutErrors = new ValidationResult();
+        
+        validationResultWithErrors = new ValidationResult();
+        validationResultWithErrors.addError("Missing title element", "missing.title");
+        validationResultWithErrors.addError("Missing meta element", "missing.element");
+    }
+    
+    /**
+     * @verifies create a new validation result initializing errors
+     * @see ValidationResult#ValidationResult()
+     */
+    @Test
+    public void ValidationResult_shouldCreateANewValidationResultInitializingErrors() throws Exception {
+        
+        ValidationResult validationResult = new ValidationResult();
+        assertThat(validationResult.getErrors(), is(empty()));
+    }
+    
+    /**
+     * @verifies add new error with given parameters
+     * @see ValidationResult#addError(String, String)
+     */
+    @Test
+    public void addError_shouldAddNewErrorWithGivenParameters() throws Exception {
+        
+        validationResultWithoutErrors.addError("Missing dublin core elements", "missing.dublincore");
+        assertThat(validationResultWithoutErrors.getErrors()
+                .size(),
+            is(1));
+        assertThat(validationResultWithoutErrors.getErrors()
+                .get(0)
+                .getDescription(),
+            is("Missing dublin core elements"));
+        assertThat(validationResultWithoutErrors.getErrors()
+                .get(0)
+                .getMessageCode(),
+            is("missing.dublincore"));
+    }
+    
+    /**
+     * @verifies add given validation error to errors
+     * @see ValidationResult#addError(ValidationError)
+     */
+    @Test
+    public void addError_shouldAddGivenValidationErrorToErrors() throws Exception {
+        
+        ValidationError validationError = new ValidationError("Missing dublin core elements", "missing.dublincore");
+        validationResultWithoutErrors.addError(validationError);
+        assertThat(validationResultWithoutErrors.getErrors()
+                .size(),
+            is(1));
+        assertThat(validationResultWithoutErrors.getErrors()
+                .get(0),
+            is(validationError));
+    }
+    
+    /**
+     * @verifies throw a validation exception if validation has errors
+     * @see ValidationResult#assertOk()
+     */
+    @Test
+    public void assertOk_shouldThrowAValidationExceptionIfValidationHasErrors() throws Exception {
+        
+        expectedException.expect(MrrtReportTemplateValidationException.class);
+        validationResultWithErrors.assertOk();
+    }
+    
+    /**
+     * @verifies not throw a validation exception if validation has errors
+     * @see ValidationResult#assertOk()
+     */
+    @Test
+    public void assertOk_shouldNotThrowAValidationExceptionIfValidationHasErrors() throws Exception {
+        
+        validationResultWithoutErrors.assertOk();
+    }
+    
+    /**
+     * @verifies return true if validation has errors
+     * @see ValidationResult#hasErrors()
+     */
+    @Test
+    public void hasErrors_shouldReturnTrueIfValidationHasErrors() throws Exception {
+        
+        assertTrue(validationResultWithErrors.hasErrors());
+    }
+    
+    /**
+     * @verifies return false if validation has no errors
+     * @see ValidationResult#hasErrors()
+     */
+    @Test
+    public void hasErrors_shouldReturnFalseIfValidationHasNoErrors() throws Exception {
+        
+        assertFalse(validationResultWithoutErrors.hasErrors());
+    }
+    
+    /**
+     * @verifies return ok if validation has no errors
+     * @see ValidationResult#toString()
+     */
+    @Test
+    public void toString_shouldReturnOkIfValidationHasNoErrors() throws Exception {
+        
+        assertThat(validationResultWithoutErrors.toString(), is("OK"));
+    }
+    
+    /**
+     * @verifies return error strings if validation has errors
+     * @see ValidationResult#toString()
+     */
+    @Test
+    public void toString_shouldReturnErrorStringsIfValidationHasErrors() throws Exception {
+        
+        assertThat(validationResultWithErrors.toString(), startsWith("Validation failed due to:"));
+        assertThat(validationResultWithErrors.toString(), containsString("Missing title element"));
+        assertThat(validationResultWithErrors.toString(), containsString("Missing meta element"));
+    }
+}

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -16,8 +16,7 @@
 @MODULE_ID@.report.template.imported=Report template imported
 @MODULE_ID@.report.template.not.imported.empty=Failed to import report template because it was empty
 @MODULE_ID@.report.template.validation.error=Template validation error
-@MODULE_ID@.report.template.validation.error.meta.charset=Template file should have exactly one meta element with charset attribute
-@MODULE_ID@.report.template.validation.error.meta.dublinCore=Template file should have exactly one meta element encoding dublin core attributes
+@MODULE_ID@.report.template.validation.error.list.header=Failed to import report template because of following violations:
 @MODULE_ID@.report.template.parser.error=Error parsing template file
 
 @MODULE_ID@.report.template.view.templateMetadata.boxheader=Template Metadata
@@ -177,6 +176,8 @@
 
 @MODULE_ID@.MrrtReportTemplate.imported=Report template imported
 @MODULE_ID@.MrrtReportTemplate.not.imported.empty=Failed to import report template because it was empty
+@MODULE_ID@.MrrtReportTemplate.validation.error.meta.charset.occurence=Template file should have exactly one 'meta' element with attribute 'charset'
+@MODULE_ID@.MrrtReportTemplate.validation.error.meta.dublinCore.missing=Template file should have at least one 'meta' element encoding dublin core attributes
 
 @MODULE_ID@.patientId=Patient Id
 @MODULE_ID@.patientFullName=Patient Full Name

--- a/omod/src/main/webapp/radiologyDashboardReportTemplatesTab.jsp
+++ b/omod/src/main/webapp/radiologyDashboardReportTemplatesTab.jsp
@@ -184,6 +184,17 @@
 
                   });
 </script>
+<c:if test="${not empty mrrtReportTemplateValidationErrors}" >
+    </br>
+    <div class="error">
+        <spring:message code="radiology.report.template.validation.error.list.header" />
+        <ul>
+        <c:forEach items="${mrrtReportTemplateValidationErrors}" var="validationError">
+            <li><spring:message code="${validationError.messageCode}" text="${validationError.description}" /></li>
+        </c:forEach>
+        </ul>
+    </div>
+</c:if>
 
 <openmrs:hasPrivilege privilege="View Radiology Report Templates">
   <div id="radiologyReportTemplates">


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
use a Production Rule System style approach to validate the mrrt meta
tag rules which are checked using jsoup in the
XsdMrrtReportTemplateValidator

* add validation engine interface which runs validation on given type
and returns a ValidationResult containing the ValidationError's
* add MetaTagsValidationEngine containing the ValidationRule's which
are checked when run
* add ValidationRule interface with ElementsExpressionValidationRule
impl which selects elements via jsoup and tests the condition Predicate
* catch MrrtReportTemplateValidationException in the
RadiologyDashboardReportTemplatesTabController and add the violations
into the model and view for display
* show violations in an <ul> to the user

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-359
