### PR TITLE
Use String instead of InputStream on importing templates

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParser.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParser.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.radiology.report.template;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 /**
  * A parser that is responsible for parsing mrrt report templates and extract metadata.
@@ -19,15 +18,15 @@ public interface MrrtReportTemplateFileParser {
     
     
     /**
-     * Parse an {@code MRRT} template and extract metadata into a {@code MrrtReportTemplate}.
+     * Parse an mrrt template and extract metadata into a {@code MrrtReportTemplate}.
      * 
-     * @param in the input stream containing the mrrt template
-     * @return the mrrt report template extracted from the input stream
-     * @throws IOException if the template file could not be read
-     * @should return an mrrt template object if file is valid
+     * @param mrrtTemplate the mrrt template to parse
+     * @return the mrrt report template
+     * @throws IOException if one is thrown during validation
+     * @should return an mrrt template object if given template is valid
      * @should store terms element in template object if they match a concept reference term in openmrs
      * @should skip terms element in template file if no corresponding concept reference term was found
      * @should ignore case when searching for a matching concept source
      */
-    public MrrtReportTemplate parse(InputStream in) throws IOException;
+    public MrrtReportTemplate parse(String mrrtTemplate) throws IOException;
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateService.java
@@ -10,7 +10,6 @@
 package org.openmrs.module.radiology.report.template;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
 import org.openmrs.annotation.Authorized;
@@ -43,15 +42,19 @@ public interface MrrtReportTemplateService extends OpenmrsService {
     
     /**
      * Import an {@code MrrtReportTemplate} into the system.
+     * <p>
+     *     This means metadata like title, description, date, license, creator, ... is stored in an {@code MrrtReportTemplate} in the database with a link to the template file which is stored on the filesystem.
+     * </p>
+     * Calls {@link #saveMrrtReportTemplate(MrrtReportTemplate)} to store an {@code MrrtReportTemplate} in the database.
      * 
-     * @param in the input stream of the mrrt template file
-     * @throws IOException if OpenmrsUtil.copyFile throws one
-     * @throws APIException if importing an invalid template file
-     * @should create mrrt report template in the database with metadata from input stream
-     * @should create report template file in report template home directory
+     * @param mrrtTemplate the mrrt template to be imported
+     * @throws IOException if one is thrown during parsing, validation or if FileUtils.writeStringToFile throws one
+     * @throws APIException if importing an invalid template
+     * @should create mrrt report template in the database and on the file system
+     * @should not create an mrrt report template in the database and store the template as file if given template is invalid
      */
     @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_REPORT_TEMPLATES)
-    public void importMrrtReportTemplate(InputStream in) throws IOException;
+    public void importMrrtReportTemplate(String mrrtTemplate) throws IOException;
     
     /**
      * Delete an {@code MrrtReportTemplate} from the database.

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceImpl.java
@@ -10,18 +10,15 @@
 package org.openmrs.module.radiology.report.template;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.List;
 
+import org.apache.commons.io.FileUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.openmrs.api.APIException;
 import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.radiology.RadiologyProperties;
-import org.openmrs.util.OpenmrsUtil;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
@@ -47,23 +44,20 @@ class MrrtReportTemplateServiceImpl extends BaseOpenmrsService implements MrrtRe
     }
     
     /**
-     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateService#importMrrtReportTemplate(InputStream)
+     * @see MrrtReportTemplateService#importMrrtReportTemplate(String)
      */
     @Override
     @Transactional
-    public void importMrrtReportTemplate(InputStream in) throws IOException {
-        final File tmp = File.createTempFile(java.util.UUID.randomUUID()
-                .toString(),
-            java.util.UUID.randomUUID()
-                    .toString());
-        OpenmrsUtil.copyFile(in, new FileOutputStream(tmp));
-        final MrrtReportTemplate template = parser.parse(new FileInputStream(tmp));
-        final File destinationFile = new File(radiologyProperties.getReportTemplateHome(), java.util.UUID.randomUUID()
+    public void importMrrtReportTemplate(String mrrtTemplate) throws IOException {
+        
+        final MrrtReportTemplate template = parser.parse(mrrtTemplate);
+        
+        final File destination = new File(radiologyProperties.getReportTemplateHome(), java.util.UUID.randomUUID()
                 .toString());
-        template.setPath(destinationFile.getAbsolutePath());
+        FileUtils.writeStringToFile(destination, mrrtTemplate);
+        
+        template.setPath(destination.getAbsolutePath());
         saveMrrtReportTemplate(template);
-        OpenmrsUtil.copyFile(new FileInputStream(tmp), new FileOutputStream(destinationFile));
-        in.close();
     }
     
     /**

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidator.java
@@ -9,24 +9,25 @@
  */
 package org.openmrs.module.radiology.report.template;
 
-import java.io.File;
+import org.openmrs.api.APIException;
+
 import java.io.IOException;
 
 /**
- * Validates {@code MrrtReportTemplate}.
- * 
+ * Validates an mrrt report template according to the IHE Management of Radiology Report Templates (MRRT).
+ *
  * @see MrrtReportTemplate
  */
 public interface MrrtReportTemplateValidator {
     
     
     /**
-     * Validate template file and make sure it follows {@code MRRT} standards.
+     * Validate an mrrt template according to the IHE standard.
      *
-     * @param templateFile the mrrt report template file been validated
-     * @throws IOException if one is thrown while reading template file
-     * @throws APIException if template file fails validation
-     * @should pass if template template file follows mrrt standards
+     * @param mrrtTemplate the mrrt report template to be validated
+     * @throws IOException
+     * @throws APIException if the mrrt template fails validation
+     * @should pass if template template follows mrrt standards
      * @should throw api exception if template does not have an html element
      * @should throw api exception if template has more than one html element
      * @should throw api exception if html element does not have a head element
@@ -49,5 +50,5 @@ public interface MrrtReportTemplateValidator {
      * @should throw api exception if html element does not have a body element
      * @should throw api exception if html element has more than one body element 
      */
-    public void validate(File templateFile) throws IOException;
+    public void validate(String mrrtTemplate) throws IOException;
 }

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/XsdMrrtReportTemplateValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/XsdMrrtReportTemplateValidator.java
@@ -11,6 +11,7 @@ package org.openmrs.module.radiology.report.template;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
@@ -18,6 +19,7 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jsoup.Jsoup;
@@ -47,12 +49,12 @@ public class XsdMrrtReportTemplateValidator implements MrrtReportTemplateValidat
     }
     
     /**
-     * @see org.openmrs.module.radiology.report.template.MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      */
     @Override
-    public void validate(File templateFile) throws IOException {
+    public void validate(String mrrtTemplate) throws IOException {
         
-        final Document document = Jsoup.parse(templateFile, null, "");
+        final Document document = Jsoup.parse(mrrtTemplate, "");
         final Elements metatags = document.getElementsByTag("meta");
         ValidationResult metaTagsValidationResult = metaTagsValidationEngine.run(metatags);
         metaTagsValidationResult.assertOk();
@@ -60,10 +62,10 @@ public class XsdMrrtReportTemplateValidator implements MrrtReportTemplateValidat
         final SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         final Schema schema;
         final Validator validator;
-        try {
+        try (InputStream in = IOUtils.toInputStream(mrrtTemplate)) {
             schema = factory.newSchema(getSchemaFile());
             validator = schema.newValidator();
-            validator.validate(new StreamSource(templateFile));
+            validator.validate(new StreamSource(in));
         }
         catch (SAXException e) {
             log.error(e.getMessage(), e);

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParserComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParserComponentTest.java
@@ -17,7 +17,9 @@ import static org.junit.Assert.assertThat;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,17 +73,53 @@ public class MrrtReportTemplateFileParserComponentTest extends BaseModuleContext
     }
     
     /**
-     * @see MrrtReportTemplateFileParser#parse()
+     * Get a files content as string.
+     *
+     * @param path the path to get the file content from
+     * @return the file content
+     */
+    private String getFileContent(String path) throws IOException {
+        
+        File file = getFile(path);
+        return getString(file);
+    }
+    
+    /**
+     * Get a file from the test resources.
+     *
+     * @param path the path to get the file from
+     * @return the file on given path
+     */
+    private File getFile(String path) {
+        return new File(getClass().getClassLoader()
+                .getResource(path)
+                .getFile());
+    }
+    
+    /**
+     * Get a file from the test resources.
+     *
+     * @param file the file to get the content from
+     * @return the file content
+     */
+    private String getString(File file) throws IOException {
+        String content = null;
+        try (InputStream in = new FileInputStream(file)) {
+            content = IOUtils.toString(in);
+        }
+        return content;
+    }
+    
+    /**
+     * @see MrrtReportTemplateFileParser#parse(String)
      * @verifies return an mrrt template object if file is valid
      */
     @Test
     public void parse_shouldReturnAnMrrtTemplateObjectIfFileIsValid() throws Exception {
-        File file = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html")
-                .getFile());
         
-        FileInputStream in = new FileInputStream(file);
-        MrrtReportTemplate template = parser.parse(in);
+        String templateContent = getFileContent("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html");
+        
+        MrrtReportTemplate template = parser.parse(templateContent);
         
         assertNotNull(template);
         assertThat(template.getCharset(), is(CHARSET));
@@ -99,18 +137,15 @@ public class MrrtReportTemplateFileParserComponentTest extends BaseModuleContext
     }
     
     /**
-     * @see MrrtReportTemplateFileParser#parse(java.io.InputStream)
+     * @see MrrtReportTemplateFileParser#parse(String)
      * @verifies store terms element in template object if they match a concept reference term in openmrs
      */
     @Test
     public void parse_shouldStoreTermsElementInTemplateObjectIfTheyMatchAconceptReferenceTermInOpenmrs() throws IOException {
         
-        File file = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html")
-                .getFile());
+        String templateContent = getFileContent("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html");
         
-        FileInputStream in = new FileInputStream(file);
-        MrrtReportTemplate template = parser.parse(in);
+        MrrtReportTemplate template = parser.parse(templateContent);
         
         assertNotNull(template.getTerms());
         assertThat(template.getTerms()
@@ -127,36 +162,31 @@ public class MrrtReportTemplateFileParserComponentTest extends BaseModuleContext
     }
     
     /**
-     * @see MrrtReportTemplateFileParser#parse(java.io.InputStream)
+     * @see MrrtReportTemplateFileParser#parse(String)
      * @verifies skip terms element in template file if no corresponding concept reference term was found
      */
     @Test
     public void parse_skipTermElementsInTemplateFileIfNoCorrespondingConceptReferenceTermWasFound() throws Exception {
         
-        File file = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/CTChestAbdomen-missingReferenceTermsForTemplateAttributesTermElements.html")
-                .getFile());
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/CTChestAbdomen-missingReferenceTermsForTemplateAttributesTermElements.html");
         
-        FileInputStream in = new FileInputStream(file);
-        MrrtReportTemplate template = parser.parse(in);
+        MrrtReportTemplate template = parser.parse(templateContent);
         
         assertNull(template.getTerms());
     }
     
     /**
-     * @see MrrtReportTemplateFileParser#parse(java.io.InputStream)
+     * @see MrrtReportTemplateFileParser#parse(String)
      * @verifies ignore case when searching for a matching concept source
      */
     @Test
     public void parse_shouldIgnoreCaseWhenSearchingForAMatchingConceptSource() throws Exception {
         
-        File file = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen-schemeIsInLowerCase.html")
-                .getFile());
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen-schemeIsInLowerCase.html");
         
-        FileInputStream in = new FileInputStream(file);
-        MrrtReportTemplate template = parser.parse(in);
+        MrrtReportTemplate template = parser.parse(templateContent);
         
         assertNotNull(template.getTerms());
         assertThat(template.getTerms()

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidatorTest.java
@@ -10,7 +10,11 @@
 package org.openmrs.module.radiology.report.template;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -31,302 +35,351 @@ public class MrrtReportTemplateValidatorTest extends BaseModuleContextSensitiveT
     public ExpectedException expectedException = ExpectedException.none();
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
-     * @verifies pass if template template file follows mrrt standards
+     * Get a files content as string.
+     *
+     * @param path the path to get the file content from
+     * @return the file content
      */
-    @Test
-    public void validate_shouldPassIfTemplateTemplateFileFollowsMrrtStandards() throws Exception {
-        File validTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html")
-                .getFile());
-        validator.validate(validTemplate);
+    private String getFileContent(String path) throws IOException {
+        
+        File file = getFile(path);
+        return getString(file);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * Get a file from the test resources.
+     *
+     * @param path the path to get the file from
+     * @return the file on given path
+     */
+    private File getFile(String path) {
+        return new File(getClass().getClassLoader()
+                .getResource(path)
+                .getFile());
+    }
+    
+    /**
+     * Get a file from the test resources.
+     *
+     * @param file the file to get the content from
+     * @return the file content
+     */
+    private String getString(File file) throws IOException {
+        String content = null;
+        try (InputStream in = new FileInputStream(file)) {
+            content = IOUtils.toString(in);
+        }
+        return content;
+    }
+    
+    /**
+     * @see MrrtReportTemplateValidator#validate(String)
+     * @verifies pass if template template follows mrrt standards
+     */
+    @Test
+    public void validate_shouldPassIfTemplateTemplateFileFollowsMrrtStandards() throws Exception {
+        
+        String templateContent = getFileContent("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html");
+        
+        validator.validate(templateContent);
+    }
+    
+    /**
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if template does not have an html element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfTemplateDoesNotHaveAnHtmlElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-missingHtmlElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-missingHtmlElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if template has more than one html element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfTemplateHasMoreThanOneHtmlElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleHtmlElements.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleHtmlElements.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if html element does not have a head element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHtmlElementDoesNotHaveAHeadElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noHeadElementFound.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noHeadElementFound.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if html element has more than one head element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHtmlElementHasMoreThanOneHeadElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleHeadElements.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleHeadElements.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if head element does not have a title element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHeadElementDoesNotHaveATitleElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noTitleElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noTitleElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if head element has more than one title element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHeadElementHasMoreThanOneTitleElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleTitleElements.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleTitleElements.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if head element does not have a meta element with charset attribute
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHeadElementDoesNotHaveAMetaElementWithCharsetAttribute() throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noMetaElementWithCharsetAttribute.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noMetaElementWithCharsetAttribute.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if head element has more than one meta element with charset attribute
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHeadElementHasMoreThanOneMetaElementWithCharsetAttribute()
             throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleMetaElementsWithCharsetAttribute.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleMetaElementsWithCharsetAttribute.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if head element does not have one or more meta elements denoting dublin core attributes
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHeadElementDoesNotHaveOneOrMoreMetaElementsDenotingDublinCoreAttributes()
             throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noMetaElementDenotingDublinCoreAttributes.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noMetaElementDenotingDublinCoreAttributes.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if head element does not have script element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHeadElementDoesNotHaveScriptElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noScriptElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noScriptElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if head element has more than one script element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHeadElementHasMoreThanOneScriptElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleScriptElements.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleScriptElements.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if script element does not have a template attributes element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfScriptElementDoesNotHaveATemplateAttributesElement() throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noTemplateAttributesElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noTemplateAttributesElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if script element has more than one template attributes element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfScriptElementHasMoreThanOneTemplateAttributesElement() throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleTemplateAttributesElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleTemplateAttributesElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if coding schemes element does not have at least one coding scheme element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfCodingSchemesElementDoesNotHaveAtLeastOneCodingSchemeElement()
             throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-codingSchemesShouldHaveAtLeastOneCodingSchemeElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-codingSchemesShouldHaveAtLeastOneCodingSchemeElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if term element does not have a code element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfTermElementDoesNotHaveACodeElement() throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-termElementShouldHaveOneCodeElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-termElementShouldHaveOneCodeElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if term element has more than one code element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfTermElementHasMoreThanOneCodeElement() throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleCodeElementsInTermElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleCodeElementsInTermElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if code element lacks one of meaning scheme or value attribute
      */
     @Test
     public void validate_shouldThrowApiExceptionIfCodeElementLacksOneOfMeaningSchemeOrValueAttribute() throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-missingAttributesInCodeElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-missingAttributesInCodeElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if template attributes element does not have a coded content element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfTemplateAttributesElementDoesNotHaveACodedContentElement()
             throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-missingAttributesInCodeElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource(
-                    "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-missingAttributesInCodeElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if template attributes element has more than one coded content element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfTemplateAttributesElementHasMoreThanOneCodedContentElement()
             throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleCodedContent.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleCodedContent.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if html element does not have a body element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHtmlElementDoesNotHaveABodyElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noBodyElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-noBodyElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
     
     /**
-     * @see MrrtReportTemplateValidator#validate(File)
+     * @see MrrtReportTemplateValidator#validate(String)
      * @verifies throw api exception if html element has more than one body element
      */
     @Test
     public void validate_shouldThrowApiExceptionIfHtmlElementHasMoreThanOneBodyElement() throws Exception {
+        
+        String templateContent =
+                getFileContent("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleBodyElement.html");
+        
         expectedException.expect(APIException.class);
-        final File invalidTemplate = new File(getClass().getClassLoader()
-                .getResource("mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-multipleBodyElement.html")
-                .getFile());
-        validator.validate(invalidTemplate);
+        validator.validate(templateContent);
     }
 }

--- a/omod/src/main/java/org/openmrs/module/radiology/report/template/web/RadiologyDashboardReportTemplatesTabController.java
+++ b/omod/src/main/java/org/openmrs/module/radiology/report/template/web/RadiologyDashboardReportTemplatesTabController.java
@@ -10,9 +10,11 @@
 package org.openmrs.module.radiology.report.template.web;
 
 import java.io.IOException;
+import java.io.InputStream;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.apache.commons.io.IOUtils;
 import org.openmrs.api.APIException;
 import org.openmrs.module.radiology.report.template.MrrtReportTemplateService;
 import org.openmrs.module.radiology.report.template.MrrtReportTemplateValidationException;
@@ -84,8 +86,9 @@ public class RadiologyDashboardReportTemplatesTabController {
             return modelAndView;
         }
         
-        try {
-            mrrtReportTemplateService.importMrrtReportTemplate(templateFile.getInputStream());
+        try (InputStream in = templateFile.getInputStream()) {
+            String mrrtTemplate = IOUtils.toString(in);
+            mrrtReportTemplateService.importMrrtReportTemplate(mrrtTemplate);
             request.getSession()
                     .setAttribute(WebConstants.OPENMRS_MSG_ATTR, "radiology.MrrtReportTemplate.imported");
         }


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Replace parameter type from InputStream to String in
interfaces for MrrtReportTemplateService.importMrrtReportTemplate
MrrtReportTemplateValidator.validate and MrrtReportTemplateFileParser.parse
since template files are expected to be < 120kB and this greatly
simplifies handling as InputStreams can only be read once.

* change import, parse, validate iface to String instead of InputStream
* simplify tests by extracting repetivite things (getFile,
getFileContent) for test mrrt template files into helper methods
* improve RadiologyDashboardReportTemplatesTabControllerTest verify
service calls and use springs MockMultipartFile
* improve javadoc im MrrtReportTemplateService and tests
* merge tests of MrrtReportTemplateService.importMrrtReportTemplate
ensuring creation in db and filesystem into one test
* make sure that the InputStream's we open are closed via
try-with-resource syntax
* use apache commons FileUtils.writeStringToFile to write template to
file instead of OpenmrsUtils