### PR TITLE
importMrrtReportTemplate returns MrrtReportTemplate

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateService.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateService.java
@@ -48,13 +48,14 @@ public interface MrrtReportTemplateService extends OpenmrsService {
      * Calls {@link #saveMrrtReportTemplate(MrrtReportTemplate)} to store an {@code MrrtReportTemplate} in the database.
      * 
      * @param mrrtTemplate the mrrt template to be imported
+     * @return the saved mrrt template
      * @throws IOException if one is thrown during parsing, validation or if FileUtils.writeStringToFile throws one
      * @throws APIException if importing an invalid template
      * @should create mrrt report template in the database and on the file system
      * @should not create an mrrt report template in the database and store the template as file if given template is invalid
      */
     @Authorized(RadiologyPrivileges.ADD_RADIOLOGY_REPORT_TEMPLATES)
-    public void importMrrtReportTemplate(String mrrtTemplate) throws IOException;
+    public MrrtReportTemplate importMrrtReportTemplate(String mrrtTemplate) throws IOException;
     
     /**
      * Delete an {@code MrrtReportTemplate} from the database.

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceImpl.java
@@ -48,7 +48,7 @@ class MrrtReportTemplateServiceImpl extends BaseOpenmrsService implements MrrtRe
      */
     @Override
     @Transactional
-    public void importMrrtReportTemplate(String mrrtTemplate) throws IOException {
+    public MrrtReportTemplate importMrrtReportTemplate(String mrrtTemplate) throws IOException {
         
         final MrrtReportTemplate template = parser.parse(mrrtTemplate);
         
@@ -57,7 +57,7 @@ class MrrtReportTemplateServiceImpl extends BaseOpenmrsService implements MrrtRe
         FileUtils.writeStringToFile(destination, mrrtTemplate);
         
         template.setPath(destination.getAbsolutePath());
-        saveMrrtReportTemplate(template);
+        return saveMrrtReportTemplate(template);
     }
     
     /**

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateServiceComponentTest.java
@@ -321,9 +321,8 @@ public class MrrtReportTemplateServiceComponentTest extends BaseModuleContextSen
         String sourcePath = "mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html";
         String template = getFileContent(sourcePath);
         
-        mrrtReportTemplateService.importMrrtReportTemplate(template);
+        MrrtReportTemplate saved = mrrtReportTemplateService.importMrrtReportTemplate(template);
         
-        MrrtReportTemplate saved = mrrtReportTemplateService.getMrrtReportTemplateByIdentifier(TEMPLATE_IDENTIFIER);
         assertNotNull(saved);
         assertThat(saved.getDcTermsIdentifier(), is(TEMPLATE_IDENTIFIER));
         


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
MrrtReportTemplateService.importMrrtReportTemplate now returns the
saved MrrtReportTemplate object which allows client code to for example
redirect the UI to the templates page after the import