### PR TITLE
Demo data: add missing privileges to reading phyisican

### DIFF
--- a/acceptanceTest/resources/demo-data.sql
+++ b/acceptanceTest/resources/demo-data.sql
@@ -152,6 +152,8 @@ INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Delete Radi
 INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Edit Radiology Reports');
 INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Get Care Settings');
 INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Get Concepts');
+INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Get Concept Sources');
+INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Get Concept Reference Terms');
 INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Get Encounter Roles');
 INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Get Encounters');
 INSERT INTO `role_privilege` VALUES ('Radiology: Reading physician','Get Orders');


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->
Role reading phyisican was missing privilege to get concept sources and
reference terms, which are needed when importing an MRRT Template which
has terms from a coding_scheme which matches a concept source