### PR TITLE
RAD-385 MrrtReportTemplate.dcTermsDate should be a Date object not a string

### DIFF
--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplate.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplate.java
@@ -9,6 +9,7 @@
  */
 package org.openmrs.module.radiology.report.template;
 
+import java.util.Date;
 import java.util.Set;
 
 import org.openmrs.BaseOpenmrsData;
@@ -44,7 +45,7 @@ public class MrrtReportTemplate extends BaseOpenmrsData {
     
     private String dcTermsLicense;
     
-    private String dcTermsDate;
+    private Date dcTermsDate;
     
     private String dcTermsCreator;
     
@@ -148,11 +149,19 @@ public class MrrtReportTemplate extends BaseOpenmrsData {
         this.dcTermsLicense = dcTermsLicense;
     }
     
-    public String getDcTermsDate() {
-        return dcTermsDate;
+    /**
+     * Get dcterms date property of an MRRT report template.
+     *
+     * @return Date date property of the MRRT report template or null if no date was set
+     */
+    public Date getDcTermsDate() {
+        if (dcTermsDate == null) {
+            return dcTermsDate;
+        }
+        return new Date(dcTermsDate.getTime());
     }
     
-    public void setDcTermsDate(String dcTermsDate) {
+    public void setDcTermsDate(Date dcTermsDate) {
         this.dcTermsDate = dcTermsDate;
     }
     

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateConstants.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateConstants.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.report.template;
+
+/**
+ * Utility class that contains constants which are used within this module.
+ */
+public final class MrrtReportTemplateConstants {
+    
+    
+    /**
+     * Constant for dcterms.date format for an {@code MrrtReportTemplate}.
+     *
+     * See table "Table 4.105.4.1.2-1: HTTP Query Parameters" on page 27 of
+     * the MRRT Standards document.
+     */
+    public static final String DATE_FORMAT = "yyyy-MM-dd";
+    
+    private MrrtReportTemplateConstants() {
+        // Utility class not meant to be instantiated.
+    }
+    
+}

--- a/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidator.java
+++ b/api/src/main/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidator.java
@@ -50,6 +50,7 @@ public interface MrrtReportTemplateValidator {
      * @should throw api exception if html element does not have a body element
      * @should throw api exception if html element has more than one body element 
      * @should catch all violation errors and throw an mrrt report template exception
+     * @should throw an mrrt report template exception if dcterms date of template file is not valid
      */
     public void validate(String mrrtTemplate) throws IOException;
 }

--- a/api/src/main/resources/MrrtReportTemplate.hbm.xml
+++ b/api/src/main/resources/MrrtReportTemplate.hbm.xml
@@ -33,7 +33,7 @@
 		<property name="dcTermsPublisher" column="dcterms_publisher" type="java.lang.String"/>
 		<property name="dcTermsRights" column="dcterms_rights" type="java.lang.String"/>
 		<property name="dcTermsLicense" column="dcterms_license" type="java.lang.String"/>
-		<property name="dcTermsDate" column="dcterms_date" type="java.lang.String"/>
+		<property name="dcTermsDate" column="dcterms_date" type="java.util.Date"/>
 		<property name="dcTermsCreator" column="dcterms_creator" type="java.lang.String"/>
 		
 		<!-- bi-directional many-to-many association to ConceptReferenceTerm -->

--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -568,4 +568,8 @@
 			<column name="uuid" value="d9015276-b7b1-45f1-ad72-323896e75a52" />
 		</insert>
 	</changeSet>
+	<changeSet id="radiology-46" author="ivange94">
+		<comment>Change the datatype of dcterms_date from varchar(32) to date</comment>
+		<modifyDataType tableName="radiology_report_template" columnName="dcterms_date" newDataType="datetime"/>
+	</changeSet>
 </databaseChangeLog>

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParserComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateFileParserComponentTest.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -120,6 +122,7 @@ public class MrrtReportTemplateFileParserComponentTest extends BaseModuleContext
         String templateContent = getFileContent("mrrttemplates/ihe/connectathon/2015/CTChestAbdomen.html");
         
         MrrtReportTemplate template = parser.parse(templateContent);
+        Date dcTermsDate = new SimpleDateFormat(MrrtReportTemplateConstants.DATE_FORMAT).parse(TEST_DCTERMS_DATE);
         
         assertNotNull(template);
         assertThat(template.getCharset(), is(CHARSET));
@@ -132,7 +135,7 @@ public class MrrtReportTemplateFileParserComponentTest extends BaseModuleContext
         assertThat(template.getDcTermsPublisher(), is(TEST_DCTERMS_PUBLISHER));
         assertThat(template.getDcTermsRights(), is(TEST_DCTERMS_RIGHTS));
         assertThat(template.getDcTermsLicense(), is(TEST_DCTERMS_LICENSE));
-        assertThat(template.getDcTermsDate(), is(TEST_DCTERMS_DATE));
+        assertThat(template.getDcTermsDate(), is(dcTermsDate));
         assertThat(template.getDcTermsCreator(), is(TEST_DCTERMS_CREATOR));
     }
     

--- a/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidatorComponentTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/template/MrrtReportTemplateValidatorComponentTest.java
@@ -407,4 +407,17 @@ public class MrrtReportTemplateValidatorComponentTest extends BaseModuleContextS
                 is(4));
         }
     }
+    
+    /**
+     * @see MrrtReportTemplateValidator#validate(String)
+     * @verifies throw an mrrt report template exception if dcterms date of template file is not valid
+     */
+    @Test
+    public void validate_shouldThrowAnMrrtReportTemplateExceptionIfDctermsDateOfTemplateFileIsNotValid() throws Exception {
+        
+        String templateContent = getFileContent(
+            "mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-dcTermsDateIsNotAValidDateObject.html");
+        expectedException.expect(MrrtReportTemplateValidationException.class);
+        validator.validate(templateContent);
+    }
 }

--- a/api/src/test/resources/mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-dcTermsDateIsNotAValidDateObject.html
+++ b/api/src/test/resources/mrrttemplates/ihe/connectathon/2015/invalidMrrtReportTemplate-dcTermsDateIsNotAValidDateObject.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>CT Chest-Abdomen</title>
+		<meta charset="UTF-8"/>
+		<meta name="dcterms.title" content="CT Chest-Abdomen"/>
+		<meta name="dcterms.identifier" content="1.3.6.1.4.1.21367.13.199.1015"/>
+        <meta name="dcterms.description" content="CT Chest-Abdomen"/>
+		<meta name="dcterms.type" content="IMAGE_REPORT_TEMPLATE"/>
+		<meta name="dcterms.publisher" content="IHE CAT Publisher"/>
+		<meta name="dcterms.rights" content="IHE Connectathon Rights"/>
+		<meta name="dcterms.license" content="IHE Connectathon License"/>
+		<meta name="dcterms.date" content="2013"/>
+		<meta name="dcterms.creator" content="Creator James, et al."/>
+		<meta name="dcterms.language" content="en"/>
+		<link rel="stylesheet" type="text/css" href="IHE_Template_Style.css" />
+		<script type="text/xml">
+			<template_attributes>
+				<top-level-flag>true</top-level-flag> 
+				<status>ACTIVE</status>
+				<coding_schemes>					  <coding_scheme name="RADLEX" designator="2.16.840.1.113883.6.256" />                </coding_schemes>					
+				<term type="modality">
+					<code meaning="computed tomography" value="RID10321" scheme="RADLEX" />
+				</term>
+				<term type="body part">
+					<code meaning="abdomen" value="RID56" scheme="RADLEX" />			
+				</term>
+				<term type="body part">
+					<code meaning="thorax" value="RID1243" scheme="RADLEX" />			
+				</term>
+				<coded_content> </coded_content>
+			</template_attributes>
+		</script>
+	</head>
+	<body>
+		<section data-section-name="The Only Section">
+			<header class="level1">Section Header</header>			
+				<p> This is the CT Chest-Abdomen report template</p>
+		</section>
+	</body>
+</html>

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -181,6 +181,7 @@
 @MODULE_ID@.MrrtReportTemplate.not.imported.empty=Failed to import report template because it was empty
 @MODULE_ID@.MrrtReportTemplate.validation.error.meta.charset.occurence=Template file should have exactly one 'meta' element with attribute 'charset'
 @MODULE_ID@.MrrtReportTemplate.validation.error.meta.dublinCore.missing=Template file should have at least one 'meta' element encoding dublin core attributes
+@MODULE_ID@.MrrtReportTemplate.validation.error.date.invalid=dcterms.date needs to be of format yyyy-MM-dd like for example 2016-01-24
 
 @MODULE_ID@.patientId=Patient Id
 @MODULE_ID@.patientFullName=Patient Full Name


### PR DESCRIPTION
<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

RAD-385 MrrtReportTemplate.dcTermsDate should be a Date object not a string
## Description

<!--- Describe your changes in detail -->
- Changed type of DcTermsDate from String to Date
- Implemented validation for dcterms.date. And make it to fail if the date could not be parsed from string to a java Date object
- Added unit test for the validate method
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue
first -->

<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->

<!--- Please link to the issue here: -->

see https://issues.openmrs.org/browse/RAD-385
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My pull request only contains one single commit.
- [x] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
