### PR TITLE
RAD-389: Use maven to generate javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,6 +270,39 @@
 
 	<profiles>
 		<profile>
+		  <id>doclint-java8-disable</id>
+		  <activation>
+		    <jdk>[1.8,)</jdk>
+		  </activation>
+		  <build>
+		    <plugins>
+		      <plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-javadoc-plugin</artifactId>
+		        <configuration>
+		          <additionalparam>-Xdoclint:none</additionalparam>
+		        </configuration>
+		      </plugin>
+		      <plugin>
+		        <groupId>org.apache.maven.plugins</groupId>
+		        <artifactId>maven-site-plugin</artifactId>
+		        <version>3.3</version>
+		        <configuration>
+		          <reportPlugins>
+		            <plugin>
+		              <groupId>org.apache.maven.plugins</groupId>
+		              <artifactId>maven-javadoc-plugin</artifactId>
+		              <configuration>
+		                <additionalparam>-Xdoclint:none</additionalparam>
+		              </configuration>
+		            </plugin>
+		          </reportPlugins>
+		        </configuration>
+		      </plugin>
+		    </plugins>
+		  </build>
+		</profile>
+		<profile>
 			<id>ci</id>
 			<activation>
 				<property>


### PR DESCRIPTION
<!--- Provide PR Title above as: '' -->
RAD-389 Use maven to generate javadoc
## Description
<!--- Describe your changes in detail -->
* Added the code for the maven-javadoc plugin as a profile in the the project's pom.xml
* Javadoc can be  generated by running the command **mvn javadoc:javadoc**

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-389

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [X] My pull request only contains one single commit.
- [X] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [X] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [X] My code follows the code style of this project.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


