### PR TITLE
fix omod Dockerfile URLs to dependencies

### DIFF
--- a/omod/src/main/docker/Dockerfile
+++ b/omod/src/main/docker/Dockerfile
@@ -2,10 +2,10 @@ FROM teleivo/openmrs-platform:2.0.0-1
 
 # Get radiology modules dependencies
 RUN curl -L \
-    "http://mavenrepo.openmrs.org/nexus/service/local/repositories/modules/content/org/openmrs/module/legacyui-omod/1.2/legacyui-omod-1.2.jar" \
+    "https://openmrs.jfrog.io/openmrs/omods/omod/legacyui-1.2.omod" \
     -o "${OPENMRS_MODULES}/legacyui-1.2.omod"
 RUN curl -L \
-    "http://mavenrepo.openmrs.org/nexus/service/local/repositories/modules/content/org/openmrs/module/webservices.rest-omod/2.16/webservices.rest-omod-2.16.jar" \
-    -o "${OPENMRS_MODULES}/webservices.rest-2.16.omod"
+    "https://openmrs.jfrog.io/openmrs/omods/omod/webservices.rest-2.17.omod" \
+    -o "${OPENMRS_MODULES}/webservices.rest-2.17.omod"
 
 COPY maven/*.omod ${OPENMRS_MODULES}/


### PR DESCRIPTION
openmrs retired its nexus repository and now uses artifactory and
bintray from jfrog.

* fixed the URLs to get the legacyui and webservices.rest module omods
in the Dockerfile which creates the radiology modules docker image
* needed to update the webservices.rest from 2.16 to 2.17 since the
former wasnt on jfrog

<!--- Provide PR Title above as: 'RAD-JiraIssueNumber JiraIssueTitle' -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue
first -->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
see https://issues.openmrs.org/browse/RAD-

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [ ] My pull request only contains one single commit.
- [ ] My pull request is based on the latest master branch
  `git pull --rebase upstream master`.
- [ ] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [ ] My code follows the code style of this project.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

