### PR TITLE
Extract a test helper class for testing Validators

### DIFF
--- a/api/src/test/java/org/openmrs/module/radiology/modality/RadiologyModalityValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/modality/RadiologyModalityValidatorTest.java
@@ -13,6 +13,8 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.openmrs.module.radiology.test.ValidatorAssertions.assertSingleGeneralError;
+import static org.openmrs.module.radiology.test.ValidatorAssertions.assertSingleNullErrorInField;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,20 +31,25 @@ import liquibase.util.StringUtils;
 public class RadiologyModalityValidatorTest extends BaseModuleContextSensitiveTest {
     
     
-    RadiologyModality radiologyModality;
+    private RadiologyModalityValidator radiologyModalityValidator;
+    
+    private RadiologyModality radiologyModality;
+    
+    private Errors errors;
     
     @Before
     public void setUp() {
+        radiologyModalityValidator = new RadiologyModalityValidator();
         
         radiologyModality = new RadiologyModality();
         radiologyModality.setAeTitle("CT01");
         radiologyModality.setName("Medical Corp Excelencium XT5980-Z");
+        
+        errors = new BindException(radiologyModality, "radiologyModality");
     }
     
     @Test
     public void shouldReturnFalseForOtherObjectTypes() throws Exception {
-        
-        RadiologyModalityValidator radiologyModalityValidator = new RadiologyModalityValidator();
         
         assertFalse(radiologyModalityValidator.supports(Object.class));
     }
@@ -50,118 +57,75 @@ public class RadiologyModalityValidatorTest extends BaseModuleContextSensitiveTe
     @Test
     public void shouldReturnTrueForRadiologyModalityObjects() throws Exception {
         
-        RadiologyModalityValidator radiologyModalityValidator = new RadiologyModalityValidator();
-        
         assertTrue(radiologyModalityValidator.supports(RadiologyModality.class));
     }
     
     @Test
     public void shouldFailValidationIfRadiologyModalityIsNull() throws Exception {
         
-        Errors errors = new BindException(radiologyModality, "radiologyModality");
+        radiologyModalityValidator.validate(null, errors);
         
-        new RadiologyModalityValidator().validate(null, errors);
-        
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.general"));
+        assertSingleGeneralError(errors);
     }
     
     @Test
-    public void shouldFailValidationIfAeTitleIsNullOrEmptyOrWhitespacesOnly() throws Exception {
+    public void shouldFailValidationIfAeTitleIsNull() throws Exception {
         
         radiologyModality.setAeTitle(null);
         
-        Errors errors = new BindException(radiologyModality, "radiologyModality");
+        radiologyModalityValidator.validate(radiologyModality, errors);
         
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
-        
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("aeTitle"));
-        
-        radiologyModality.setAeTitle("");
-        
-        errors = new BindException(radiologyModality, "radiologyModality");
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
-        
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("aeTitle"));
-        
-        radiologyModality.setAeTitle("  ");
-        
-        errors = new BindException(radiologyModality, "radiologyModality");
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
-        
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("aeTitle"));
+        assertSingleNullErrorInField(errors, "aeTitle");
     }
     
     @Test
-    public void shouldFailValidationIfNameIsNullOrEmptyOrWhitespacesOnly() throws Exception {
+    public void shouldFailValidationIfAeTitleIsEmpty() throws Exception {
+        
+        radiologyModality.setAeTitle("");
+        
+        radiologyModalityValidator.validate(radiologyModality, errors);
+        
+        assertSingleNullErrorInField(errors, "aeTitle");
+    }
+    
+    @Test
+    public void shouldFailValidationIfAeTitleIsWhitespacesOnly() throws Exception {
+        
+        radiologyModality.setAeTitle("  ");
+        
+        radiologyModalityValidator.validate(radiologyModality, errors);
+        
+        assertSingleNullErrorInField(errors, "aeTitle");
+    }
+    
+    @Test
+    public void shouldFailValidationIfNameIsNull() throws Exception {
         
         radiologyModality.setName(null);
         
-        Errors errors = new BindException(radiologyModality, "radiologyModality");
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
+        radiologyModalityValidator.validate(radiologyModality, errors);
         
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("name"));
+        assertSingleNullErrorInField(errors, "name");
+    }
+    
+    @Test
+    public void shouldFailValidationIfNameIsEmpty() throws Exception {
         
         radiologyModality.setName("");
         
-        errors = new BindException(radiologyModality, "radiologyModality");
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
+        radiologyModalityValidator.validate(radiologyModality, errors);
         
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("name"));
+        assertSingleNullErrorInField(errors, "name");
+    }
+    
+    @Test
+    public void shouldFailValidationIfNameIsWhitespacesOnly() throws Exception {
         
         radiologyModality.setName("  ");
         
-        errors = new BindException(radiologyModality, "radiologyModality");
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
+        radiologyModalityValidator.validate(radiologyModality, errors);
         
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("name"));
+        assertSingleNullErrorInField(errors, "name");
     }
     
     @Test
@@ -169,17 +133,9 @@ public class RadiologyModalityValidatorTest extends BaseModuleContextSensitiveTe
         
         radiologyModality.setRetired(true);
         
-        Errors errors = new BindException(radiologyModality, "radiologyModality");
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
+        radiologyModalityValidator.validate(radiologyModality, errors);
         
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("retireReason"));
+        assertSingleNullErrorInField(errors, "retireReason");
     }
     
     @Test
@@ -190,8 +146,7 @@ public class RadiologyModalityValidatorTest extends BaseModuleContextSensitiveTe
         radiologyModality.setDescription(StringUtils.repeat("1", 256));
         radiologyModality.setRetireReason(StringUtils.repeat("1", 256));
         
-        Errors errors = new BindException(radiologyModality, "radiologyModality");
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
+        radiologyModalityValidator.validate(radiologyModality, errors);
         
         assertTrue(errors.hasErrors());
         ObjectError err = (errors.getAllErrors()).get(0);
@@ -207,9 +162,7 @@ public class RadiologyModalityValidatorTest extends BaseModuleContextSensitiveTe
     @Test
     public void shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
         
-        Errors errors = new BindException(radiologyModality, "radiologyModality");
-        
-        new RadiologyModalityValidator().validate(radiologyModality, errors);
+        radiologyModalityValidator.validate(radiologyModality, errors);
         
         assertFalse(errors.hasErrors());
     }

--- a/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
+++ b/api/src/test/java/org/openmrs/module/radiology/report/RadiologyReportValidatorTest.java
@@ -9,10 +9,10 @@
  */
 package org.openmrs.module.radiology.report;
 
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.openmrs.module.radiology.test.ValidatorAssertions.assertSingleGeneralError;
+import static org.openmrs.module.radiology.test.ValidatorAssertions.assertSingleNullErrorInField;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -29,14 +29,19 @@ import org.springframework.validation.Errors;
 public class RadiologyReportValidatorTest {
     
     
-    RadiologyOrder radiologyOrder;
+    private RadiologyReportValidator radiologyReportValidator;
     
-    RadiologyStudy radiologyStudy;
+    private RadiologyOrder radiologyOrder;
     
-    RadiologyReport radiologyReport;
+    private RadiologyStudy radiologyStudy;
+    
+    private RadiologyReport radiologyReport;
+    
+    private Errors errors;
     
     @Before
     public void setUp() {
+        radiologyReportValidator = new RadiologyReportValidator();
         
         radiologyOrder = new RadiologyOrder();
         radiologyStudy = new RadiologyStudy();
@@ -45,12 +50,12 @@ public class RadiologyReportValidatorTest {
         radiologyReport = new RadiologyReport(radiologyOrder);
         radiologyReport.setPrincipalResultsInterpreter(new Provider());
         radiologyReport.setBody("Found a broken bone.");
+        
+        errors = new BindException(radiologyReport, "radiologyReport");
     }
     
     @Test
     public void shouldReturnFalseForOtherObjectTypes() throws Exception {
-        
-        RadiologyReportValidator radiologyReportValidator = new RadiologyReportValidator();
         
         assertFalse(radiologyReportValidator.supports(Object.class));
     }
@@ -58,98 +63,61 @@ public class RadiologyReportValidatorTest {
     @Test
     public void shouldReturnTrueForRadiologyReportObjects() throws Exception {
         
-        RadiologyReportValidator radiologyReportValidator = new RadiologyReportValidator();
-        
         assertTrue(radiologyReportValidator.supports(RadiologyReport.class));
     }
     
     @Test
     public void shouldFailValidationIfRadiologyReportIsNull() throws Exception {
         
-        Errors errors = new BindException(radiologyReport, "radiologyReport");
+        radiologyReportValidator.validate(null, errors);
         
-        new RadiologyReportValidator().validate(null, errors);
-        
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.general"));
+        assertSingleGeneralError(errors);
     }
     
     @Test
-    public void shouldFailValidationIfPrincipalResultsInterpreterIsNullOrEmptyOrWhitespacesOnly() throws Exception {
+    public void shouldFailValidationIfPrincipalResultsInterpreterIsNull() throws Exception {
         
         radiologyReport.setPrincipalResultsInterpreter(null);
         
-        Errors errors = new BindException(radiologyReport, "radiologyReport");
+        radiologyReportValidator.validate(radiologyReport, errors);
         
-        new RadiologyReportValidator().validate(radiologyReport, errors);
-        
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("principalResultsInterpreter"));
+        assertSingleNullErrorInField(errors, "principalResultsInterpreter");
     }
     
     @Test
-    public void shouldFailValidationIfReportBodyIsNullOrEmptyOrWhitespacesOnly() throws Exception {
+    public void shouldFailValidationIfReportBodyIsNull() throws Exception {
         
         radiologyReport.setBody(null);
-        Errors errors = new BindException(radiologyReport, "radiologyReport");
         
-        new RadiologyReportValidator().validate(radiologyReport, errors);
+        radiologyReportValidator.validate(radiologyReport, errors);
         
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("body"));
+        assertSingleNullErrorInField(errors, "body");
+    }
+    
+    @Test
+    public void shouldFailValidationIfReportBodyIsEmpty() throws Exception {
         
         radiologyReport.setBody("");
         
-        errors = new BindException(radiologyReport, "radiologyReport");
-        new RadiologyReportValidator().validate(radiologyReport, errors);
+        radiologyReportValidator.validate(radiologyReport, errors);
         
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("body"));
+        assertSingleNullErrorInField(errors, "body");
+    }
+    
+    @Test
+    public void shouldFailValidationIfReportBodyIsWhitespacesOnly() throws Exception {
         
         radiologyReport.setBody("  ");
         
-        errors = new BindException(radiologyReport, "radiologyReport");
-        new RadiologyReportValidator().validate(radiologyReport, errors);
+        radiologyReportValidator.validate(radiologyReport, errors);
         
-        assertTrue(errors.hasErrors());
-        assertThat(errors.getAllErrors()
-                .size(),
-            is(1));
-        assertThat((errors.getAllErrors()).get(0)
-                .getCode(),
-            is("error.null"));
-        assertTrue(errors.hasFieldErrors("body"));
+        assertSingleNullErrorInField(errors, "body");
     }
     
     @Test
     public void shouldPassValidationIfAllFieldsAreCorrect() throws Exception {
         
-        Errors errors = new BindException(radiologyReport, "radiologyReport");
-        
-        new RadiologyReportValidator().validate(radiologyReport, errors);
+        radiologyReportValidator.validate(radiologyReport, errors);
         
         assertFalse(errors.hasErrors());
     }

--- a/api/src/test/java/org/openmrs/module/radiology/test/ValidatorAssertions.java
+++ b/api/src/test/java/org/openmrs/module/radiology/test/ValidatorAssertions.java
@@ -1,0 +1,74 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.radiology.test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import org.springframework.validation.Errors;
+
+/**
+ * Assertions to ease testing of {@link org.springframework.validation.Validator}.
+ */
+public final class ValidatorAssertions {
+    
+    
+    private ValidatorAssertions() {
+        throw new UnsupportedOperationException("Utility class not meant for instantiation");
+    }
+    
+    /**
+     * Assert that a single error in given field with code "error.null" caused the validation to fail.
+     * 
+     * @param errors the errors to check
+     * @param field the field causing the validation to fail
+     */
+    public static void assertSingleNullErrorInField(Errors errors, String field) {
+        assertSingleErrorInField(errors, field, "error.null");
+    }
+    
+    /**
+     * Assert that a single error in given field with given code caused the validation to fail.
+     * 
+     * @param errors the errors to check
+     * @param field the field causing the validation to fail
+     * @param errorCode the error code of the failure
+     */
+    public static void assertSingleErrorInField(Errors errors, String field, String errorCode) {
+        assertSingleErrorOfCode(errors, errorCode);
+        assertTrue(String.format("Field '%s' is not in fieldErrors", field), errors.hasFieldErrors(field));
+    }
+    
+    /**
+     * Assert that a single error with code "error.general" caused the validation to fail.
+     * 
+     * @param errors the errors to check
+     */
+    public static void assertSingleGeneralError(Errors errors) {
+        assertSingleErrorOfCode(errors, "error.general");
+    }
+    
+    /**
+     * Assert that a single error with given code caused the validation to fail.
+     * 
+     * @param errors the errors to check
+     * @param errorCode the error code of the failure
+     */
+    public static void assertSingleErrorOfCode(Errors errors, String errorCode) {
+        assertTrue(errors.hasErrors());
+        assertThat(errors.getAllErrors()
+                .size(),
+            is(1));
+        assertThat((errors.getAllErrors()).get(0)
+                .getCode(),
+            is(errorCode));
+    }
+}


### PR DESCRIPTION
* extract a test helper class to reduce duplcation in testing Validators
* arrange ValidatorTests similarly, make Errors, Validator under test
and the valid object a member of the test class to remove boilerplate
in tests
* arrange tests in Arrange, Act, Assert style
* split the null, empty string, whitespace tests into separate tests so
they do not depend on each other

